### PR TITLE
Remove absolute path for logo.

### DIFF
--- a/doc/lib/BackRestDoc/Latex/DocLatex.pm
+++ b/doc/lib/BackRestDoc/Latex/DocLatex.pm
@@ -103,7 +103,7 @@ sub process
     my $oRender = $self->{oManifest}->renderGet(RENDER_TYPE_PDF);
 
     # Copy the logo
-    copy('/backrest/doc/resource/latex/cds-logo.eps', "$self->{strLatexPath}/logo.eps")
+    copy('doc/resource/latex/cds-logo.eps', "$self->{strLatexPath}/logo.eps")
         or confess &log(ERROR, "unable to copy logo");
 
     my $strLatex = $self->{oManifest}->variableReplace(fileStringRead($self->{strPreambleFile}), 'latex') . "\n";

--- a/doc/manifest.xml
+++ b/doc/manifest.xml
@@ -13,7 +13,7 @@
         <variable key="project-favicon">favicon.png</variable>
 
         <!-- Logo locations -->
-        <variable key="logo">/backrest/doc/output/latex/logo</variable>
+        <variable key="logo">doc/output/latex/logo</variable>
 
         <!-- HTML variables  -->
         <variable key="html-footer" eval='y'>


### PR DESCRIPTION
While building the documentation within the projects root directory the build
fails because of absolute file paths within DocLatex.pm and manifest.xml.

Fix: Using relative paths.