### PR TITLE
Closes #196: Fix perl warnings/errors in String.pm

### DIFF
--- a/lib/pgBackRest/Common/String.pm
+++ b/lib/pgBackRest/Common/String.pm
@@ -172,7 +172,11 @@ sub timestampFormat
 
     my ($iSecond, $iMinute, $iHour, $iMonthDay, $iMonth, $iYear, $iWeekDay, $iYearDay, $bIsDst) = localtime($lTime);
 
-    return sprintf($strFormat, $iYear + 1900, $iMonth + 1, $iMonthDay, $iHour, $iMinute, $iSecond);
+    if ($strFormat eq "%4d") {
+        return sprintf($strFormat, $iYear + 1900)
+    } else {
+        return sprintf($strFormat, $iYear + 1900, $iMonth + 1, $iMonthDay, $iHour, $iMinute, $iSecond);
+    }
 }
 
 push @EXPORT, qw(timestampFormat);


### PR DESCRIPTION
Somewhere in perl 5.2x.x the behavior of sprintf changed. sprintf throws a
warning if more arguments are given then used within the format string.

The timestmapFormat function takes any format string.

Fix by special casing the only given format string "%4d" within
timestampFormat.