### PR TITLE
Suppress compiler warnings while building the c library.

### DIFF
--- a/libc/pageChecksum.c
+++ b/libc/pageChecksum.c
@@ -218,7 +218,7 @@ pageChecksumBuffer(const char *szPageBuffer, uint32 uiBufferSize, uint32 uiBlock
     // Loop through all pages in the buffer
     for (uint32 uiIndex = 0; uiIndex < uiBufferSize / uiPageSize; uiIndex++)
     {
-        char *szPage = szPageBuffer + (uiIndex * uiPageSize);
+        const char *szPage = szPageBuffer + (uiIndex * uiPageSize);
 
         // Return false if the checksums do not match
         if (((PageHeader)szPage)->pd_checksum != pageChecksum(szPage, uiBlockNoStart + uiIndex, uiPageSize))


### PR DESCRIPTION
The former assignment discards the const qualifier of *szPageBuffer.
Declaring *szPage as const suppresses this warning.