### PR TITLE
Fix perl warnings in doc/ tree

### DIFF
--- a/doc/lib/BackRestDoc/Common/Doc.pm
+++ b/doc/lib/BackRestDoc/Common/Doc.pm
@@ -86,7 +86,8 @@ sub new
 
             eval
             {
-                local $XML::Checker::FAIL = sub
+                local $XML::Checker::FAIL;
+                $XML::Checker::FAIL = sub
                 {
                     my $iCode = shift;
 
@@ -154,7 +155,7 @@ sub parse
     # Store the node name
     $oOut{name} = $strName;
 
-    if (keys($$oyNode[$iIndex]))
+    if (keys(%{$$oyNode[$iIndex]}))
     {
         $oOut{param} = $$oyNode[$iIndex];
     }
@@ -184,7 +185,7 @@ sub parse
                         $oOut{children} = [];
                     }
 
-                    push($oOut{children}, $strBuffer);
+                    push(@{$oOut{children}}, $strBuffer);
                 }
                 # Don't allow strings mixed with children
                 elsif (length(trim($strBuffer)) > 0)
@@ -217,7 +218,7 @@ sub parse
                 $oOut{children} = [];
             }
 
-            push($oOut{children}, $self->parse($$oyNode[$iIndex++], $$oyNode[$iIndex++]));
+            push(@{$oOut{children}}, $self->parse($$oyNode[$iIndex++], $$oyNode[$iIndex++]));
         }
     }
 
@@ -257,7 +258,7 @@ sub build
     # Get all params
     if (defined($$oDoc{param}))
     {
-        for my $strParam (keys $$oDoc{param})
+        for my $strParam (keys %{$$oDoc{param}})
         {
             $$oOut{param}{$strParam} = $$oDoc{param}{$strParam};
         }
@@ -289,7 +290,7 @@ sub build
             }
             else
             {
-                push($$oOut{children}, $self->build($oSub));
+                push(@{$$oOut{children}}, $self->build($oSub));
             }
         }
     }

--- a/doc/lib/BackRestDoc/Common/DocConfig.pm
+++ b/doc/lib/BackRestDoc/Common/DocConfig.pm
@@ -84,7 +84,7 @@ sub process
     my $oDoc = $self->{oDoc};
     my $oConfigHash = {};
 
-    foreach my $strCommand (sort(keys(commandHashGet())))
+    foreach my $strCommand (sort(keys(%{commandHashGet()})))
     {
         if ($strCommand eq CMD_REMOTE)
         {
@@ -103,7 +103,7 @@ sub process
     # Iterate through all options
     my $oOptionRule = optionRuleGet();
 
-    foreach my $strOption (sort(keys($oOptionRule)))
+    foreach my $strOption (sort(keys(%{$oOptionRule})))
     {
         if ($strOption =~ /^test/ || $strOption eq 'no-fork')
         {
@@ -111,8 +111,8 @@ sub process
         }
 
         # Iterate through all commands
-        my @stryCommandList = sort(keys(defined($$oOptionRule{$strOption}{&OPTION_RULE_COMMAND}) ?
-                              $$oOptionRule{$strOption}{&OPTION_RULE_COMMAND} : $$oConfigHash{&CONFIG_HELP_COMMAND}));
+        my @stryCommandList = sort(keys(%{defined($$oOptionRule{$strOption}{&OPTION_RULE_COMMAND}) ?
+                              $$oOptionRule{$strOption}{&OPTION_RULE_COMMAND} : $$oConfigHash{&CONFIG_HELP_COMMAND}}));
 
         foreach my $strCommand (@stryCommandList)
         {
@@ -257,7 +257,7 @@ sub helpDataWrite
     my $oConfigHash = $self->{oConfigHash};
     my $strOptionData;
 
-    foreach my $strOption (sort(keys($$oConfigHash{&CONFIG_HELP_OPTION})))
+    foreach my $strOption (sort(keys(%{$$oConfigHash{&CONFIG_HELP_OPTION}})))
     {
         my $oOptionHash = $$oConfigHash{&CONFIG_HELP_OPTION}{$strOption};
 
@@ -284,7 +284,7 @@ sub helpDataWrite
     # Iterate commands
     my $strCommandData;
 
-    foreach my $strCommand (sort(keys($$oConfigHash{&CONFIG_HELP_COMMAND})))
+    foreach my $strCommand (sort(keys(%{$$oConfigHash{&CONFIG_HELP_COMMAND}})))
     {
         my $oCommandHash = $$oConfigHash{&CONFIG_HELP_COMMAND}{$strCommand};
 
@@ -315,7 +315,7 @@ sub helpDataWrite
                 '            ' . CONFIG_HELP_OPTION . " =>\n" .
                 "            {\n";
 
-            foreach my $strOption (sort(keys($$oCommandHash{&CONFIG_HELP_OPTION})))
+            foreach my $strOption (sort(keys(%{$$oCommandHash{&CONFIG_HELP_OPTION}})))
             {
                 my $oOptionHash = $$oCommandHash{&CONFIG_HELP_OPTION}{$strOption};
 
@@ -506,7 +506,7 @@ sub helpConfigDocGet
     my $oConfigDoc = $self->{oDoc}->nodeGet('config');
     my $oSectionHash = {};
 
-    foreach my $strOption (sort(keys($$oConfigHash{&CONFIG_HELP_OPTION})))
+    foreach my $strOption (sort(keys(%{$$oConfigHash{&CONFIG_HELP_OPTION}})))
     {
         my $oOption = $$oConfigHash{&CONFIG_HELP_OPTION}{$strOption};
 
@@ -527,7 +527,7 @@ sub helpConfigDocGet
     $oIntroSectionDoc->nodeAdd('title')->textSet('Introduction');
     $oIntroSectionDoc->textSet($oConfigDoc->textGet());
 
-    foreach my $strSection (sort(keys($oSectionHash)))
+    foreach my $strSection (sort(keys(%{$oSectionHash})))
     {
         my $oSectionElement = $oDoc->nodeAdd('section', undef, {id => "section-${strSection}"});
 
@@ -538,7 +538,7 @@ sub helpConfigDocGet
                 {name => 'text',
                  children=> [$oSectionDoc->paramGet('name') . ' Options (', {name => 'id', value => $strSection}, ')']});
 
-        foreach my $strOption (sort(keys($$oSectionHash{$strSection})))
+        foreach my $strOption (sort(keys(%{$$oSectionHash{$strSection}})))
         {
             $self->helpOptionGet(undef, $strOption, $oSectionElement, $$oConfigHash{&CONFIG_HELP_OPTION}{$strOption});
         }
@@ -580,7 +580,7 @@ sub helpCommandDocGet
     $oIntroSectionDoc->nodeAdd('title')->textSet('Introduction');
     $oIntroSectionDoc->textSet($oOperationDoc->textGet());
 
-    foreach my $strCommand (sort(keys($$oConfigHash{&CONFIG_HELP_COMMAND})))
+    foreach my $strCommand (sort(keys(%{$$oConfigHash{&CONFIG_HELP_COMMAND}})))
     {
         my $oCommandHash = $$oConfigHash{&CONFIG_HELP_COMMAND}{$strCommand};
         my $oSectionElement = $oDoc->nodeAdd('section', undef, {id => "command-${strCommand}"});

--- a/doc/lib/BackRestDoc/Common/DocExecute.pm
+++ b/doc/lib/BackRestDoc/Common/DocExecute.pm
@@ -355,7 +355,7 @@ sub backrestConfig
                 {
                     delete(${$self->{config}}{$strHostName}{$strFile}{$strSection}{$strKey});
 
-                    if (keys(${$self->{config}}{$strHostName}{$strFile}{$strSection}) == 0)
+                    if (keys(%{${$self->{config}}{$strHostName}{$strFile}{$strSection}}) == 0)
                     {
                         delete(${$self->{config}}{$strHostName}{$strFile}{$strSection});
                     }
@@ -617,7 +617,7 @@ sub sectionChildProcess
             $oHost->executeSimple("sh -c 'echo \"# Test Hosts\" >> /etc/hosts'", undef, 'root');
 
             # Add all other host IPs to this host
-            foreach my $strOtherHostName (sort(keys($self->{host})))
+            foreach my $strOtherHostName (sort(keys(%{$self->{host}})))
             {
                 if ($strOtherHostName ne $strName)
                 {
@@ -628,7 +628,7 @@ sub sectionChildProcess
             }
 
             # Add this host IP to all other hosts
-            foreach my $strOtherHostName (sort(keys($self->{host})))
+            foreach my $strOtherHostName (sort(keys(%{$self->{host}})))
             {
                 if ($strOtherHostName ne $strName)
                 {

--- a/doc/lib/BackRestDoc/Common/DocManifest.pm
+++ b/doc/lib/BackRestDoc/Common/DocManifest.pm
@@ -444,7 +444,7 @@ sub renderList
 
     if (defined(${$self->{oManifest}}{render}))
     {
-        @stryRender = sort(keys(${$self->{oManifest}}{render}));
+        @stryRender = sort(keys(%{${$self->{oManifest}}{render}}));
     }
 
     # Return from function and log return values if any
@@ -512,7 +512,7 @@ sub renderOutList
 
     if (defined(${$self->{oManifest}}{render}{$strType}))
     {
-        @stryRenderOut = sort(keys(${$self->{oManifest}}{render}{$strType}{out}));
+        @stryRenderOut = sort(keys(%{${$self->{oManifest}}{render}{$strType}{out}}));
     }
 
     # Return from function and log return values if any

--- a/doc/lib/BackRestDoc/Common/DocRender.pm
+++ b/doc/lib/BackRestDoc/Common/DocRender.pm
@@ -348,7 +348,7 @@ sub required
     if (!defined($bDepend) || $bDepend)
     {
         # Match section and all child sections
-        foreach my $strChildPath (sort(keys($self->{oSection})))
+        foreach my $strChildPath (sort(keys(%{$self->{oSection}})))
         {
             if ($strChildPath =~ /^$strPath$/ || $strChildPath =~ /^$strPath\/.*$/)
             {


### PR DESCRIPTION
Somewhere between perl 5.14 and 5.20, constructs like this:
  perl -e '$a = {}; keys $a'
started to throw warnings:
  keys on reference is experimental at -e line 1.

Fix by adding a bunch of %{} and @{} casts

Also fix a "is used only once" warning on $XML::Checker::FAIL.