### PR TITLE
Retention-archive-type being ignored.

### DIFF
--- a/bin/pgbackrest
+++ b/bin/pgbackrest
@@ -112,7 +112,7 @@ local $EVAL_ERROR = undef; eval
         exitSafe($oLocal->process());
     }
 
-    # Set the log levels
+    # Set the log levels - even though configLoad sets them, they may be turned off above, so need to ensure they are on here
     logLevelSet(optionGet(OPTION_LOG_LEVEL_FILE), optionGet(OPTION_LOG_LEVEL_CONSOLE));
 
     # Log the command start

--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -417,7 +417,7 @@
 
             <!-- CONFIG - EXPIRE -->
             <config-section id="expire" name="Expire">
-                <text>The <setting>expire</setting> section defines how long backups will be retained.  Expiration only occurs when the number of complete backups exceeds the allowed retention.  In other words, if full-retention is set to 2, then there must be 3 complete backups before the oldest will be expired.  Make sure you always have enough space for retention + 1 backups.</text>
+                <text>The <setting>expire</setting> section defines how long backups will be retained.  Expiration only occurs when the number of complete backups exceeds the allowed retention.  In other words, if retention-full is set to 2, then there must be 3 complete backups before the oldest will be expired.  Make sure you always have enough space for retention + 1 backups.</text>
 
                 <!-- CONFIG - RETENTION SECTION - FULL-RETENTION KEY -->
                 <config-key-list>
@@ -442,16 +442,16 @@
                     <config-key id="retention-archive-type" name="Archive Retention Type">
                         <summary>Backup type for WAL retention.</summary>
 
-                        <text>If set to <setting>full</setting> <backrest/> will keep archive logs for the number of full backups defined by <setting>retention-archive</setting>.  If set to <setting>diff</setting> (differential) <backrest/> will keep archive logs for the number of full and differential backups defined by <setting>retention-archive</setting>.  If set to <setting>incr</setting> (incremental) <backrest/> will keep archive logs for the number of full, differential, and incremental backups defined by <setting>retention-archive</setting>.</text>
+                        <text>If set to <setting>full</setting> <backrest/> will keep archive logs for the number of full backups defined by <setting>retention-archive</setting>.  If set to <setting>diff</setting> (differential) <backrest/> will keep archive logs for the number of full and differential backups defined by <setting>retention-archive</setting>, meaning if the last backup taken was a full backup, it will be counted as a differential for the purpose of retention.  If set to <setting>incr</setting> (incremental) <backrest/> will keep archive logs for the number of full, differential, and incremental backups defined by <setting>retention-archive</setting>. It is recommended that this setting not be changed from the default which will only expire WAL in conjunction with expiring full backups.</text>
 
                         <example>diff</example>
                     </config-key>
 
                     <!-- CONFIG - RETENTION SECTION - ARCHIVE-RETENTION KEY -->
                     <config-key id="retention-archive" name="Archive Retention">
-                        <summary>Number of backups worth of WAL to retain.</summary>
+                        <summary>Number of backups worth of WAL to retain. Only WAL required to make the backup consistent will be retained.</summary>
 
-                        <text>Number of backups worth of archive log to keep.</text>
+                        <text>If this value is not set, then the number of archives to expire will default to the <setting>retention-full</setting> (or <setting>retention-diff</setting>) value corresponding to the <setting>retention-archive-type</setting> if set to <setting>full</setting> (or <setting>diff</setting>). This will insure that WAL is only expired for backups that are expired. It must be set if <setting>retention-archive-type</setting> is set to <setting>incr</setting>. If disk space is at a premium, then this setting, in conjunction with <setting>retention-archive-type</setting>, can be used to agressively expire WAL; however, doing so will negate the ability to perform PITR from the backups with expired WAL and is therefore not recommended.</text>
 
                         <example>2</example>
                     </config-key>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -128,6 +128,14 @@
 
                         <p>Fixed the <cmd>check</cmd> command so backup info is checked remotely and not just locally.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="shang.cynthia"/>
+                        </release-item-contributor-list>
+
+                        <p>Fixed an issue where <br-option>retention-archive-type</br-option> was being ignored if <br-option>retention-archive</br-option> was not set, resulting in archive logs not being expired with expiring backups.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-feature-list>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -702,7 +702,7 @@
         <section id="full">
             <title>Full Backup Retention</title>
 
-            <p>Set <br-option>full-retention</br-option> to the number of full backups required.  New backups must be completed before expiration will occur &amp;mdash; that means if <br-setting>retention-full=2</br-setting> then there will be three full backups stored before the oldest one is expired.</p>
+            <p>Set <br-option>retention-full</br-option> to the number of full backups required.  New backups must be completed before expiration will occur &amp;mdash; that means if <br-setting>retention-full=2</br-setting> then there will be three full backups stored before the oldest one is expired.</p>
 
             <backrest-config host="{[host-db-master]}" file="{[backrest-config-demo]}">
                 <title>Configure <br-option>retention-full</br-option></title>
@@ -782,6 +782,53 @@
                     <exe-highlight>expire diff backup set: {[backup-diff-second]}</exe-highlight>
                 </execute>
             </execute-list>
+        </section>
+
+        <!-- SECTION => RETENTION - ARCHIVE -->
+        <section id="archive">
+            <title>Archive Retention</title>
+
+            <p>Although <backrest/> automatically removes archived WAL segments when expiring backups (the default expires WAL for full backups based on the retention-full setting), it may be useful to expire archive more aggressively to save disk space. Expiring archive will never remove WAL segments that are required to make a backup consistent, however, PITR can only be on a continuous WAL stream, so care should be taken when expiring archive outside of the normal backup expiration process. Note that full backups are considered differential backups for the purpose of differential archive retention.</p>
+
+            <backrest-config host="{[host-db-master]}" file="{[backrest-config-demo]}">
+                <title>Configure <br-option>retention-diff</br-option></title>
+
+                <backrest-config-option section="global" key="retention-diff">2</backrest-config-option>
+            </backrest-config>
+
+            <execute-list host="{[host-db-master]}">
+                <title>Perform differential backup</title>
+
+                <execute show="n" variable-key="backup-diff-first">
+                    <exe-cmd>{[cmd-backup-last]}</exe-cmd>
+                </execute>
+
+                <execute output="y">
+                    <exe-cmd>{[project-exe]} {[dash]}-stanza={[postgres-cluster-demo]} --type=diff
+                        --log-level-console=info backup</exe-cmd>
+                    <exe-highlight>new backup label</exe-highlight>
+                </execute>
+
+                <execute show="n" variable-key="backup-diff-second">
+                    <exe-cmd>{[cmd-backup-last]}</exe-cmd>
+                </execute>
+            </execute-list>
+
+            <execute-list host="{[host-db-master]}">
+                <title>Expire archive</title>
+
+                <execute output="y">
+                    <exe-cmd>{[project-exe]} {[dash]}-stanza={[postgres-cluster-demo]} --log-level-console=detail
+                        --retention-archive-type=diff --retention-archive=1 expire</exe-cmd>
+                    <exe-highlight>archive retention on backup {[backup-diff-first]}|remove archive</exe-highlight>
+                </execute>
+
+            </execute-list>
+
+            <p>The <id>{[backup-diff-first]}</id> differential backup has archived WAL segments that must be retained to make the older backups consistent even though they cannot be played any further forward with PITR; the other WAL segments for <id>{[backup-diff-first]}</id> that are no longer required are removed. WAL segments for the new backup {[backup-diff-second]} remain and can be used for PITR.</p>
+
+            <p>Since full backups are considered differential backups for the purpose of differential archive retention, if a full backup is now performed with the same settings, only the archive for that full backup is retained for PITR.</p>
+
         </section>
     </section>
 

--- a/lib/pgBackRest/Config/ConfigHelpData.pm
+++ b/lib/pgBackRest/Config/ConfigHelpData.pm
@@ -570,9 +570,14 @@ my $oConfigHelpData =
         {
             section => 'expire',
             summary =>
-                "Number of backups worth of WAL to retain.",
+                "Number of backups worth of WAL to retain. Only WAL required to make the backup consistent will be retained.",
             description =>
-                "Number of backups worth of archive log to keep."
+                "If this value is not set, then the number of archives to expire will default to the retention-full (or " .
+                    "retention-diff) value corresponding to the retention-archive-type if set to full (or diff). This will " .
+                    "insure that WAL is only expired for backups that are expired. It must be set if retention-archive-type is " .
+                    "set to incr. If disk space is at a premium, then this setting, in conjunction with retention-archive-type, " .
+                    "can be used to agressively expire WAL; however, doing so will negate the ability to perform PITR from the " .
+                    "backups with expired WAL and is therefore not recommended."
         },
 
         # RETENTION-ARCHIVE-TYPE Option Help
@@ -585,8 +590,11 @@ my $oConfigHelpData =
             description =>
                 "If set to full pgBackRest will keep archive logs for the number of full backups defined by retention-archive. " .
                     "If set to diff (differential) pgBackRest will keep archive logs for the number of full and differential " .
-                    "backups defined by retention-archive. If set to incr (incremental) pgBackRest will keep archive logs for " .
-                    "the number of full, differential, and incremental backups defined by retention-archive."
+                    "backups defined by retention-archive, meaning if the last backup taken was a full backup, it will be " .
+                    "counted as a differential for the purpose of retention. If set to incr (incremental) pgBackRest will keep " .
+                    "archive logs for the number of full, differential, and incremental backups defined by retention-archive. " .
+                    "It is recommended that this setting not be changed from the default which will only expire WAL in " .
+                    "conjunction with expiring full backups."
         },
 
         # RETENTION-DIFF Option Help

--- a/test/expect/backup-expire-001.log
+++ b/test/expect/backup-expire-001.log
@@ -2216,3 +2216,818 @@ db-version="9.2"
 000000010000000200000027-0000000000000000000000000000000000000000.gz
 000000010000000200000028-0000000000000000000000000000000000000000
 000000010000000200000029-0000000000000000000000000000000000000000.gz
+
+* full backup: label = [BACKUP-FULL-4], start = 00000001000000020000002A, stop = 00000001000000020000002C
+* diff backup: label = [BACKUP-DIFF-5], prior = [BACKUP-FULL-4], start = 000000010000000200000030, stop = 000000010000000200000032
+* full backup: label = [BACKUP-FULL-5], start = 000000010000000200000036, stop = 000000010000000200000038
+====================================================================================================================================
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000010","backup-archive-stop":"000000010000000200000012","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000001E","backup-archive-stop":"000000010000000200000020","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-INCR-2]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-INCR-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000024","backup-archive-stop":"000000010000000200000026","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-4]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000030","backup-archive-stop":"000000010000000200000032","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-4]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-3]
+[BACKUP-DIFF-4]
+[BACKUP-INCR-3]
+[BACKUP-FULL-4]
+[BACKUP-DIFF-5]
+[BACKUP-FULL-5]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+000000010000000200000010-0000000000000000000000000000000000000000.gz
+000000010000000200000011-0000000000000000000000000000000000000000
+000000010000000200000012-0000000000000000000000000000000000000000.gz
+00000001000000020000001E-0000000000000000000000000000000000000000.gz
+00000001000000020000001F-0000000000000000000000000000000000000000
+000000010000000200000020-0000000000000000000000000000000000000000.gz
+000000010000000200000024-0000000000000000000000000000000000000000.gz
+000000010000000200000025-0000000000000000000000000000000000000000
+000000010000000200000026-0000000000000000000000000000000000000000.gz
+000000010000000200000027-0000000000000000000000000000000000000000.gz
+000000010000000200000028-0000000000000000000000000000000000000000
+000000010000000200000029-0000000000000000000000000000000000000000.gz
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+00000001000000020000002D-0000000000000000000000000000000000000000.gz
+00000001000000020000002E-0000000000000000000000000000000000000000
+00000001000000020000002F-0000000000000000000000000000000000000000.gz
+000000010000000200000030-0000000000000000000000000000000000000000.gz
+000000010000000200000031-0000000000000000000000000000000000000000
+000000010000000200000032-0000000000000000000000000000000000000000.gz
+000000010000000200000033-0000000000000000000000000000000000000000.gz
+000000010000000200000034-0000000000000000000000000000000000000000
+000000010000000200000035-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+000000010000000200000039-0000000000000000000000000000000000000000.gz
+00000001000000020000003A-0000000000000000000000000000000000000000
+00000001000000020000003B-0000000000000000000000000000000000000000.gz
+
+Expire diff treating full as diff
+> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config="[TEST_PATH]/db-master/pgbackrest.conf" --stanza=db --log-level-console=detail --retention-full=2 --retention-diff=1 --retention-archive-type=diff --retention-archive=1 expire
+------------------------------------------------------------------------------------------------------------------------------------
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-archive-type=diff --retention-diff=1 --retention-full=2 --stanza=db
+  INFO: expire full backup set: [BACKUP-FULL-3], [BACKUP-DIFF-4], [BACKUP-INCR-3]
+  INFO: expire diff backup [BACKUP-DIFF-5]
+  INFO: remove expired backup [BACKUP-DIFF-5]
+  INFO: remove expired backup [BACKUP-INCR-3]
+  INFO: remove expired backup [BACKUP-DIFF-4]
+  INFO: remove expired backup [BACKUP-FULL-3]
+DETAIL: archive retention on backup [BACKUP-FULL-4], start = 00000001000000020000002A, stop = 00000001000000020000002C
+DETAIL: archive retention on backup [BACKUP-FULL-5], start = 000000010000000200000036
+DETAIL: remove archive: start = 000000010000000200000010, stop = 000000010000000200000029
+DETAIL: remove archive: start = 00000001000000020000002D, stop = 000000010000000200000035
+  INFO: expire stop
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+000000010000000200000039-0000000000000000000000000000000000000000.gz
+00000001000000020000003A-0000000000000000000000000000000000000000
+00000001000000020000003B-0000000000000000000000000000000000000000.gz
+
+* full backup: label = [BACKUP-FULL-6], start = 00000001000000020000003C, stop = 00000001000000020000003E
+* diff backup: label = [BACKUP-DIFF-6], prior = [BACKUP-FULL-6], start = 000000010000000200000042, stop = 000000010000000200000044
+* diff backup: label = [BACKUP-DIFF-7], prior = [BACKUP-DIFF-6], start = 000000010000000200000048, stop = 00000001000000020000004A
+====================================================================================================================================
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000003C","backup-archive-stop":"00000001000000020000003E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000042","backup-archive-stop":"000000010000000200000044","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000048","backup-archive-stop":"00000001000000020000004A","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+[BACKUP-FULL-6]
+[BACKUP-DIFF-6]
+[BACKUP-DIFF-7]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+000000010000000200000039-0000000000000000000000000000000000000000.gz
+00000001000000020000003A-0000000000000000000000000000000000000000
+00000001000000020000003B-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+00000001000000020000003F-0000000000000000000000000000000000000000.gz
+000000010000000200000040-0000000000000000000000000000000000000000
+000000010000000200000041-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000045-0000000000000000000000000000000000000000.gz
+000000010000000200000046-0000000000000000000000000000000000000000
+000000010000000200000047-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004B-0000000000000000000000000000000000000000.gz
+00000001000000020000004C-0000000000000000000000000000000000000000
+00000001000000020000004D-0000000000000000000000000000000000000000.gz
+
+Expire diff with retention-archive with warning retention-diff not set
+> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config="[TEST_PATH]/db-master/pgbackrest.conf" --stanza=db --log-level-console=detail --retention-archive-type=diff --retention-archive=1 expire
+------------------------------------------------------------------------------------------------------------------------------------
+  WARN: option 'retention-diff' is not set for 'retention-archive-type=diff' 
+        HINT: to retain backups indefinitely, set the value to the maximum.
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-archive-type=diff --stanza=db
+DETAIL: archive retention on backup [BACKUP-FULL-4], start = 00000001000000020000002A, stop = 00000001000000020000002C
+DETAIL: archive retention on backup [BACKUP-FULL-5], start = 000000010000000200000036, stop = 000000010000000200000038
+DETAIL: archive retention on backup [BACKUP-FULL-6], start = 00000001000000020000003C, stop = 00000001000000020000003E
+DETAIL: archive retention on backup [BACKUP-DIFF-6], start = 000000010000000200000042, stop = 000000010000000200000044
+DETAIL: archive retention on backup [BACKUP-DIFF-7], start = 000000010000000200000048
+DETAIL: remove archive: start = 000000010000000200000039, stop = 00000001000000020000003B
+DETAIL: remove archive: start = 00000001000000020000003F, stop = 000000010000000200000041
+DETAIL: remove archive: start = 000000010000000200000045, stop = 000000010000000200000047
+  INFO: expire stop
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000003C","backup-archive-stop":"00000001000000020000003E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000042","backup-archive-stop":"000000010000000200000044","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000048","backup-archive-stop":"00000001000000020000004A","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+[BACKUP-FULL-6]
+[BACKUP-DIFF-6]
+[BACKUP-DIFF-7]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004B-0000000000000000000000000000000000000000.gz
+00000001000000020000004C-0000000000000000000000000000000000000000
+00000001000000020000004D-0000000000000000000000000000000000000000.gz
+
+* full backup: label = [BACKUP-FULL-7], start = 00000001000000020000004E, stop = 000000010000000200000050
+* full backup: label = [BACKUP-FULL-8], start = 000000010000000200000054, stop = 000000010000000200000056
+====================================================================================================================================
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000003C","backup-archive-stop":"00000001000000020000003E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000042","backup-archive-stop":"000000010000000200000044","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000048","backup-archive-stop":"00000001000000020000004A","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000004E","backup-archive-stop":"000000010000000200000050","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+[BACKUP-FULL-6]
+[BACKUP-DIFF-6]
+[BACKUP-DIFF-7]
+[BACKUP-FULL-7]
+[BACKUP-FULL-8]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004B-0000000000000000000000000000000000000000.gz
+00000001000000020000004C-0000000000000000000000000000000000000000
+00000001000000020000004D-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000051-0000000000000000000000000000000000000000.gz
+000000010000000200000052-0000000000000000000000000000000000000000
+000000010000000200000053-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+
+Expire full with retention-archive with warning retention-full not set
+> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config="[TEST_PATH]/db-master/pgbackrest.conf" --stanza=db --log-level-console=detail --retention-archive-type=full --retention-archive=1 expire
+------------------------------------------------------------------------------------------------------------------------------------
+  WARN: option 'retention-full' is not set for 'retention-archive-type=full' 
+        HINT: to retain backups indefinitely, set the value to the maximum.
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-archive-type=full --stanza=db
+DETAIL: archive retention on backup [BACKUP-FULL-4], start = 00000001000000020000002A, stop = 00000001000000020000002C
+DETAIL: archive retention on backup [BACKUP-FULL-5], start = 000000010000000200000036, stop = 000000010000000200000038
+DETAIL: archive retention on backup [BACKUP-FULL-6], start = 00000001000000020000003C, stop = 00000001000000020000003E
+DETAIL: archive retention on backup [BACKUP-DIFF-6], start = 000000010000000200000042, stop = 000000010000000200000044
+DETAIL: archive retention on backup [BACKUP-DIFF-7], start = 000000010000000200000048, stop = 00000001000000020000004A
+DETAIL: archive retention on backup [BACKUP-FULL-7], start = 00000001000000020000004E, stop = 000000010000000200000050
+DETAIL: archive retention on backup [BACKUP-FULL-8], start = 000000010000000200000054
+DETAIL: remove archive: start = 00000001000000020000004B, stop = 00000001000000020000004D
+DETAIL: remove archive: start = 000000010000000200000051, stop = 000000010000000200000053
+  INFO: expire stop
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000003C","backup-archive-stop":"00000001000000020000003E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000042","backup-archive-stop":"000000010000000200000044","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000048","backup-archive-stop":"00000001000000020000004A","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000004E","backup-archive-stop":"000000010000000200000050","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+[BACKUP-FULL-6]
+[BACKUP-DIFF-6]
+[BACKUP-DIFF-7]
+[BACKUP-FULL-7]
+[BACKUP-FULL-8]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+
+* incr backup: label = [BACKUP-INCR-4], prior = [BACKUP-FULL-8], start = 00000001000000020000005A, stop = 00000001000000020000005C
+====================================================================================================================================
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000002A","backup-archive-stop":"00000001000000020000002C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-5]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000036","backup-archive-stop":"000000010000000200000038","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000003C","backup-archive-stop":"00000001000000020000003E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-6]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000042","backup-archive-stop":"000000010000000200000044","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000048","backup-archive-stop":"00000001000000020000004A","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-6]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-7]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000004E","backup-archive-stop":"000000010000000200000050","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000005A","backup-archive-stop":"00000001000000020000005C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-4]
+[BACKUP-FULL-5]
+[BACKUP-FULL-6]
+[BACKUP-DIFF-6]
+[BACKUP-DIFF-7]
+[BACKUP-FULL-7]
+[BACKUP-FULL-8]
+[BACKUP-INCR-4]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+00000001000000020000005A-0000000000000000000000000000000000000000.gz
+00000001000000020000005B-0000000000000000000000000000000000000000
+00000001000000020000005C-0000000000000000000000000000000000000000.gz
+00000001000000020000005D-0000000000000000000000000000000000000000.gz
+00000001000000020000005E-0000000000000000000000000000000000000000
+00000001000000020000005F-0000000000000000000000000000000000000000.gz
+
+Expire no archive with warning since retention-archive not set for INCR
+> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config="[TEST_PATH]/db-master/pgbackrest.conf" --stanza=db --log-level-console=detail --retention-full=1 --retention-diff=1 --retention-archive-type=incr expire
+------------------------------------------------------------------------------------------------------------------------------------
+  WARN: WAL segments will not be expired: option 'retention-archive-type=incr' but option 'retention-archive' is not set
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive-type=incr --retention-diff=1 --retention-full=1 --stanza=db
+  INFO: expire full backup [BACKUP-FULL-4]
+  INFO: expire full backup [BACKUP-FULL-5]
+  INFO: expire full backup set: [BACKUP-FULL-6], [BACKUP-DIFF-6], [BACKUP-DIFF-7]
+  INFO: expire full backup [BACKUP-FULL-7]
+  INFO: remove expired backup [BACKUP-FULL-7]
+  INFO: remove expired backup [BACKUP-DIFF-7]
+  INFO: remove expired backup [BACKUP-DIFF-6]
+  INFO: remove expired backup [BACKUP-FULL-6]
+  INFO: remove expired backup [BACKUP-FULL-5]
+  INFO: remove expired backup [BACKUP-FULL-4]
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
+  INFO: expire stop
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000005A","backup-archive-stop":"00000001000000020000005C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-8]
+[BACKUP-INCR-4]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+00000001000000020000005A-0000000000000000000000000000000000000000.gz
+00000001000000020000005B-0000000000000000000000000000000000000000
+00000001000000020000005C-0000000000000000000000000000000000000000.gz
+00000001000000020000005D-0000000000000000000000000000000000000000.gz
+00000001000000020000005E-0000000000000000000000000000000000000000
+00000001000000020000005F-0000000000000000000000000000000000000000.gz
+
+* full backup: label = [BACKUP-FULL-9], start = 000000010000000200000060, stop = 000000010000000200000062
+* diff backup: label = [BACKUP-DIFF-8], prior = [BACKUP-FULL-9], start = 000000010000000200000066, stop = 000000010000000200000068
+* diff backup: label = [BACKUP-DIFF-9], prior = [BACKUP-DIFF-8], start = 00000001000000020000006C, stop = 00000001000000020000006E
+====================================================================================================================================
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000005A","backup-archive-stop":"00000001000000020000005C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-9]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000060","backup-archive-stop":"000000010000000200000062","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000066","backup-archive-stop":"000000010000000200000068","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-9]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-9]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000006C","backup-archive-stop":"00000001000000020000006E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-8]
+[BACKUP-INCR-4]
+[BACKUP-FULL-9]
+[BACKUP-DIFF-8]
+[BACKUP-DIFF-9]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+00000001000000020000005A-0000000000000000000000000000000000000000.gz
+00000001000000020000005B-0000000000000000000000000000000000000000
+00000001000000020000005C-0000000000000000000000000000000000000000.gz
+00000001000000020000005D-0000000000000000000000000000000000000000.gz
+00000001000000020000005E-0000000000000000000000000000000000000000
+00000001000000020000005F-0000000000000000000000000000000000000000.gz
+000000010000000200000060-0000000000000000000000000000000000000000.gz
+000000010000000200000061-0000000000000000000000000000000000000000
+000000010000000200000062-0000000000000000000000000000000000000000.gz
+000000010000000200000063-0000000000000000000000000000000000000000.gz
+000000010000000200000064-0000000000000000000000000000000000000000
+000000010000000200000065-0000000000000000000000000000000000000000.gz
+000000010000000200000066-0000000000000000000000000000000000000000.gz
+000000010000000200000067-0000000000000000000000000000000000000000
+000000010000000200000068-0000000000000000000000000000000000000000.gz
+000000010000000200000069-0000000000000000000000000000000000000000.gz
+00000001000000020000006A-0000000000000000000000000000000000000000
+00000001000000020000006B-0000000000000000000000000000000000000000.gz
+00000001000000020000006C-0000000000000000000000000000000000000000.gz
+00000001000000020000006D-0000000000000000000000000000000000000000
+00000001000000020000006E-0000000000000000000000000000000000000000.gz
+00000001000000020000006F-0000000000000000000000000000000000000000.gz
+000000010000000200000070-0000000000000000000000000000000000000000
+000000010000000200000071-0000000000000000000000000000000000000000.gz
+
+Expire no archive with warning since neither retention-archive nor retention-diff is set
+> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config="[TEST_PATH]/db-master/pgbackrest.conf" --stanza=db --log-level-console=detail --retention-archive-type=diff expire
+------------------------------------------------------------------------------------------------------------------------------------
+  WARN: WAL segments will not be expired: option 'retention-archive-type=diff' but option 'retention-archive' nor option 'retention-diff' are not set
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive-type=diff --stanza=db
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
+  INFO: expire stop
+
++ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
+---------------------------------------------------------------------
+[backrest]
+backrest-checksum="[CHECKSUM]"
+backrest-format=5
+backrest-version="[VERSION-1]"
+
+[backup:current]
+[BACKUP-FULL-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000054","backup-archive-stop":"000000010000000200000056","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000005A","backup-archive-stop":"00000001000000020000005C","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-FULL-9]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000060","backup-archive-stop":"000000010000000200000062","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-8]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"000000010000000200000066","backup-archive-stop":"000000010000000200000068","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-9]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+[BACKUP-DIFF-9]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":"00000001000000020000006C","backup-archive-stop":"00000001000000020000006E","backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-8]","backup-reference":[],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":true,"option-archive-copy":false,"option-backup-standby":false,"option-compress":true,"option-hardlink":false,"option-online":true}
+
+[db]
+db-catalog-version=20920101
+db-control-version=921
+db-id=1
+db-system-id=920000000000000001
+db-version="9.2"
+
+[db:history]
+1={"db-catalog-version":20920101,"db-control-version":921,"db-system-id":920000000000000001,"db-version":"9.2"}
+
+> ls [TEST_PATH]/db-master/repo/backup/db | grep -v "backup.*"
+------------------------------------------------------------------------------------------------------------------------------------
+[BACKUP-FULL-8]
+[BACKUP-INCR-4]
+[BACKUP-FULL-9]
+[BACKUP-DIFF-8]
+[BACKUP-DIFF-9]
+
+> ls -R [TEST_PATH]/db-master/repo/archive/db | grep -v "archive.info"
+------------------------------------------------------------------------------------------------------------------------------------
+[TEST_PATH]/db-master/repo/archive/db:
+9.2-1
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1:
+0000000100000002
+
+[TEST_PATH]/db-master/repo/archive/db/9.2-1/0000000100000002:
+00000001000000020000002A-0000000000000000000000000000000000000000.gz
+00000001000000020000002B-0000000000000000000000000000000000000000
+00000001000000020000002C-0000000000000000000000000000000000000000.gz
+000000010000000200000036-0000000000000000000000000000000000000000.gz
+000000010000000200000037-0000000000000000000000000000000000000000
+000000010000000200000038-0000000000000000000000000000000000000000.gz
+00000001000000020000003C-0000000000000000000000000000000000000000.gz
+00000001000000020000003D-0000000000000000000000000000000000000000
+00000001000000020000003E-0000000000000000000000000000000000000000.gz
+000000010000000200000042-0000000000000000000000000000000000000000.gz
+000000010000000200000043-0000000000000000000000000000000000000000
+000000010000000200000044-0000000000000000000000000000000000000000.gz
+000000010000000200000048-0000000000000000000000000000000000000000.gz
+000000010000000200000049-0000000000000000000000000000000000000000
+00000001000000020000004A-0000000000000000000000000000000000000000.gz
+00000001000000020000004E-0000000000000000000000000000000000000000.gz
+00000001000000020000004F-0000000000000000000000000000000000000000
+000000010000000200000050-0000000000000000000000000000000000000000.gz
+000000010000000200000054-0000000000000000000000000000000000000000.gz
+000000010000000200000055-0000000000000000000000000000000000000000
+000000010000000200000056-0000000000000000000000000000000000000000.gz
+000000010000000200000057-0000000000000000000000000000000000000000.gz
+000000010000000200000058-0000000000000000000000000000000000000000
+000000010000000200000059-0000000000000000000000000000000000000000.gz
+00000001000000020000005A-0000000000000000000000000000000000000000.gz
+00000001000000020000005B-0000000000000000000000000000000000000000
+00000001000000020000005C-0000000000000000000000000000000000000000.gz
+00000001000000020000005D-0000000000000000000000000000000000000000.gz
+00000001000000020000005E-0000000000000000000000000000000000000000
+00000001000000020000005F-0000000000000000000000000000000000000000.gz
+000000010000000200000060-0000000000000000000000000000000000000000.gz
+000000010000000200000061-0000000000000000000000000000000000000000
+000000010000000200000062-0000000000000000000000000000000000000000.gz
+000000010000000200000063-0000000000000000000000000000000000000000.gz
+000000010000000200000064-0000000000000000000000000000000000000000
+000000010000000200000065-0000000000000000000000000000000000000000.gz
+000000010000000200000066-0000000000000000000000000000000000000000.gz
+000000010000000200000067-0000000000000000000000000000000000000000
+000000010000000200000068-0000000000000000000000000000000000000000.gz
+000000010000000200000069-0000000000000000000000000000000000000000.gz
+00000001000000020000006A-0000000000000000000000000000000000000000
+00000001000000020000006B-0000000000000000000000000000000000000000.gz
+00000001000000020000006C-0000000000000000000000000000000000000000.gz
+00000001000000020000006D-0000000000000000000000000000000000000000
+00000001000000020000006E-0000000000000000000000000000000000000000.gz
+00000001000000020000006F-0000000000000000000000000000000000000000.gz
+000000010000000200000070-0000000000000000000000000000000000000000
+000000010000000200000071-0000000000000000000000000000000000000000.gz

--- a/test/expect/backup-synthetic-001.log
+++ b/test/expect/backup-synthetic-001.log
@@ -185,7 +185,7 @@ full backup - create pg_stat link, pg_clog dir (db-master host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -651,7 +651,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1419,7 +1419,7 @@ incr backup - add tablespace 1 (db-master host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1703,7 +1703,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1858,7 +1858,7 @@ diff backup - cannot resume - new diff (db-master host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2007,7 +2007,7 @@ diff backup - cannot resume - disabled (db-master host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2246,7 +2246,7 @@ incr backup - add files and remove tablespace 2 (db-master host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2395,7 +2395,7 @@ incr backup - update files (db-master host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2546,7 +2546,7 @@ diff backup - updates since last full (db-master host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2693,7 +2693,7 @@ incr backup - remove files - but won't affect manifest (db-master host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2845,7 +2845,7 @@ DETAIL: skip file removed by database [TEST_PATH]/db-master/db/base-2/base/base2
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3004,7 +3004,7 @@ full backup - update file (db-master host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3468,7 +3468,8 @@ info db stanza - normal output (db-master host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -3489,7 +3490,7 @@ diff backup - add file (db-master host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-002.log
+++ b/test/expect/backup-synthetic-002.log
@@ -170,7 +170,7 @@ full backup - create pg_stat link, pg_clog dir (db-master host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -446,7 +446,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1032,7 +1032,7 @@ incr backup - add tablespace 1 (db-master host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1346,7 +1346,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1495,7 +1495,7 @@ diff backup - cannot resume - new diff (db-master host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1638,7 +1638,7 @@ diff backup - cannot resume - disabled (db-master host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1871,7 +1871,7 @@ incr backup - add files and remove tablespace 2 (db-master host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2011,7 +2011,7 @@ incr backup - update files (db-master host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2156,7 +2156,7 @@ diff backup - updates since last full (db-master host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2297,7 +2297,7 @@ incr backup - remove files - but won't affect manifest (db-master host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2443,7 +2443,7 @@ DETAIL: skip file removed by database [TEST_PATH]/db-master/db/base-2/base/base2
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2596,7 +2596,7 @@ full backup - update file (db-master host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3054,7 +3054,8 @@ info db stanza - normal output (db-master host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -3075,7 +3076,7 @@ diff backup - add file (db-master host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-003.log
+++ b/test/expect/backup-synthetic-003.log
@@ -170,7 +170,7 @@ full backup - create pg_stat link, pg_clog dir (db-master host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -444,7 +444,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1005,7 +1005,7 @@ incr backup - add tablespace 1 (db-master host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1273,7 +1273,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1420,7 +1420,7 @@ diff backup - cannot resume - new diff (db-master host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1561,7 +1561,7 @@ diff backup - cannot resume - disabled (db-master host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1792,7 +1792,7 @@ incr backup - add files and remove tablespace 2 (db-master host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1930,7 +1930,7 @@ incr backup - update files (db-master host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2073,7 +2073,7 @@ diff backup - updates since last full (db-master host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2212,7 +2212,7 @@ incr backup - remove files - but won't affect manifest (db-master host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2356,7 +2356,7 @@ DETAIL: skip file removed by database [TEST_PATH]/db-master/db/base-2/base/base2
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2507,7 +2507,7 @@ full backup - update file (db-master host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2963,7 +2963,8 @@ info db stanza - normal output (db-master host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -2984,7 +2985,7 @@ diff backup - add file (db-master host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-004.log
+++ b/test/expect/backup-synthetic-004.log
@@ -170,7 +170,7 @@ full backup - create pg_stat link, pg_clog dir (db-master host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -445,7 +445,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1030,7 +1030,7 @@ incr backup - add tablespace 1 (db-master host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1343,7 +1343,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1491,7 +1491,7 @@ diff backup - cannot resume - new diff (db-master host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1633,7 +1633,7 @@ diff backup - cannot resume - disabled (db-master host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1865,7 +1865,7 @@ incr backup - add files and remove tablespace 2 (db-master host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2004,7 +2004,7 @@ incr backup - update files (db-master host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2148,7 +2148,7 @@ diff backup - updates since last full (db-master host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2288,7 +2288,7 @@ incr backup - remove files - but won't affect manifest (db-master host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2433,7 +2433,7 @@ DETAIL: skip file removed by database [TEST_PATH]/db-master/db/base-2/base/base2
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2585,7 +2585,7 @@ full backup - update file (db-master host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3042,7 +3042,8 @@ info db stanza - normal output (db-master host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -3063,7 +3064,7 @@ diff backup - add file (db-master host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-005.log
+++ b/test/expect/backup-synthetic-005.log
@@ -161,7 +161,7 @@ full backup - create pg_stat link, pg_clog dir (backup host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -788,7 +788,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1373,7 +1373,7 @@ incr backup - add tablespace 1 (backup host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1651,7 +1651,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1822,7 +1822,7 @@ diff backup - cannot resume - new diff (backup host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1985,7 +1985,7 @@ diff backup - cannot resume - disabled (backup host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2238,7 +2238,7 @@ incr backup - add files and remove tablespace 2 (backup host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2401,7 +2401,7 @@ incr backup - update files (backup host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2566,7 +2566,7 @@ diff backup - updates since last full (backup host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2727,7 +2727,7 @@ incr backup - remove files - but won't affect manifest (backup host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2893,7 +2893,7 @@ DETAIL: skip file removed by database db-master:[TEST_PATH]/db-master/db/base-2/
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3066,7 +3066,7 @@ full backup - update file (backup host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3544,7 +3544,8 @@ info db stanza - normal output (backup host)
 expire full=1 (backup host)
 > [CONTAINER-EXEC] backup [BACKREST-BIN] --config=[TEST_PATH]/backup/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -3565,7 +3566,7 @@ diff backup - add file (backup host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-006.log
+++ b/test/expect/backup-synthetic-006.log
@@ -161,7 +161,7 @@ full backup - create pg_stat link, pg_clog dir (backup host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -451,7 +451,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1053,7 +1053,7 @@ incr backup - add tablespace 1 (backup host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1376,7 +1376,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1548,7 +1548,7 @@ diff backup - cannot resume - new diff (backup host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1712,7 +1712,7 @@ diff backup - cannot resume - disabled (backup host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1966,7 +1966,7 @@ incr backup - add files and remove tablespace 2 (backup host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2127,7 +2127,7 @@ incr backup - update files (backup host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2293,7 +2293,7 @@ diff backup - updates since last full (backup host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2455,7 +2455,7 @@ incr backup - remove files - but won't affect manifest (backup host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2622,7 +2622,7 @@ DETAIL: skip file removed by database db-master:[TEST_PATH]/db-master/db/base-2/
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2796,7 +2796,7 @@ full backup - update file (backup host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3275,7 +3275,8 @@ info db stanza - normal output (backup host)
 expire full=1 (backup host)
 > [CONTAINER-EXEC] backup [BACKREST-BIN] --config=[TEST_PATH]/backup/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --retention-archive=1 --retention-full=1 --stanza=db
   INFO: expire full backup set: [BACKUP-FULL-2], [BACKUP-DIFF-2], [BACKUP-INCR-3], [BACKUP-INCR-4], [BACKUP-DIFF-3], [BACKUP-INCR-5], [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-DIFF-4]
   INFO: remove expired backup [BACKUP-INCR-5]
@@ -3296,7 +3297,7 @@ diff backup - add file (backup host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-007.log
+++ b/test/expect/backup-synthetic-007.log
@@ -161,7 +161,7 @@ full backup - create pg_stat link, pg_clog dir (backup host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -448,7 +448,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1024,7 +1024,7 @@ incr backup - add tablespace 1 (backup host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1300,7 +1300,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1469,7 +1469,7 @@ diff backup - cannot resume - new diff (backup host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1630,7 +1630,7 @@ diff backup - cannot resume - disabled (backup host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1881,7 +1881,7 @@ incr backup - add files and remove tablespace 2 (backup host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2039,7 +2039,7 @@ incr backup - update files (backup host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2202,7 +2202,7 @@ diff backup - updates since last full (backup host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2361,7 +2361,7 @@ incr backup - remove files - but won't affect manifest (backup host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2525,7 +2525,7 @@ DETAIL: skip file removed by database db-master:[TEST_PATH]/db-master/db/base-2/
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2696,7 +2696,7 @@ full backup - update file (backup host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3172,7 +3172,8 @@ info db stanza - normal output (backup host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --backup-host=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/spool/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/spool/log --repo-path=[TEST_PATH]/backup/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --backup-host=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/spool/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/spool/log --repo-path=[TEST_PATH]/backup/repo --retention-archive=1 --retention-full=1 --stanza=db
  ERROR: [147]: backup and expire commands must be run on the backup host
   INFO: expire stop
 
@@ -3186,7 +3187,7 @@ diff backup - add file (backup host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/expect/backup-synthetic-008.log
+++ b/test/expect/backup-synthetic-008.log
@@ -161,7 +161,7 @@ full backup - create pg_stat link, pg_clog dir (backup host)
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-1]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -449,7 +449,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/global/pg_control (8
  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1049,7 +1049,7 @@ incr backup - add tablespace 1 (backup host)
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1370,7 +1370,7 @@ DETAIL: checksum resumed file [TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH
  DEBUG:     BackupInfo->current=>: bTest = true
  DEBUG:     BackupInfo->current(): strBackup = [BACKUP-FULL-2]
  DEBUG:     BackupInfo->current=>: bTest = true
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
  DEBUG:     Common::Lock::lockRelease(): bFailOnNoLock = <true>
  DEBUG:     Common::Exit::exitSafe(): iExitCode = 0, oException = [undef], strSignal = [undef]
   INFO: expire stop
@@ -1540,7 +1540,7 @@ diff backup - cannot resume - new diff (backup host)
   INFO: new backup label = [BACKUP-DIFF-1]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1702,7 +1702,7 @@ diff backup - cannot resume - disabled (backup host)
   INFO: new backup label = [BACKUP-DIFF-2]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -1954,7 +1954,7 @@ incr backup - add files and remove tablespace 2 (backup host)
   INFO: new backup label = [BACKUP-INCR-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2113,7 +2113,7 @@ incr backup - update files (backup host)
   INFO: new backup label = [BACKUP-INCR-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2277,7 +2277,7 @@ diff backup - updates since last full (backup host)
   INFO: new backup label = [BACKUP-DIFF-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2437,7 +2437,7 @@ incr backup - remove files - but won't affect manifest (backup host)
   INFO: new backup label = [BACKUP-INCR-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2602,7 +2602,7 @@ DETAIL: skip file removed by database db-master:[TEST_PATH]/db-master/db/base-2/
   INFO: new backup label = [BACKUP-DIFF-4]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -2774,7 +2774,7 @@ full backup - update file (backup host)
   INFO: new backup label = [BACKUP-FULL-3]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf
@@ -3251,7 +3251,8 @@ info db stanza - normal output (backup host)
 expire full=1 (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --log-level-console=detail --retention-full=1  --stanza=db expire
 ------------------------------------------------------------------------------------------------------------------------------------
-  INFO: expire start: --backup-host=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/spool/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/spool/log --repo-path=[TEST_PATH]/backup/repo --retention-full=1 --stanza=db
+  INFO: option 'retention-archive' is not set for 'retention-archive-type=full' so it is being set to the value of option 'retention-full'
+  INFO: expire start: --backup-host=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/spool/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/spool/log --repo-path=[TEST_PATH]/backup/repo --retention-archive=1 --retention-full=1 --stanza=db
  ERROR: [147]: backup and expire commands must be run on the backup host
   INFO: expire stop
 
@@ -3265,7 +3266,7 @@ diff backup - add file (backup host)
   INFO: new backup label = [BACKUP-DIFF-5]
   INFO: backup stop
   INFO: expire start: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
-  INFO: archive retention type not set - archive logs will not be expired
+  INFO: option 'retention-archive' is not set - archive logs will not be expired
   INFO: expire stop
 
 + supplemental file: [TEST_PATH]/db-master/pgbackrest.conf

--- a/test/lib/pgBackRestTest/Backup/BackupTest.pm
+++ b/test/lib/pgBackRestTest/Backup/BackupTest.pm
@@ -667,6 +667,44 @@ sub backupTestRun
             $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_INCR, $lBaseTime += SECONDS_PER_DAY);
             $oExpireTest->process($strStanza, 1, 1, BACKUP_TYPE_INCR, 1, $strDescription);
 
+            #-----------------------------------------------------------------------------------------------------------------------
+            $strDescription = 'Expire diff treating full as diff';
+
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_DIFF, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->process($strStanza, 2, 1, BACKUP_TYPE_DIFF, 1, $strDescription);
+
+            #-----------------------------------------------------------------------------------------------------------------------
+            $strDescription = 'Expire diff with retention-archive with warning retention-diff not set';
+
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_DIFF, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_DIFF, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->process($strStanza, undef, undef, BACKUP_TYPE_DIFF, 1, $strDescription);
+
+            #-----------------------------------------------------------------------------------------------------------------------
+            $strDescription = 'Expire full with retention-archive with warning retention-full not set';
+
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->process($strStanza, undef, undef, BACKUP_TYPE_FULL, 1, $strDescription);
+
+
+            #-----------------------------------------------------------------------------------------------------------------------
+            $strDescription = 'Expire no archive with warning since retention-archive not set for INCR';
+
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_INCR, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->process($strStanza, 1, 1, BACKUP_TYPE_INCR, undef, $strDescription);
+
+            #-----------------------------------------------------------------------------------------------------------------------
+            $strDescription = 'Expire no archive with warning since neither retention-archive nor retention-diff is set';
+
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_FULL, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_DIFF, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->backupCreate($strStanza, BACKUP_TYPE_DIFF, $lBaseTime += SECONDS_PER_DAY);
+            $oExpireTest->process($strStanza, undef, undef, BACKUP_TYPE_DIFF, undef, $strDescription);
+
             testCleanup(\$oLogTest);
         }
     }

--- a/test/lib/pgBackRestTest/Backup/Common/ExpireCommonTest.pm
+++ b/test/lib/pgBackRestTest/Backup/Common/ExpireCommonTest.pm
@@ -391,10 +391,10 @@ sub process
         (
             __PACKAGE__ . '->process', \@_,
             {name => 'strStanza'},
-            {name => 'iExpireFull'},
-            {name => 'iExpireDiff'},
+            {name => 'iExpireFull', required => false},
+            {name => 'iExpireDiff', required => false},
             {name => 'strExpireArchiveType'},
-            {name => 'iExpireArchive'},
+            {name => 'iExpireArchive', required => false},
             {name => 'strDescription'}
         );
 
@@ -422,8 +422,15 @@ sub process
 
     if (defined($strExpireArchiveType))
     {
-        $strCommand .= ' --retention-archive-type=' . $strExpireArchiveType .
-                       ' --retention-archive=' . $iExpireArchive;
+        if (defined($iExpireArchive))
+        {
+            $strCommand .= ' --retention-archive-type=' . $strExpireArchiveType .
+                           ' --retention-archive=' . $iExpireArchive;
+        }
+        else
+        {
+            $strCommand .= ' --retention-archive-type=' . $strExpireArchiveType;
+        }
     }
 
     $strCommand .= ' expire';


### PR DESCRIPTION
Fixed an issue where retention-archive-type was being ignored if retention-archive was not set, resulting in archive logs not being expired with expiring backups.