### PR TITLE
suppress a warning on vagrant VM initialization

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -12,6 +12,8 @@ Vagrant.configure(2) do |config|
 
     # Provision the VM
     config.vm.provision "shell", inline: <<-SHELL
+        # Suppress "dpkg-reconfigure: unable to re-open stdin: No file or directory" warning
+        export DEBIAN_FRONTEND=noninteractive
         # Install Docker
         apt-get update
         apt-get install -y apt-transport-https ca-certificates


### PR DESCRIPTION
A minor thing to fix, but I figure every little bit helps.