### PR TITLE
Issue #306: Add Warning message for remap-tablespace in PostgreSQL < 9.2

### DIFF
--- a/lib/pgBackRest/Db.pm
+++ b/lib/pgBackRest/Db.pm
@@ -655,7 +655,7 @@ sub backupStart
         # generated later on.
         else
         {
-            &log(WARN, OPTION_STOP_AUTO . 'option is only available in PostgreSQL >= ' . PG_VERSION_93);
+            &log(WARN, OPTION_STOP_AUTO . ' option is only available in PostgreSQL >= ' . PG_VERSION_93);
         }
     }
 

--- a/lib/pgBackRest/Restore.pm
+++ b/lib/pgBackRest/Restore.pm
@@ -310,6 +310,14 @@ sub manifestLoad
         }
     }
 
+    # Issue a warning message when we remap tablespaces in postgre < 9.2
+    if ($oManifest->get(MANIFEST_SECTION_BACKUP_DB, MANIFEST_KEY_DB_VERSION) < PG_VERSION_92 &&
+       (optionTest(OPTION_TABLESPACE_MAP) || optionTest(OPTION_TABLESPACE_MAP_ALL)))
+    {
+        &log(WARN, "pg_tablespace.spclocation should be updated to reflect the new tablespace location in PostgreSQL < " .
+             PG_VERSION_92)
+    }
+
     # Alter manifest for remapped tablespaces
     if (defined($oTablespaceRemap))
     {


### PR DESCRIPTION
Hi, 

This PR adds a warning message for remap-tablespace and remap-tablespace-all in PostgreSQL < 9.2
I also added a missing space in a warning message for OPTION_STOP_AUTO.

Benoit.