### PR TITLE
Info command enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.01dev: UNDER DEVELOPMENT
 __No Release Date Set__
 
-* 
+* Enhanced text output of `info` command to include timestamps, sizes, and the reference list for all backups. _Contributed by Cynthia Shang_.
 
 ## v1.00: New Repository Format and Configuration Scheme, Link Support
 __Released April 14, 2016__

--- a/doc/xml/change-log.xml
+++ b/doc/xml/change-log.xml
@@ -8,7 +8,7 @@
     <changelog>
          <changelog-release date="XXXX-XX-XX" version="1.01dev" title="UNDER DEVELOPMENT">
              <release-feature-bullet-list>
-                <release-feature><text></text></release-feature>
+                <release-feature><text>Enhanced text output of <cmd>info</cmd> command to include timestamps, sizes, and the reference list for all backups. <i>Contributed by Cynthia Shang</i>.</text></release-feature>
              </release-feature-bullet-list>
          </changelog-release>
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -429,7 +429,7 @@
 
             <p>The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
 
-            <p>The '<id>start / stop timestamp</id>' defines the time period when the backup ran.  The '<id>stop timestamp</id>' can be used to determine the earliest valid timestamp to use when performing Point-In-Time Recovery.</p>
+            <p>The '<id>start / stop timestamp</id>' defines the time period when the backup ran.  The '<id>stop timestamp</id>' can be used to determine the earliest valid timestamp to use when performing Point-In-Time Recovery.  More information about Point-In-Time Recovery can be found in the <link section="/pitr">Point-In-Time Recovery</link> section.</p>
 
             <p>The '<id>database size</id>' is the full uncompressed size of the database while '<id>backup size</id>' is the amount of data actually backed up (these will be the same for full backups).  The '<id>repository size</id>' includes all the files from this backup and any referenced backups that are required to restore the database while '<id>repository backup size</id>' includes only the files in this backup (these will also be the same for full backups).  Repository sizes reflect compressed file sizes if compression is enabled in <backrest/> or the filesystem.</p>
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -429,7 +429,7 @@
 
             <p>The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
 
-            <p>The '<id>start / stop timestamp</id>' defines the time period when the backup ran.  The '<id>stop timestamp</id>' can be used to determine the earliest valid timestamp to use when performing Point-In-Time Recovery.  More information about Point-In-Time Recovery can be found in the <link section="/pitr">Point-In-Time Recovery</link> section.</p>
+            <p>The '<id>start / stop timestamp</id>' defines the time period when the backup ran.  The '<id>stop timestamp</id>' can be used to determine the backup to use when performing Point-In-Time Recovery.  More information about Point-In-Time Recovery can be found in the <link section="/pitr">Point-In-Time Recovery</link> section.</p>
 
             <p>The '<id>database size</id>' is the full uncompressed size of the database while '<id>backup size</id>' is the amount of data actually backed up (these will be the same for full backups).  The '<id>repository size</id>' includes all the files from this backup and any referenced backups that are required to restore the database while '<id>repository backup size</id>' includes only the files in this backup (these will also be the same for full backups).  Repository sizes reflect compressed file sizes if compression is enabled in <backrest/> or the filesystem.</p>
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -416,13 +416,13 @@
 
                 <execute filter="n" output="y">
                     <exe-cmd>{[project-exe]} info</exe-cmd>
-                    <exe-highlight>(oldest|latest) backup label</exe-highlight>
+                    <exe-highlight>(full|incr|diff) backup</exe-highlight>
                 </execute>
             </execute-list>
 
-            <p>The oldest and newest backups are shown in the info output.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
+            <p>The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
 
-            <p>More information about the <cmd>backup</cmd> command can be found in the <link section="/backup">Backup</link> section.</p>
+            <p>More information about the <cmd>backup</cmd> command can be found in the <link section="/backup">Backup</link> section. More information about the <cmd>info</cmd> command can be found in the <link section="/pitr">Point-in-Time Recovery</link> section.</p>
         </section>
 
         <!-- SECTION => QUICKSTART - PERFORM RESTORE -->
@@ -915,6 +915,17 @@
         </execute-list>
 
         <p>Using an earlier backup will allow <postgres/> to play forward to the correct time again.  The default behavior for restore is to use the most recent backup but an earlier backup can be specified with the <br-option>{[dash]}-set</br-option> option.</p>
+
+        <execute-list host="{[host-db-master]}">
+            <title>Get info for the {[postgres-cluster-demo]} cluster</title>
+
+            <execute filter="n" output="y">
+                <exe-cmd>{[project-exe]} info</exe-cmd>
+                <exe-highlight>diff backup</exe-highlight>
+            </execute>
+        </execute-list>
+
+         <p>The start / stop timestamp shows that the differential backup is the one containing the data. The deltas indicate the sizes of the changes since the last referenced backup. The database and repository sizes will be different if the repository is compressed.</p>
 
         <execute-list host="{[host-db-master]}">
             <title>Stop <postgres/>, restore from the previous backup, and start <postgres/></title>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -409,6 +409,13 @@
 
             <p>This time there was no warning because a full backup already existed.  While incremental backups can be based on a full <i>or</i> differential backup, differential backups must be based on a full backup.  A full backup can be performed by running the <cmd>backup</cmd> command with <br-setting>{[dash]}-type=full</br-setting>.</p>
 
+            <p>More information about the <cmd>backup</cmd> command can be found in the <link section="/backup">Backup</link> section.</p>
+        </section>
+
+        <!-- SECTION => QUICKSTART - BACKUP INFO -->
+        <section id="backup-info" depend="perform-backup">
+            <title>Backup Information</title>
+
             <p>Use the <cmd>info</cmd> command to get information about backups.</p>
 
             <execute-list host="{[host-db-master]}">
@@ -422,7 +429,11 @@
 
             <p>The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
 
-            <p>More information about the <cmd>backup</cmd> command can be found in the <link section="/backup">Backup</link> section. More information about the <cmd>info</cmd> command can be found in the <link section="/pitr">Point-in-Time Recovery</link> section.</p>
+            <p>The '<id>start / stop timestamp</id>' defines the time period when the backup ran.  The '<id>stop timestamp</id>' can be used to determine the earliest valid timestamp to use when performing Point-In-Time Recovery.</p>
+
+            <p>The '<id>database size</id>' is the full uncompressed size of the database while '<id>backup size</id>' is the amount of data actually backed up (these will be the same for full backups).  The '<id>repository size</id>' includes all the files from this backup and any referenced backups that are required to restore the database while '<id>repository backup size</id>' includes only the files in this backup (these will also be the same for full backups).  Repository sizes reflect compressed file sizes if compression is enabled in <backrest/> or the filesystem.</p>
+
+            <p>The '<id>backup reference list</id>' contains the additional backups that are required to restore this backup.</p>
         </section>
 
         <!-- SECTION => QUICKSTART - PERFORM RESTORE -->
@@ -743,7 +754,7 @@
     </section>
 
     <!-- SECTION => PITR -->
-    <section id="pitr">
+    <section id="pitr" depend="quickstart/perform-backup">
         <title>Point-in-Time Recovery</title>
 
         <p><link section="/quickstart/perform-restore">Restore a Backup</link> in <link section="/quickstart">Quick Start</link> performed default recovery, which is to play all the way to the end of the WAL stream.  In the case of a hardware failure this is usually the best choice but for data corruption scenarios (whether machine or human in origin) Point-in-Time Recovery (PITR) is often more appropriate.</p>
@@ -914,21 +925,21 @@
             </execute>
         </execute-list>
 
-        <p>Using an earlier backup will allow <postgres/> to play forward to the correct time again.  The default behavior for restore is to use the most recent backup but an earlier backup can be specified with the <br-option>{[dash]}-set</br-option> option.</p>
+        <p>Using an earlier backup will allow <postgres/> to play forward to the correct time.  The <cmd>info</cmd> command can be used to find the next to last backup.</p>
 
         <execute-list host="{[host-db-master]}">
-            <title>Get info for the {[postgres-cluster-demo]} cluster</title>
+            <title>Get backup info for the {[postgres-cluster-demo]} cluster</title>
 
             <execute filter="n" output="y">
                 <exe-cmd>{[project-exe]} info</exe-cmd>
-                <exe-highlight>diff backup</exe-highlight>
+                <exe-highlight>{[backup-last]}</exe-highlight>
             </execute>
         </execute-list>
 
-         <p>The start / stop timestamp is the period of time which the backup covers. The 'backup size' is the uncompressed size of the data backed up since the last referenced backup whereas the 'repository backup size' is the compressed size if compression is used.</p>
+        <p>The default behavior for restore is to use the last backup but an earlier backup can be specified with the <br-option>{[dash]}-set</br-option> option.</p>
 
         <execute-list host="{[host-db-master]}">
-            <title>Stop <postgres/>, restore from the previous backup, and start <postgres/></title>
+            <title>Stop <postgres/>, restore from the selected backup, and start <postgres/></title>
 
             <execute user="root">
                 <exe-cmd>{[db-cluster-stop]}</exe-cmd>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -925,7 +925,7 @@
             </execute>
         </execute-list>
 
-         <p>The start / stop timestamp shows that the differential backup is the one containing the data. The deltas indicate the sizes of the changes since the last referenced backup. The database and repository sizes will be different if the repository is compressed.</p>
+         <p>The start / stop timestamp is the period of time which the backup covers. The 'backup size' is the uncompressed size of the data backed up since the last referenced backup whereas the 'repository backup size' is the compressed size if compression is used.</p>
 
         <execute-list host="{[host-db-master]}">
             <title>Stop <postgres/>, restore from the previous backup, and start <postgres/></title>

--- a/lib/pgBackRest/Info.pm
+++ b/lib/pgBackRest/Info.pm
@@ -134,39 +134,35 @@ sub process
 
         foreach my $oStanzaInfo (@{$oyStanzaList})
         {
-            $strOutput = defined($strOutput) ? $strOutput .= "\n" : '';
-
             $strOutput .= ' stanza: ' . $$oStanzaInfo{&INFO_STANZA_NAME} . "\n";
             $strOutput .= '    status: ' . ($$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_CODE} == 0 ? INFO_STANZA_STATUS_OK :
-                          INFO_STANZA_STATUS_ERROR . ' (' . $$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_MESSAGE} . ')') . "\n";
+                          INFO_STANZA_STATUS_ERROR . ' (' . $$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_MESSAGE} . ')') . "\n\n";
 
             # print out the information for each backup of the stanza, from oldest to newest
             foreach my $oBackupInfo (@{$$oStanzaInfo{&INFO_BACKUP_SECTION_BACKUP}})
             {
-                $strOutput .= "\n    ". $$oBackupInfo{&INFO_KEY_TYPE} .' backup: '. $$oBackupInfo{&INFO_KEY_LABEL};
-                $strOutput .= "\n        start / stop timestamp: " .
+                $strOutput .= '    '.$$oBackupInfo{&INFO_KEY_TYPE} .' backup: '. $$oBackupInfo{&INFO_KEY_LABEL} . "\n";
+                $strOutput .= '        start / stop timestamp: ' .
                                         timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_START}) .
                                         ' / ' .
-                                        timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_STOP});
-                $strOutput .= "\n        database size: " .
+                                        timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_STOP}) . "\n";
+                $strOutput .= '        database size: ' .
                                         (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) : '').
-                                        ($$oBackupInfo{&INFO_KEY_TYPE} ne BACKUP_TYPE_FULL ?
-                                        (', delta: ' .
+                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) : '') .
+                                        (', backup size: ' .
                                         (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) : '')) : '');
-                $strOutput .= "\n        repository size: " .
+                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) : '')) . "\n";
+                $strOutput .= '        repository size: ' .
                                         (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) ?
                                         fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) : '').
-                                        ($$oBackupInfo{&INFO_KEY_TYPE} ne BACKUP_TYPE_FULL ?
-                                        (', delta: ' .
+                                        (', repository backup size: ' .
                                         (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) : '')) : '');
+                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) : '')) . "\n";
 
                 # list the backup reference chain, if any, for this back up
                 if (defined($$oBackupInfo{&INFO_KEY_REFERENCE}))
                 {
-                    $strOutput .= "\n        backup reference list: " . (join(', ' ,@{$$oBackupInfo{&INFO_KEY_REFERENCE}}));
+                    $strOutput .= '        backup reference list: ' . (join(', ' ,@{$$oBackupInfo{&INFO_KEY_REFERENCE}})) . "\n";
                 }
                 $strOutput .= "\n";
             }

--- a/lib/pgBackRest/Info.pm
+++ b/lib/pgBackRest/Info.pm
@@ -134,37 +134,46 @@ sub process
 
         foreach my $oStanzaInfo (@{$oyStanzaList})
         {
-            $strOutput .= ' stanza: ' . $$oStanzaInfo{&INFO_STANZA_NAME} . "\n";
-            $strOutput .= '    status: ' . ($$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_CODE} == 0 ? INFO_STANZA_STATUS_OK :
-                          INFO_STANZA_STATUS_ERROR . ' (' . $$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_MESSAGE} . ')') . "\n\n";
+            # Add an LF between stanzas
+            $strOutput .= defined($strOutput) ? "\n" : '';
 
-            # print out the information for each backup of the stanza, from oldest to newest
+            # Output stanza name and status
+            $strOutput .=
+                'stanza: ' . $$oStanzaInfo{&INFO_STANZA_NAME} . "\n" .
+                '    status: ' . ($$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_CODE} == 0 ? INFO_STANZA_STATUS_OK :
+                INFO_STANZA_STATUS_ERROR . ' (' . $$oStanzaInfo{&INFO_SECTION_STATUS}{&INFO_KEY_MESSAGE} . ')') . "\n";
+
+            # Output information for each stanza backup, from oldest to newest
             foreach my $oBackupInfo (@{$$oStanzaInfo{&INFO_BACKUP_SECTION_BACKUP}})
             {
-                $strOutput .= '    '.$$oBackupInfo{&INFO_KEY_TYPE} .' backup: '. $$oBackupInfo{&INFO_KEY_LABEL} . "\n";
-                $strOutput .= '        start / stop timestamp: ' .
-                                        timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_START}) .
-                                        ' / ' .
-                                        timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_STOP}) . "\n";
-                $strOutput .= '        database size: ' .
-                                        (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) : '') .
-                                        (', backup size: ' .
-                                        (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) : '')) . "\n";
-                $strOutput .= '        repository size: ' .
-                                        (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) : '').
-                                        (', repository backup size: ' .
-                                        (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) ?
-                                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) : '')) . "\n";
+                $strOutput .=
+                    "\n".
+                    '    ' . $$oBackupInfo{&INFO_KEY_TYPE} . ' backup: ' . $$oBackupInfo{&INFO_KEY_LABEL} . "\n" .
 
-                # list the backup reference chain, if any, for this back up
+                    '        start / stop timestamp: ' .
+                    timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_START}) .
+                    ' / ' .
+                    timestampFormat(undef, $$oBackupInfo{&INFO_SECTION_TIMESTAMP}{&INFO_KEY_STOP}) . "\n" .
+
+                    '        database size: ' .
+                    (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) ?
+                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_SIZE}) : '') .
+                    ', backup size: ' .
+                    (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) ?
+                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_KEY_DELTA}) : '') . "\n" .
+
+                    '        repository size: ' .
+                    (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) ?
+                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_SIZE}) : '') .
+                    ', repository backup size: ' .
+                    (defined($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) ?
+                        fileSizeFormat($$oBackupInfo{&INFO_SECTION_INFO}{&INFO_SECTION_REPO}{&INFO_KEY_DELTA}) : '') . "\n";
+
+                # List the backup reference chain, if any, for this backup
                 if (defined($$oBackupInfo{&INFO_KEY_REFERENCE}))
                 {
                     $strOutput .= '        backup reference list: ' . (join(', ' ,@{$$oBackupInfo{&INFO_KEY_REFERENCE}})) . "\n";
                 }
-                $strOutput .= "\n";
             }
         }
 

--- a/test/expect/backup-synthetic-001.log
+++ b/test/expect/backup-synthetic-001.log
@@ -224,7 +224,7 @@ db-version="9.3"
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: stop start: --config=[TEST_PATH]/db/pgbackrest.conf --force --lock-path=[TEST_PATH]/backrest/lock --log-level-console=debug --log-level-file=trace --log-path=[TEST_PATH]/backrest/log --repo-path=[TEST_PATH]/backrest
   INFO: sent term signal to process [PROCESS-ID]
-        
+
  DEBUG:     Exit::exitSafe(): iExitCode = 0, strSignal = [undef]
   INFO: stop stop
  DEBUG:     Common:::Lock::lockRelease(): bFailOnNoLock = false
@@ -2442,7 +2442,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -2945,7 +2945,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-3]
@@ -2959,7 +2959,7 @@ info
         repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3056,7 +3056,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-001.log
+++ b/test/expect/backup-synthetic-001.log
@@ -339,67 +339,6 @@ start (local)
   INFO: start stop
  DEBUG:     Common:::Lock::lockRelease(): bFailOnNoLock = false
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2500,6 +2439,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --no-compress --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/backrest/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backrest/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2684,14 +2945,21 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-3]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 8KB, delta: 9B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2788,7 +3056,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-001.log
+++ b/test/expect/backup-synthetic-001.log
@@ -2447,49 +2447,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -2950,13 +2950,13 @@ info
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 8KB, delta: 9B
+        database size: 8KB, backup size: 9B
+        repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-002.log
+++ b/test/expect/backup-synthetic-002.log
@@ -2305,49 +2305,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -2809,13 +2809,13 @@ info
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 8KB, delta: 9B
+        database size: 8KB, backup size: 9B
+        repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-002.log
+++ b/test/expect/backup-synthetic-002.log
@@ -2300,7 +2300,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -2804,7 +2804,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-3]
@@ -2818,7 +2818,7 @@ info
         repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2915,7 +2915,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-002.log
+++ b/test/expect/backup-synthetic-002.log
@@ -221,67 +221,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2358,6 +2297,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --no-compress --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/backrest/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backrest/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2543,14 +2804,21 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-3]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 8KB, delta: 9B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2647,7 +2915,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-003.log
+++ b/test/expect/backup-synthetic-003.log
@@ -219,67 +219,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2294,6 +2233,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/backrest/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backrest/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2477,14 +2738,21 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-3]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 401B, delta: 29B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2581,7 +2849,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-003.log
+++ b/test/expect/backup-synthetic-003.log
@@ -2241,49 +2241,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -2743,13 +2743,13 @@ info
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 401B, delta: 29B
+        database size: 8KB, backup size: 9B
+        repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-003.log
+++ b/test/expect/backup-synthetic-003.log
@@ -2236,7 +2236,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -2738,7 +2738,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-3]
@@ -2752,7 +2752,7 @@ info
         repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2849,7 +2849,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-004.log
+++ b/test/expect/backup-synthetic-004.log
@@ -2293,49 +2293,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -2796,13 +2796,13 @@ info
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 401B, delta: 29B
+        database size: 8KB, backup size: 9B
+        repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-004.log
+++ b/test/expect/backup-synthetic-004.log
@@ -2288,7 +2288,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -2791,7 +2791,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-3]
@@ -2805,7 +2805,7 @@ info
         repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2902,7 +2902,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-004.log
+++ b/test/expect/backup-synthetic-004.log
@@ -220,67 +220,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2346,6 +2285,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/backrest/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backrest/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2530,14 +2791,21 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-3]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 401B, delta: 29B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -2634,7 +2902,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-005.log
+++ b/test/expect/backup-synthetic-005.log
@@ -2767,49 +2767,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -3292,54 +3292,54 @@ info
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 8KB, delta: 9B
+        database size: 8KB, backup size: 9B
+        repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-005.log
+++ b/test/expect/backup-synthetic-005.log
@@ -2762,7 +2762,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3287,7 +3287,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3342,7 +3342,7 @@ info
         repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3658,7 +3658,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-005.log
+++ b/test/expect/backup-synthetic-005.log
@@ -502,67 +502,6 @@ start (remote)
   INFO: start stop
  DEBUG:     Common:::Lock::lockRelease(): bFailOnNoLock = false
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/backrest/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2820,6 +2759,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --no-compress --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/local/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/local/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -3026,14 +3287,62 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-2]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 8KB, delta: 9B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3349,7 +3658,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-006.log
+++ b/test/expect/backup-synthetic-006.log
@@ -2543,49 +2543,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -3069,54 +3069,54 @@ info
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 8KB, delta: 25B
+        database size: 8KB, backup size: 25B
+        repository size: 8KB, repository backup size: 25B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 8KB, delta: 13B
+        database size: 8KB, backup size: 13B
+        repository size: 8KB, repository backup size: 13B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 8KB, delta: 8B
+        database size: 8KB, backup size: 8B
+        repository size: 8KB, repository backup size: 8B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 8KB, delta: 39B
+        database size: 8KB, backup size: 39B
+        repository size: 8KB, repository backup size: 39B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 8KB, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 8KB, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 8KB, delta: 30B
+        database size: 8KB, backup size: 30B
+        repository size: 8KB, repository backup size: 30B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 8KB
+        database size: 8KB, backup size: 8KB
+        repository size: 8KB, repository backup size: 8KB
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 8KB, delta: 9B
+        database size: 8KB, backup size: 9B
+        repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-006.log
+++ b/test/expect/backup-synthetic-006.log
@@ -2538,7 +2538,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3064,7 +3064,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3119,7 +3119,7 @@ info
         repository size: 8KB, repository backup size: 9B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3435,7 +3435,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-006.log
+++ b/test/expect/backup-synthetic-006.log
@@ -237,67 +237,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/backrest/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2596,6 +2535,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --no-compress --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/local/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/local/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2803,14 +3064,62 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-2]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 8KB, delta: 25B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 8KB, delta: 13B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 8KB, delta: 8B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 8KB, delta: 39B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 8KB, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 8KB, delta: 30B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 8KB
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 8KB, delta: 9B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3126,7 +3435,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-007.log
+++ b/test/expect/backup-synthetic-007.log
@@ -234,67 +234,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/backrest/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2520,6 +2459,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/local/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/local/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2724,14 +2985,62 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-2]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 401B, delta: 29B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3047,7 +3356,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-007.log
+++ b/test/expect/backup-synthetic-007.log
@@ -2462,7 +2462,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -2985,7 +2985,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3040,7 +3040,7 @@ info
         repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3356,7 +3356,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-007.log
+++ b/test/expect/backup-synthetic-007.log
@@ -2467,49 +2467,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -2990,54 +2990,54 @@ info
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 401B, delta: 29B
+        database size: 8KB, backup size: 9B
+        repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/expect/backup-synthetic-008.log
+++ b/test/expect/backup-synthetic-008.log
@@ -235,67 +235,6 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
-------------------------------------------------------------------------------------------------------------------------------------
-stanza db
-    status: ok
-    oldest backup label: [BACKUP-FULL-1]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-FULL-1]
-    latest backup timestamp: [TIMESTAMP-STR]
-
-info db
-> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
-------------------------------------------------------------------------------------------------------------------------------------
-[
-    {
-        "backup" : [
-            {
-                "archive" : {
-                    "start" : null,
-                    "stop" : null
-                },
-                "backrest" : {
-                    "format" : 5,
-                    "version" : "[VERSION-1]"
-                },
-                "database" : {
-                    "id" : 1
-                },
-                "info" : {
-                    "delta" : [DELTA],
-                    "repository" : {
-                        "delta" : [DELTA],
-                        "size" : [SIZE]
-                    },
-                    "size" : [SIZE]
-                },
-                "label" : "[BACKUP-FULL-1]",
-                "prior" : null,
-                "reference" : null,
-                "timestamp" : {
-                    "start" : [TIMESTAMP],
-                    "stop" : [TIMESTAMP]
-                },
-                "type" : "full"
-            }
-        ],
-        "db" : [
-            {
-                "id" : "1",
-                "system-id" : 6156904820763115222,
-                "version" : "9.3"
-            }
-        ],
-        "name" : "db",
-        "status" : {
-            "code" : 0,
-            "message" : "ok"
-        }
-    }
-]
-
 full backup (resume)
 > [BACKREST_BIN] --config=[TEST_PATH]/backrest/pgbackrest.conf --no-online --type=full --stanza=db backup --test --test-delay=0.2 --test-point=backup-resume=y
 ------------------------------------------------------------------------------------------------------------------------------------
@@ -2572,6 +2511,328 @@ db-version="9.3"
 [db:history]
 1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":6156904820763115222,"db-version":"9.3"}
 
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
+------------------------------------------------------------------------------------------------------------------------------------
+ stanza: db
+    status: ok
+
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+info db
+> [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
+------------------------------------------------------------------------------------------------------------------------------------
+[
+    {
+        "backup" : [
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-2]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-2]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-3]",
+                "prior" : "[BACKUP-DIFF-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-4]",
+                "prior" : "[BACKUP-INCR-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-2]",
+                    "[BACKUP-INCR-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-3]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-INCR-5]",
+                "prior" : "[BACKUP-DIFF-3]",
+                "reference" : [
+                    "[BACKUP-FULL-2]",
+                    "[BACKUP-DIFF-3]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "incr"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-DIFF-4]",
+                "prior" : "[BACKUP-FULL-2]",
+                "reference" : [
+                    "[BACKUP-FULL-2]"
+                ],
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "diff"
+            },
+            {
+                "archive" : {
+                    "start" : null,
+                    "stop" : null
+                },
+                "backrest" : {
+                    "format" : 5,
+                    "version" : "[VERSION-1]"
+                },
+                "database" : {
+                    "id" : 1
+                },
+                "info" : {
+                    "delta" : [DELTA],
+                    "repository" : {
+                        "delta" : [DELTA],
+                        "size" : [SIZE]
+                    },
+                    "size" : [SIZE]
+                },
+                "label" : "[BACKUP-FULL-3]",
+                "prior" : null,
+                "reference" : null,
+                "timestamp" : {
+                    "start" : [TIMESTAMP],
+                    "stop" : [TIMESTAMP]
+                },
+                "type" : "full"
+            }
+        ],
+        "db" : [
+            {
+                "id" : "1",
+                "system-id" : 6156904820763115222,
+                "version" : "9.3"
+            }
+        ],
+        "name" : "db",
+        "status" : {
+            "code" : 0,
+            "message" : "ok"
+        }
+    }
+]
+
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --stanza=db expire --log-level-console=detail --retention-full=1
 ------------------------------------------------------------------------------------------------------------------------------------
   INFO: expire start: --config=[TEST_PATH]/db/pgbackrest.conf --lock-path=[TEST_PATH]/local/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/local/log --repo-path=[TEST_PATH]/backrest --retention-full=1 --stanza=db
@@ -2777,14 +3038,62 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza db
+ stanza: db
     status: ok
-    oldest backup label: [BACKUP-FULL-2]
-    oldest backup timestamp: [TIMESTAMP-STR]
-    latest backup label: [BACKUP-DIFF-5]
-    latest backup timestamp: [TIMESTAMP-STR]
 
-stanza db_empty
+    full backup: [BACKUP-FULL-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 277B
+
+    diff backup: [BACKUP-DIFF-2]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 25B
+        repository size: 362B, delta: 85B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 13B
+        repository size: 388B, delta: 53B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
+
+    incr backup: [BACKUP-INCR-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 8B
+        repository size: 392B, delta: 28B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
+
+    diff backup: [BACKUP-DIFF-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 39B
+        repository size: 392B, delta: 139B
+        backup reference list: [BACKUP-FULL-2]
+
+    incr backup: [BACKUP-INCR-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 0B
+        repository size: 392B, delta: 0B
+        backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
+
+    diff backup: [BACKUP-DIFF-4]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 30B
+        repository size: 343B, delta: 90B
+        backup reference list: [BACKUP-FULL-2]
+
+    full backup: [BACKUP-FULL-3]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB
+        repository size: 372B
+
+    diff backup: [BACKUP-DIFF-5]
+        start / stop timestamp: [TIMESTAMP-STR]
+        database size: 8KB, delta: 9B
+        repository size: 401B, delta: 29B
+        backup reference list: [BACKUP-FULL-3]
+
+ stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3100,7 +3409,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
-stanza bogus
+ stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-008.log
+++ b/test/expect/backup-synthetic-008.log
@@ -2514,7 +2514,7 @@ db-version="9.3"
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3038,7 +3038,7 @@ restore_command = '[BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-
 info
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: db
+stanza: db
     status: ok
 
     full backup: [BACKUP-FULL-2]
@@ -3093,7 +3093,7 @@ info
         repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
- stanza: db_empty
+stanza: db_empty
     status: error (no valid backups)
 
 info
@@ -3409,7 +3409,7 @@ info
 info bogus
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=bogus info
 ------------------------------------------------------------------------------------------------------------------------------------
- stanza: bogus
+stanza: bogus
     status: error (missing stanza path)
 
 info bogus

--- a/test/expect/backup-synthetic-008.log
+++ b/test/expect/backup-synthetic-008.log
@@ -2519,49 +2519,49 @@ info db
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
 info db
 > [BACKREST_BIN] --config=[TEST_PATH]/db/pgbackrest.conf --log-level-console=warn --stanza=db info --output=json
@@ -3043,54 +3043,54 @@ info
 
     full backup: [BACKUP-FULL-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 277B
+        database size: 8KB, backup size: 8KB
+        repository size: 277B, repository backup size: 277B
 
     diff backup: [BACKUP-DIFF-2]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 25B
-        repository size: 362B, delta: 85B
+        database size: 8KB, backup size: 25B
+        repository size: 362B, repository backup size: 85B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 13B
-        repository size: 388B, delta: 53B
+        database size: 8KB, backup size: 13B
+        repository size: 388B, repository backup size: 53B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2]
 
     incr backup: [BACKUP-INCR-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 8B
-        repository size: 392B, delta: 28B
+        database size: 8KB, backup size: 8B
+        repository size: 392B, repository backup size: 28B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3]
 
     diff backup: [BACKUP-DIFF-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 39B
-        repository size: 392B, delta: 139B
+        database size: 8KB, backup size: 39B
+        repository size: 392B, repository backup size: 139B
         backup reference list: [BACKUP-FULL-2]
 
     incr backup: [BACKUP-INCR-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 0B
-        repository size: 392B, delta: 0B
+        database size: 8KB, backup size: 0B
+        repository size: 392B, repository backup size: 0B
         backup reference list: [BACKUP-FULL-2], [BACKUP-DIFF-3]
 
     diff backup: [BACKUP-DIFF-4]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 30B
-        repository size: 343B, delta: 90B
+        database size: 8KB, backup size: 30B
+        repository size: 343B, repository backup size: 90B
         backup reference list: [BACKUP-FULL-2]
 
     full backup: [BACKUP-FULL-3]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB
-        repository size: 372B
+        database size: 8KB, backup size: 8KB
+        repository size: 372B, repository backup size: 372B
 
     diff backup: [BACKUP-DIFF-5]
         start / stop timestamp: [TIMESTAMP-STR]
-        database size: 8KB, delta: 9B
-        repository size: 401B, delta: 29B
+        database size: 8KB, backup size: 9B
+        repository size: 401B, repository backup size: 29B
         backup reference list: [BACKUP-FULL-3]
 
  stanza: db_empty

--- a/test/lib/pgBackRestTest/BackupTest.pm
+++ b/test/lib/pgBackRestTest/BackupTest.pm
@@ -1062,11 +1062,6 @@ sub BackRestTestBackup_Test
             # Cleanup any garbage left in the temp backup path
             executeTest('rm -rf ' . BackRestTestCommon_RepoPathGet() . "/temp/${strStanza}.tmp", {bRemote => $bRemote});
 
-            # Backup Info
-            #-----------------------------------------------------------------------------------------------------------------------
-            BackRestTestBackup_Info($strStanza, undef, false);
-            BackRestTestBackup_Info($strStanza, INFO_OUTPUT_JSON, false);
-
             # Resume Full Backup
             #-----------------------------------------------------------------------------------------------------------------------
             $strType = 'full';
@@ -1502,6 +1497,11 @@ sub BackRestTestBackup_Test
 
             $strFullBackup = BackRestTestBackup_BackupSynthetic($strType, $strStanza, \%oManifest, 'update file',
                                                                 {strOptionalParam => '--log-level-console=detail'});
+
+            # Backup Info
+            #-----------------------------------------------------------------------------------------------------------------------
+            BackRestTestBackup_Info($strStanza, undef, false);
+            BackRestTestBackup_Info($strStanza, INFO_OUTPUT_JSON, false);
 
             # Call expire
             #-----------------------------------------------------------------------------------------------------------------------

--- a/test/lib/pgBackRestTest/Common/LogTest.pm
+++ b/test/lib/pgBackRestTest/Common/LogTest.pm
@@ -320,7 +320,7 @@ sub regExpReplace
 }
 
 ####################################################################################################################################
-# regExpReplaceAll
+# regExpReplaceAll - replaces dynamic test output so that the expected test output can be verified against actual test output
 ####################################################################################################################################
 sub regExpReplaceAll
 {
@@ -375,8 +375,8 @@ sub regExpReplaceAll
         "size\"[ ]{0,1}:[ ]{0,1}[0-9]+", '[0-9]+$', false);
     $strLine = $self->regExpReplace($strLine, 'DELTA',
         "delta\"[ ]{0,1}:[ ]{0,1}[0-9]+", '[0-9]+$', false);
-    $strLine = $self->regExpReplace($strLine, 'TIMESTAMP-STR', "est backup timestamp: $strTimestampRegExp",
-                                                "${strTimestampRegExp}\$", false);
+    $strLine = $self->regExpReplace($strLine, 'TIMESTAMP-STR', " timestamp: $strTimestampRegExp / $strTimestampRegExp",
+                                                "${strTimestampRegExp} / ${strTimestampRegExp}\$", false);
     $strLine = $self->regExpReplace($strLine, 'CHECKSUM', 'checksum=[\"]{0,1}[0-f]{40}', '[0-f]{40}$', false);
 
     $strLine = $self->regExpReplace($strLine, 'REMOTE-PROCESS-TERMINATED-MESSAGE',

--- a/test/lib/pgBackRestTest/Common/LogTest.pm
+++ b/test/lib/pgBackRestTest/Common/LogTest.pm
@@ -320,7 +320,9 @@ sub regExpReplace
 }
 
 ####################################################################################################################################
-# regExpReplaceAll - replaces dynamic test output so that the expected test output can be verified against actual test output
+# regExpReplaceAll
+#
+# Replaces dynamic test output so that the expected test output can be verified against actual test output.
 ####################################################################################################################################
 sub regExpReplaceAll
 {


### PR DESCRIPTION
- Enhanced output of "pgbackrest info" command to include timestamps, sizes and backup reference list. 
- Moved location of info test for more detailed output during testing. 
- Updated User Guide with examples and additional descriptions for the info command with a link to details in the PITR section.
