### PR TITLE
Stop using temp/[stanza] for backups.

### DIFF
--- a/lib/pgBackRest/Backup/Backup.pm
+++ b/lib/pgBackRest/Backup/Backup.pm
@@ -72,6 +72,7 @@ sub fileNotInManifest
         $strOperation,
         $oFileLocal,
         $strPathType,
+        $strPath,
         $oManifest,
         $oAbortedManifest
     ) =
@@ -80,12 +81,13 @@ sub fileNotInManifest
             __PACKAGE__ . '->fileNotInManifest', \@_,
             {name => 'oFileLocal', trace => true},
             {name => 'strPathType', trace => true},
+            {name => 'strPath', trace => true},
             {name => 'oManifest', trace => true},
             {name => 'oAbortedManifest', trace => true}
         );
 
     # Build manifest for aborted temp path
-    my $hFile = $oFileLocal->manifest($strPathType);
+    my $hFile = $oFileLocal->manifest($strPathType, $strPath);
 
     # Get compress flag
     my $bCompressed = $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS);
@@ -183,6 +185,7 @@ sub tmpClean
     (
         $strOperation,
         $oFileLocal,
+        $strBackupLabel,
         $oManifest,
         $oAbortedManifest
     ) =
@@ -190,18 +193,19 @@ sub tmpClean
     (
         __PACKAGE__ . '->tmpClean', \@_,
         {name => 'oFileLocal', trace => true},
+        {name => 'strBackupLabel', trace => true},
         {name => 'oManifest', trace => true},
         {name => 'oAbortedManifest', trace => true}
     );
 
-    &log(DETAIL, 'clean backup temp path: ' . $oFileLocal->pathGet(PATH_BACKUP_TMP));
+    &log(DETAIL, 'clean resumed backup path: ' . $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, $strBackupLabel));
 
     # Get the list of files that should be deleted from temp
-    my @stryFile = $self->fileNotInManifest($oFileLocal, PATH_BACKUP_TMP, $oManifest, $oAbortedManifest);
+    my @stryFile = $self->fileNotInManifest($oFileLocal, PATH_BACKUP_CLUSTER, $strBackupLabel, $oManifest, $oAbortedManifest);
 
     foreach my $strFile (sort {$b cmp $a} @stryFile)
     {
-        my $strDelete = $oFileLocal->pathGet(PATH_BACKUP_TMP, $strFile);
+        my $strDelete = $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strFile}");
 
         # If a path then delete it, all the files should have already been deleted since we are going in reverse order
         if (!-X $strDelete && -d $strDelete)
@@ -245,6 +249,7 @@ sub processManifest
         $bCompress,
         $bHardLink,
         $oBackupManifest,
+        $strBackupLabel,
         $strLsnStart,
     ) =
         logDebugParam
@@ -258,6 +263,7 @@ sub processManifest
         {name => 'bCompress'},
         {name => 'bHardLink'},
         {name => 'oBackupManifest'},
+        {name => 'strBackupLabel'},
         {name => 'strLsnStart', required => false},
     );
 
@@ -288,7 +294,7 @@ sub processManifest
         # Create paths
         foreach my $strPath ($oBackupManifest->keys(MANIFEST_SECTION_TARGET_PATH))
         {
-            $oFileMaster->pathCreate(PATH_BACKUP_TMP, $strPath, undef, true);
+            $oFileMaster->pathCreate(PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strPath}", undef, true);
         }
 
         if (optionGet(OPTION_REPO_LINK))
@@ -298,7 +304,8 @@ sub processManifest
                 if ($oBackupManifest->isTargetTablespace($strTarget))
                 {
                     $oFileMaster->linkCreate(
-                        PATH_BACKUP_TMP, $strTarget, PATH_BACKUP_TMP, MANIFEST_TARGET_PGDATA . "/${strTarget}", false, true);
+                        PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strTarget}",
+                        PATH_BACKUP_CLUSTER, "${strBackupLabel}/" . MANIFEST_TARGET_PGDATA . "/${strTarget}", false, true);
                 }
             }
         }
@@ -329,7 +336,8 @@ sub processManifest
                 logDebugMisc($strOperation, "hardlink ${strRepoFile} to ${strReference}");
 
                 $oFileMaster->linkCreate(
-                    PATH_BACKUP_CLUSTER, "${strReference}/${strRepoFile}", PATH_BACKUP_TMP, "${strRepoFile}", true, false, true);
+                    PATH_BACKUP_CLUSTER, "${strReference}/${strRepoFile}",
+                    PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strRepoFile}", true, false, true);
             }
             # Else log the reference
             else
@@ -379,7 +387,7 @@ sub processManifest
             $iHostConfigIdx, $strQueueKey, $strRepoFile, OP_BACKUP_FILE,
             [$strDbFile, $strRepoFile, $lSize,
                 $oBackupManifest->get(MANIFEST_SECTION_TARGET_FILE, $strRepoFile, MANIFEST_SUBKEY_CHECKSUM, false),
-                optionGet(OPTION_CHECKSUM_PAGE) ? isChecksumPage($strRepoFile) : false, $bCompress,
+                optionGet(OPTION_CHECKSUM_PAGE) ? isChecksumPage($strRepoFile) : false, $strBackupLabel, $bCompress,
                 $oBackupManifest->numericGet(MANIFEST_SECTION_TARGET_FILE, $strRepoFile, MANIFEST_SUBKEY_TIMESTAMP, false),
                 $bIgnoreMissing, optionGet(OPTION_CHECKSUM_PAGE) && isChecksumPage($strRepoFile) ? $hStartLsnParam : undef]);
 
@@ -476,13 +484,6 @@ sub process
     # Load the backup.info
     my $oBackupInfo = new pgBackRest::Backup::Info($oFileLocal->pathGet(PATH_BACKUP_CLUSTER));
 
-    # Build backup tmp and config
-    my $strBackupTmpPath = $oFileLocal->pathGet(PATH_BACKUP_TMP);
-    my $strBackupConfFile = $oFileLocal->pathGet(PATH_BACKUP_TMP, 'backup.manifest');
-
-    # Declare the backup manifest
-    my $oBackupManifest = new pgBackRest::Manifest($strBackupConfFile, false);
-
     # Initialize database objects
     my $oDbMaster = undef;
     my $oDbStandby = undef;
@@ -565,6 +566,134 @@ sub process
             $strBackupLastPath = undef;
         }
     }
+
+    # Search cluster directory for an aborted backup
+    my $strBackupLabel;
+    my $oAbortedManifest;
+    my $strBackupPath;
+
+    foreach my $strAbortedBackup ($oFileLocal->list(
+        PATH_BACKUP_CLUSTER, undef, {strExpression => backupRegExpGet(true, true, true), strSortOrder => 'reverse'}))
+    {
+        # Abort backups have a copy of the manifest but no manifest
+        if ($oFileLocal->exists(PATH_BACKUP_CLUSTER, "${strAbortedBackup}/" . FILE_MANIFEST_COPY) &&
+            !$oFileLocal->exists(PATH_BACKUP_CLUSTER, "${strAbortedBackup}/" . FILE_MANIFEST))
+        {
+            my $bUsable;
+            my $strReason = "resume is disabled";
+            $strBackupPath = $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, $strAbortedBackup);
+
+            # Attempt to read the manifest file in the aborted backup to see if it can be used.  If any error at all occurs then the
+            # backup will be considered unusable and a resume will not be attempted.
+            if (optionGet(OPTION_RESUME))
+            {
+                $strReason = "unable to read ${strBackupPath}/" . FILE_MANIFEST;
+
+                eval
+                {
+                    # Load the aborted manifest
+                    $oAbortedManifest = new pgBackRest::Manifest("${strBackupPath}/" . FILE_MANIFEST_COPY);
+
+                    # Key and values that do not match
+                    my $strKey;
+                    my $strValueNew;
+                    my $strValueAborted;
+
+                    # Check version
+                    if ($oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION) ne BACKREST_VERSION)
+                    {
+                        $strKey =  INI_KEY_VERSION;
+                        $strValueNew = BACKREST_VERSION;
+                        $strValueAborted = $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION);
+                    }
+                    # Check format
+                    elsif ($oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT) ne BACKREST_FORMAT)
+                    {
+                        $strKey =  INI_KEY_FORMAT;
+                        $strValueNew = BACKREST_FORMAT;
+                        $strValueAborted = $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT);
+                    }
+                    # Check backup type
+                    elsif ($oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE) ne $strType)
+                    {
+                        $strKey =  MANIFEST_KEY_TYPE;
+                        $strValueNew = $strType;
+                        $strValueAborted = $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE);
+                    }
+                    # Check prior label
+                    elsif ($oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>') ne
+                           (defined($strBackupLastPath) ? $strBackupLastPath : '<undef>'))
+                    {
+                        $strKey =  MANIFEST_KEY_PRIOR;
+                        $strValueNew = defined($strBackupLastPath) ? $strBackupLastPath : '<undef>';
+                        $strValueAborted =
+                            $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>');
+                    }
+                    # Check compression
+                    elsif ($oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS) !=
+                           optionGet(OPTION_COMPRESS))
+                    {
+                        $strKey = MANIFEST_KEY_COMPRESS;
+                        $strValueNew = optionGet(OPTION_COMPRESS);
+                        $strValueAborted = $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS);
+                    }
+                    # Check hardlink
+                    elsif ($oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK) !=
+                           optionGet(OPTION_HARDLINK))
+                    {
+                        $strKey = MANIFEST_KEY_HARDLINK;
+                        $strValueNew = optionGet(OPTION_HARDLINK);
+                        $strValueAborted = $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK);
+                    }
+
+                    # If key is defined then something didn't match
+                    if (defined($strKey))
+                    {
+                        $strReason = "new ${strKey} '${strValueNew}' does not match aborted ${strKey} '${strValueAborted}'";
+                    }
+                    # Else the backup can be resumed
+                    else
+                    {
+                        $bUsable = true;
+                    }
+
+                    return true;
+                }
+                or do
+                {
+                    $bUsable = false;
+                }
+            }
+
+            # If the backup is usable then set the backup label
+            if ($bUsable)
+            {
+                $strBackupLabel = $strAbortedBackup;
+            }
+            else
+            {
+                &log(WARN,
+                    "aborted backup ${strAbortedBackup} exists, but cannot be resumed (${strReason})" .
+                    ' - will be dropped');
+                &log(TEST, TEST_BACKUP_NORESUME);
+
+                $oFileLocal->remove(PATH_BACKUP_CLUSTER, "${strAbortedBackup}/" . FILE_MANIFEST_COPY);
+                undef($oAbortedManifest);
+            }
+
+            last;
+        }
+    }
+
+    # If backup label is not defined then create the label and path.
+    if (!defined($strBackupLabel))
+    {
+        $strBackupLabel = backupLabel($oFileLocal, $strType, $strBackupLastPath, $lTimestampStart);
+        $strBackupPath = $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, $strBackupLabel);
+    }
+
+    # Declare the backup manifest
+    my $oBackupManifest = new pgBackRest::Manifest("$strBackupPath/" . FILE_MANIFEST, false);
 
     # Backup settings
     $oBackupManifest->set(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE, undef, $strType);
@@ -716,122 +845,20 @@ sub process
                             $hTablespaceMap, $hDatabaseMap);
     &log(TEST, TEST_MANIFEST_BUILD);
 
-    # Check if an aborted backup exists for this stanza
-    if (-e $strBackupTmpPath)
+    # If resuming from an aborted backup
+    if (defined($oAbortedManifest))
     {
-        my $bUsable;
-        my $strReason = "resume is disabled";
-        my $oAbortedManifest;
+        &log(WARN, "aborted backup ${strBackupLabel} of same type exists, will be cleaned to remove invalid files and resumed");
+        &log(TEST, TEST_BACKUP_RESUME);
 
-        # Attempt to read the manifest file in the aborted backup to see if it can be used.  If any error at all occurs then the
-        # backup will be considered unusable and a resume will not be attempted.
-        if (optionGet(OPTION_RESUME))
-        {
-            $strReason = "unable to read ${strBackupTmpPath}/backup.manifest";
-
-            eval
-            {
-                # Load the aborted manifest
-                $oAbortedManifest = new pgBackRest::Manifest("${strBackupTmpPath}/backup.manifest");
-
-                # Key and values that do not match
-                my $strKey;
-                my $strValueNew;
-                my $strValueAborted;
-
-                # Check version
-                if ($oBackupManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION) ne
-                    $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION))
-                {
-                    $strKey =  INI_KEY_VERSION;
-                    $strValueNew = $oBackupManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION);
-                    $strValueAborted = $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_VERSION);
-                }
-                # Check format
-                elsif ($oBackupManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT) ne
-                       $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT))
-                {
-                    $strKey =  INI_KEY_FORMAT;
-                    $strValueNew = $oBackupManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT);
-                    $strValueAborted = $oAbortedManifest->get(INI_SECTION_BACKREST, INI_KEY_FORMAT);
-                }
-                # Check backup type
-                elsif ($oBackupManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE) ne
-                       $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE))
-                {
-                    $strKey =  MANIFEST_KEY_TYPE;
-                    $strValueNew = $oBackupManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE);
-                    $strValueAborted = $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TYPE);
-                }
-                # Check prior label
-                elsif ($oBackupManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>') ne
-                       $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>'))
-                {
-                    $strKey =  MANIFEST_KEY_PRIOR;
-                    $strValueNew = $oBackupManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>');
-                    $strValueAborted = $oAbortedManifest->get(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_PRIOR, undef, false, '<undef>');
-                }
-                # Check compression
-                elsif ($oBackupManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS) ne
-                       $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS))
-                {
-                    $strKey = MANIFEST_KEY_COMPRESS;
-                    $strValueNew = $oBackupManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS);
-                    $strValueAborted = $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_COMPRESS);
-                }
-                # Check hardlink
-                elsif ($oBackupManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK) ne
-                       $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK))
-                {
-                    $strKey = MANIFEST_KEY_HARDLINK;
-                    $strValueNew = $oBackupManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK);
-                    $strValueAborted = $oAbortedManifest->boolGet(MANIFEST_SECTION_BACKUP_OPTION, MANIFEST_KEY_HARDLINK);
-                }
-
-                # If key is defined then something didn't match
-                if (defined($strKey))
-                {
-                    $strReason = "new ${strKey} '${strValueNew}' does not match aborted ${strKey} '${strValueAborted}'";
-                }
-                # Else the backup can be resumed
-                else
-                {
-                    $bUsable = true;
-                }
-
-                return true;
-            }
-            or do
-            {
-                $bUsable = false;
-            }
-        }
-
-        # If the aborted backup is usable then clean it
-        if ($bUsable)
-        {
-            &log(WARN, 'aborted backup of same type exists, will be cleaned to remove invalid files and resumed');
-            &log(TEST, TEST_BACKUP_RESUME);
-
-            # Clean the old backup tmp path
-            $self->tmpClean($oFileLocal, $oBackupManifest, $oAbortedManifest);
-        }
-        # Else remove it
-        else
-        {
-            &log(WARN, "aborted backup exists, but cannot be resumed (${strReason}) - will be dropped and recreated");
-            &log(TEST, TEST_BACKUP_NORESUME);
-
-            remove_tree($oFileLocal->pathGet(PATH_BACKUP_TMP))
-                or confess &log(ERROR, "unable to delete tmp path: ${strBackupTmpPath}");
-            $oFileLocal->pathCreate(PATH_BACKUP_TMP, undef, undef, false, true);
-        }
+        # Clean the old backup tmp path
+        $self->tmpClean($oFileLocal, $strBackupLabel, $oBackupManifest, $oAbortedManifest);
     }
-    # Else create the backup tmp path
+    # Else create the backup path
     else
     {
-        logDebugMisc($strOperation, "create temp backup path ${strBackupTmpPath}");
-        $oFileLocal->pathCreate(PATH_BACKUP_TMP, undef, undef, false, true);
+        logDebugMisc($strOperation, "create backup path ${strBackupPath}");
+        $oFileLocal->pathCreate(PATH_BACKUP_CLUSTER, $strBackupLabel, undef, false, true);
     }
 
     # Save the backup manifest
@@ -841,7 +868,7 @@ sub process
     my $lBackupSizeTotal =
         $self->processManifest(
             $oFileMaster, $strDbMasterPath, $strDbCopyPath, $strType, $strDbVersion, $bCompress, $bHardLink, $oBackupManifest,
-            $strLsnStart);
+            $strBackupLabel, $strLsnStart);
     &log(INFO, "${strType} backup size = " . fileSizeFormat($lBackupSizeTotal));
 
     # Master file object no longer needed
@@ -865,7 +892,7 @@ sub process
             # Only save the file if it has content
             if (defined($$oFileHash{$strFile}))
             {
-                my $strFileName = $oFileLocal->pathGet(PATH_BACKUP_TMP, $strFile);
+                my $strFileName = $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strFile}");
 
                 # Write content out to a file
                 fileStringWrite($strFileName, $$oFileHash{$strFile}, false);
@@ -927,9 +954,10 @@ sub process
 
                 my ($bCopyResult, $strCopyChecksum, $lCopySize) =
                     $oFileLocal->copy(PATH_BACKUP_ARCHIVE, "${strArchiveId}/${strArchiveFile}",
-                                 PATH_BACKUP_TMP, $strDestinationFile,
+                                 PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strDestinationFile}",
                                  $bArchiveCompressed, $bCompress,
-                                 undef, $lModificationTime, undef, true);
+                                 undef, $lModificationTime, undef, true,
+                                 undef, undef, undef, undef, undef, undef, false);
 
                 # Add the archive file to the manifest so it can be part of the restore and checked in validation
                 my $strPathLog = MANIFEST_TARGET_PGDATA . '/pg_xlog';
@@ -948,33 +976,28 @@ sub process
         }
     }
 
-    # Create label for new backup
-    my $lTimestampStop = time();
-    my $strBackupLabel = backupLabel($oFileLocal, $strType, $strBackupLastPath, $lTimestampStop);
-
     # Record timestamp stop in the config
+    my $lTimestampStop = time();
     $oBackupManifest->set(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_TIMESTAMP_STOP, undef, $lTimestampStop + 0);
     $oBackupManifest->set(MANIFEST_SECTION_BACKUP, MANIFEST_KEY_LABEL, undef, $strBackupLabel);
+
+    # Sync all paths in the backup cluster path
+    if (optionGet(OPTION_REPO_SYNC))
+    {
+        $oFileLocal->pathSync(PATH_BACKUP_CLUSTER, $strBackupLabel, true);
+    }
 
     # Final save of the backup manifest
     $oBackupManifest->save();
 
-    # Sync all paths in the backup tmp path
-    if (optionGet(OPTION_REPO_SYNC))
-    {
-        $oFileLocal->pathSync(PATH_BACKUP_TMP, undef, true);
-    }
-
     &log(INFO, "new backup label = ${strBackupLabel}");
 
     # Make a compressed copy of the manifest for history
-    $oFileLocal->copy(PATH_BACKUP_TMP, FILE_MANIFEST,
-                         PATH_BACKUP_TMP, FILE_MANIFEST . '.gz',
-                         undef, true);
-
-    # Move the backup tmp path to complete the backup
-    logDebugMisc($strOperation, "move ${strBackupTmpPath} to " . $oFileLocal->pathGet(PATH_BACKUP_CLUSTER, $strBackupLabel));
-    $oFileLocal->move(PATH_BACKUP_TMP, undef, PATH_BACKUP_CLUSTER, $strBackupLabel);
+    $oFileLocal->copy(
+        PATH_BACKUP_CLUSTER, "${strBackupLabel}/" . FILE_MANIFEST,
+        PATH_BACKUP_CLUSTER, "${strBackupLabel}/" . FILE_MANIFEST . '.gz',
+        undef, true,
+        undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, false);
 
     # Copy manifest to history
     $oFileLocal->move(PATH_BACKUP_CLUSTER, "${strBackupLabel}/" . FILE_MANIFEST . '.gz',

--- a/lib/pgBackRest/Backup/Common.pm
+++ b/lib/pgBackRest/Backup/Common.pm
@@ -127,14 +127,14 @@ sub backupLabelFormat
         $strOperation,
         $strType,
         $strBackupLabelLast,
-        $lTimestampStop
+        $lTimestampStart
     ) =
         logDebugParam
         (
             __PACKAGE__ . '::backupLabelFormat', \@_,
             {name => 'strType', trace => true},
             {name => 'strBackupLabelLast', required => false, trace => true},
-            {name => 'lTimestampStop', trace => true}
+            {name => 'lTimestampTart', trace => true}
         );
 
     # Full backup label
@@ -149,7 +149,7 @@ sub backupLabelFormat
         }
 
         # Format the timestamp and add the full indicator
-        $strBackupLabel = timestampFileFormat(undef, $lTimestampStop) . 'F';
+        $strBackupLabel = timestampFileFormat(undef, $lTimestampStart) . 'F';
     }
     # Else diff or incr label
     else
@@ -164,7 +164,7 @@ sub backupLabelFormat
         $strBackupLabel = substr($strBackupLabelLast, 0, 16);
 
         # Format the timestamp
-        $strBackupLabel .= '_' . timestampFileFormat(undef, $lTimestampStop);
+        $strBackupLabel .= '_' . timestampFileFormat(undef, $lTimestampStart);
 
         # Add the diff indicator
         if ($strType eq BACKUP_TYPE_DIFF)
@@ -202,7 +202,7 @@ sub backupLabel
         $oFile,
         $strType,
         $strBackupLabelLast,
-        $lTimestampStop
+        $lTimestampStart
     ) =
         logDebugParam
         (
@@ -210,11 +210,11 @@ sub backupLabel
             {name => 'oFile', trace => true},
             {name => 'strType', trace => true},
             {name => 'strBackupLabelLast', required => false, trace => true},
-            {name => 'lTimestampStop', trace => true}
+            {name => 'lTimestampStart', trace => true}
         );
 
     # Create backup label
-    my $strBackupLabel = backupLabelFormat($strType, $strBackupLabelLast, $lTimestampStop);
+    my $strBackupLabel = backupLabelFormat($strType, $strBackupLabelLast, $lTimestampStart);
 
     # Make sure that the timestamp has not already been used by a prior backup.  This is unlikely for online backups since there is
     # already a wait after the manifest is built but it's still possible if the remote and local systems don't have synchronized
@@ -222,11 +222,11 @@ sub backupLabel
     # be skipped by dealing with any backup label collisions here.
     if (fileList($oFile->pathGet(PATH_BACKUP_CLUSTER),
                  {strExpression =>
-                    ($strType eq BACKUP_TYPE_FULL ? '^' : '_') . timestampFileFormat(undef, $lTimestampStop) .
+                    ($strType eq BACKUP_TYPE_FULL ? '^' : '_') . timestampFileFormat(undef, $lTimestampStart) .
                     ($strType eq BACKUP_TYPE_FULL ? 'F' : '(D|I)$')}) ||
-        fileList($oFile->pathGet(PATH_BACKUP_CLUSTER, PATH_BACKUP_HISTORY . '/' . timestampFormat('%4d', $lTimestampStop)),
+        fileList($oFile->pathGet(PATH_BACKUP_CLUSTER, PATH_BACKUP_HISTORY . '/' . timestampFormat('%4d', $lTimestampStart)),
                  {strExpression =>
-                    ($strType eq BACKUP_TYPE_FULL ? '^' : '_') . timestampFileFormat(undef, $lTimestampStop) .
+                    ($strType eq BACKUP_TYPE_FULL ? '^' : '_') . timestampFileFormat(undef, $lTimestampStart) .
                     ($strType eq BACKUP_TYPE_FULL ? 'F' : '(D|I)\.manifest\.' . $oFile->{strCompressExtension}),
                     bIgnoreMissing => true}))
     {

--- a/lib/pgBackRest/Backup/File.pm
+++ b/lib/pgBackRest/Backup/File.pm
@@ -168,6 +168,7 @@ sub backupFile
         $lSizeFile,                                 # File size
         $strChecksum,                               # File checksum to be checked
         $bChecksumPage,                             # Should page checksums be calculated?
+        $strBackupLabel,                            # Label of current backup
         $bDestinationCompress,                      # Compress destination file
         $lModificationTime,                         # File modification time
         $bIgnoreMissing,                            # Is it OK if the file is missing?
@@ -182,6 +183,7 @@ sub backupFile
             {name => 'lSizeFile', trace => true},
             {name => 'strChecksum', required => false, trace => true},
             {name => 'bChecksumPage', trace => true},
+            {name => 'strBackupLabel', trace => true},
             {name => 'bDestinationCompress', trace => true},
             {name => 'lModificationTime', trace => true},
             {name => 'bIgnoreMissing', default => true, trace => true},
@@ -203,7 +205,7 @@ sub backupFile
     if (defined($strChecksum))
     {
         ($strCopyChecksum, $lCopySize) =
-            $oFile->hashSize(PATH_BACKUP_TMP, $strFileOp, $bDestinationCompress);
+            $oFile->hashSize(PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strFileOp}", $bDestinationCompress);
 
         $bCopy = !($strCopyChecksum eq $strChecksum && $lCopySize == $lSizeFile);
 
@@ -228,7 +230,7 @@ sub backupFile
         # Copy the file from the database to the backup (will return false if the source file is missing)
         (my $bCopyResult, $strCopyChecksum, $lCopySize, $rExtra) = $oFile->copy(
             PATH_DB_ABSOLUTE, $strDbFile,
-            PATH_BACKUP_TMP, $strFileOp,
+            PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strFileOp}",
             false,                                                  # Source is not compressed since it is the db directory
             $bDestinationCompress,                                  # Destination should be compressed based on backup settings
             $bIgnoreMissing,                                        # Ignore missing files
@@ -252,7 +254,7 @@ sub backupFile
     # compression may affect the actual repo size and this cannot be calculated in stream.
     if ($iCopyResult == BACKUP_FILE_COPY || $iCopyResult == BACKUP_FILE_RECOPY || $iCopyResult == BACKUP_FILE_CHECKSUM)
     {
-        $lRepoSize = (fileStat($oFile->pathGet(PATH_BACKUP_TMP, $strFileOp)))->size;
+        $lRepoSize = (fileStat($oFile->pathGet(PATH_BACKUP_CLUSTER, "${strBackupLabel}/${strFileOp}")))->size;
     }
 
     # Return from function and log return values if any

--- a/lib/pgBackRest/File.pm
+++ b/lib/pgBackRest/File.pm
@@ -40,8 +40,6 @@ use constant PATH_BACKUP_ABSOLUTE                                   => 'backup:a
     push @EXPORT, qw(PATH_BACKUP_ABSOLUTE);
 use constant PATH_BACKUP_CLUSTER                                    => 'backup:cluster';
     push @EXPORT, qw(PATH_BACKUP_CLUSTER);
-use constant PATH_BACKUP_TMP                                        => 'backup:tmp';
-    push @EXPORT, qw(PATH_BACKUP_TMP);
 use constant PATH_BACKUP_ARCHIVE                                    => 'backup:archive';
     push @EXPORT, qw(PATH_BACKUP_ARCHIVE);
 use constant PATH_BACKUP_ARCHIVE_OUT                                => 'backup:archive:out';
@@ -159,7 +157,7 @@ sub pathGet
     my
     (
         $strOperation,
-        $strType,                                   # Base type of the path to get (PATH_DB_ABSOLUTE, PATH_BACKUP_TMP, etc)
+        $strType,                                   # Base type of the path to get (PATH_DB_ABSOLUTE, PATH_BACKUP_CLUSTER, etc)
         $strFile,                                   # File to append to the base path (can include a path as well)
         $bTemp                                      # Return the temp file for this path type - only some types have temp files
     ) =
@@ -180,8 +178,8 @@ sub pathGet
     # Make sure a temp file is valid for this type and file
     if ($bTemp)
     {
-        # Only allow temp files for PATH_BACKUP_ARCHIVE, PATH_BACKUP_ARCHIVE_OUT, PATH_BACKUP_TMP and any absolute path
-        if (!($strType eq PATH_BACKUP_ARCHIVE || $strType eq PATH_BACKUP_ARCHIVE_OUT || $strType eq PATH_BACKUP_TMP || $bAbsolute))
+        # Only allow temp files for PATH_BACKUP_ARCHIVE, PATH_BACKUP_ARCHIVE_OUT, and any absolute path
+        if (!($strType eq PATH_BACKUP_ARCHIVE || $strType eq PATH_BACKUP_ARCHIVE_OUT || $bAbsolute))
         {
             confess &log(ASSERT, "temp file not supported for path type '${strType}'");
         }
@@ -225,13 +223,8 @@ sub pathGet
             confess &log(ASSERT, 'strStanza not defined');
         }
 
-        # Get the backup tmp path
-        if ($strType eq PATH_BACKUP_TMP)
-        {
-            $strPath .= "/temp/$self->{strStanza}.tmp";
-        }
-        # Else get archive paths
-        elsif ($strType eq PATH_BACKUP_ARCHIVE_OUT || $strType eq PATH_BACKUP_ARCHIVE)
+        # Get archive paths
+        if ($strType eq PATH_BACKUP_ARCHIVE_OUT || $strType eq PATH_BACKUP_ARCHIVE)
         {
             $strPath .= "/archive/$self->{strStanza}";
 

--- a/test/expect/full-synthetic-001.log
+++ b/test/expect/full-synthetic-001.log
@@ -97,6 +97,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -107,41 +111,41 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_dynshmem, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_notify, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_replslot, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_serial, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_snapshots, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat_tmp, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_subtrans, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_dynshmem, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_notify, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_replslot, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_serial, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_snapshots, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat_tmp, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_subtrans, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -206,9 +210,7 @@ P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -414,6 +416,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-1]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-1]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -424,9 +434,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00   TEST:         PgBaCkReStTeSt-BACKUP-START-PgBaCkReStTeSt
 P00  DEBUG:     Common::Exit::exitSafe(): iExitCode = 63, oException = [undef], strSignal = TERM
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = false, iRemoteIdx = [undef], strRemoteType = [undef]
@@ -539,6 +549,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -553,6 +565,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -564,46 +584,46 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp, pg_data/PG_VERSION)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/file.tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/file.tmp
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_dynshmem, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_notify, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_replslot, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_serial, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_snapshots, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat_tmp, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_subtrans, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_dynshmem, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_notify, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_replslot, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_serial, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_snapshots, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat_tmp, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_subtrans, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -653,29 +673,27 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 163878
 P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_dynshmem, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_notify, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_replslot, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_serial, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_snapshots, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat_tmp, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_subtrans, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_dynshmem, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_notify, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_replslot, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_serial, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_snapshots, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat_tmp, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_subtrans, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1425,6 +1443,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1435,9 +1461,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1449,8 +1475,8 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
@@ -1476,18 +1502,16 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 18
 P00   INFO: incr backup size = 18B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1673,6 +1697,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1696,6 +1722,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1712,12 +1746,12 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1729,11 +1763,11 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
@@ -1765,21 +1799,19 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 29
 P00   INFO: incr backup size = 29B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1964,11 +1996,11 @@ diff backup - cannot resume - new diff (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --repo-path=[TEST_PATH]/db-master/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1979,6 +2011,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -2127,11 +2160,11 @@ diff backup - cannot resume - disabled / no repo link (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/db-master/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -2142,6 +2175,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-002.log
+++ b/test/expect/full-synthetic-002.log
@@ -97,6 +97,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -107,34 +111,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -199,9 +203,7 @@ P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -368,6 +370,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -382,6 +386,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -393,39 +405,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp, pg_data/PG_VERSION)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/file.tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/file.tmp
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -475,22 +487,20 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 163878
 P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1021,6 +1031,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1031,53 +1049,53 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/pg_tblspc/1, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1098,26 +1116,24 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 18
 P00   INFO: incr backup size = 18B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1297,6 +1313,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1320,6 +1338,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1333,75 +1359,75 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (pg_data/PG_VERSION, pg_data/base/1/12000, pg_data/base/1/PG_VERSION, pg_data/base/16384/17000, pg_data/base/16384/PG_VERSION, pg_data/base/32768/33000, pg_data/base/32768/33000.32767, pg_data/base/32768/33001, pg_data/base/32768/PG_VERSION, pg_data/global/pg_control, pg_data/pg_stat/global.stat, pg_data/pg_tblspc/1, pg_data/postgresql.conf)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/postgresql.conf
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/pg_tblspc/1
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/pg_stat/global.stat
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/global/pg_control
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33001
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33000.32767
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/16384/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/16384/17000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/1/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/1/12000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/postgresql.conf
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_tblspc/1
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_stat/global.stat
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/global/pg_control
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33001
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.32767
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/17000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/12000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/2, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/2, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/1, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/2, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/2, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1429,29 +1455,27 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 29
 P00   INFO: incr backup size = 29B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1626,11 +1650,11 @@ diff backup - cannot resume - new diff (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --hardlink --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --repo-path=[TEST_PATH]/db-master/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1641,6 +1665,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1783,11 +1808,11 @@ diff backup - cannot resume - disabled / no repo link (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --hardlink --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/db-master/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1798,6 +1823,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-003.log
+++ b/test/expect/full-synthetic-003.log
@@ -97,6 +97,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -107,34 +111,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -199,9 +203,7 @@ P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -366,6 +368,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -380,6 +384,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -391,39 +403,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp.gz, pg_data/PG_VERSION.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/file.tmp.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/file.tmp.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -473,22 +485,20 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 163878
 P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1017,6 +1027,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1027,9 +1045,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1041,8 +1059,8 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
@@ -1068,18 +1086,16 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 18
 P00   INFO: incr backup size = 18B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1257,6 +1273,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1280,6 +1298,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1293,12 +1319,12 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1310,11 +1336,11 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
@@ -1346,21 +1372,19 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 29
 P00   INFO: incr backup size = 29B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1533,11 +1557,11 @@ diff backup - cannot resume - new diff (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --repo-path=[TEST_PATH]/db-master/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1548,6 +1572,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1688,11 +1713,11 @@ diff backup - cannot resume - disabled / no repo link (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/db-master/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1703,6 +1728,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-004.log
+++ b/test/expect/full-synthetic-004.log
@@ -97,6 +97,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -107,34 +111,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -199,9 +203,7 @@ P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -367,6 +369,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -381,6 +385,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -392,39 +404,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp.gz, pg_data/PG_VERSION.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/file.tmp.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]/file.tmp.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -474,22 +486,20 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 163878
 P00   INFO: full backup size = 160KB
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1019,6 +1029,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1029,53 +1047,53 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/pg_tblspc/1, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1096,26 +1114,24 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 18
 P00   INFO: incr backup size = 18B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1294,6 +1310,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1317,6 +1335,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1330,75 +1356,75 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/db-master/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (pg_data/PG_VERSION.gz, pg_data/base/1/12000.gz, pg_data/base/1/PG_VERSION.gz, pg_data/base/16384/17000.gz, pg_data/base/16384/PG_VERSION.gz, pg_data/base/32768/33000.32767.gz, pg_data/base/32768/33000.gz, pg_data/base/32768/33001.gz, pg_data/base/32768/PG_VERSION.gz, pg_data/global/pg_control.gz, pg_data/pg_stat/global.stat.gz, pg_data/pg_tblspc/1, pg_data/postgresql.conf.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/postgresql.conf.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/pg_tblspc/1
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/pg_stat/global.stat.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/global/pg_control.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33001.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/32768/33000.32767.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/16384/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/16384/17000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/1/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/base/1/12000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/postgresql.conf.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_tblspc/1
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_stat/global.stat.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/global/pg_control.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33001.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.32767.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/17000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/12000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create local protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/2, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/2, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/1, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/2, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/2, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/db-master/pgbackrest.conf --host-id=1 --lock-path=[TEST_PATH]/db-master/repo/lock --log-path=[TEST_PATH]/db-master/repo/log --process=1 --repo-path=[TEST_PATH]/db-master/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1426,29 +1452,27 @@ P00  DEBUG:     Backup::Backup->processManifest=>: lSizeTotal = 29
 P00   INFO: incr backup size = 29B
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteIdx = [undef], strRemoteType = [undef]
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/db-master/repo/temp/db.tmp to [TEST_PATH]/db-master/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1622,11 +1646,11 @@ diff backup - cannot resume - new diff (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --hardlink --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --repo-path=[TEST_PATH]/db-master/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1637,6 +1661,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1778,11 +1803,11 @@ diff backup - cannot resume - disabled / no repo link (db-master host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --db-path=[TEST_PATH]/db-master/db/base --hardlink --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/db-master/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1793,6 +1818,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/db-master/pgbackrest.conf --lock-path=[TEST_PATH]/db-master/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/db-master/repo/log --repo-path=[TEST_PATH]/db-master/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-005.log
+++ b/test/expect/full-synthetic-005.log
@@ -99,6 +99,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -109,34 +113,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <1>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-timeout=1 --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --protocol-timeout=2 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 2, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-timeout=1 --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --protocol-timeout=2 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -203,9 +207,7 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemot
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -409,6 +411,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-1])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-1]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-1]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -419,9 +429,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00   TEST:         PgBaCkReStTeSt-BACKUP-START-PgBaCkReStTeSt
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
@@ -464,6 +474,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-1]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create (cached) remote protocol
@@ -478,6 +490,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2], [BACKUP-FULL-1])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -488,9 +508,11 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00   TEST:         PgBaCkReStTeSt-BACKUP-START-PgBaCkReStTeSt
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
@@ -521,6 +543,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-1]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create (cached) remote protocol
@@ -582,6 +606,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-1]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create (cached) remote protocol
@@ -666,6 +692,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-1]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: create (cached) remote protocol
@@ -680,6 +708,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2], [BACKUP-FULL-1])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -690,11 +726,11 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00   TEST:         PgBaCkReStTeSt-BACKUP-START-PgBaCkReStTeSt
 P00  DEBUG:     Common::Exit::exitSafe(): iExitCode = 63, oException = [undef], strSignal = TERM
 P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = false, iRemoteIdx = [undef], strRemoteType = [undef]
@@ -748,6 +784,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -764,6 +802,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -775,39 +821,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp, pg_data/PG_VERSION)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/file.tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/file.tmp
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -859,22 +905,20 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1441,6 +1485,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1451,9 +1503,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1465,8 +1517,8 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
@@ -1494,18 +1546,16 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1706,6 +1756,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1731,6 +1783,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1747,12 +1807,12 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1764,11 +1824,11 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
@@ -1802,21 +1862,19 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -2016,11 +2074,11 @@ diff backup - cannot resume - new diff (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --repo-path=[TEST_PATH]/backup/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -2031,6 +2089,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -2194,11 +2253,11 @@ diff backup - cannot resume - disabled / no repo link (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/backup/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -2209,6 +2268,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-006.log
+++ b/test/expect/full-synthetic-006.log
@@ -99,6 +99,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -109,34 +113,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -203,9 +207,7 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemot
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -394,6 +396,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -410,6 +414,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -421,39 +433,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp, pg_data/PG_VERSION)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/file.tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/file.tmp
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -505,22 +517,20 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1079,6 +1089,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1089,53 +1107,53 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/pg_tblspc/1, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1158,26 +1176,24 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1379,6 +1395,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1404,6 +1422,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1417,75 +1443,75 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (pg_data/PG_VERSION, pg_data/base/1/12000, pg_data/base/1/PG_VERSION, pg_data/base/16384/17000, pg_data/base/16384/PG_VERSION, pg_data/base/32768/33000, pg_data/base/32768/33000.32767, pg_data/base/32768/33001, pg_data/base/32768/PG_VERSION, pg_data/global/pg_control, pg_data/pg_stat/global.stat, pg_data/pg_tblspc/1, pg_data/postgresql.conf)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/postgresql.conf
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/pg_tblspc/1
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/pg_stat/global.stat
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/global/pg_control
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33001
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33000.32767
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/16384/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/16384/17000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/1/PG_VERSION
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/1/12000
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/postgresql.conf
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_tblspc/1
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_stat/global.stat
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/global/pg_control
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33001
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.32767
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/17000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/PG_VERSION
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/12000
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/PG_VERSION
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = false, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/2, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/2, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/1, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/2, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/2, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 0, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1515,29 +1541,27 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1734,11 +1758,11 @@ diff backup - cannot resume - new diff (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --hardlink --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --repo-path=[TEST_PATH]/backup/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1749,6 +1773,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1913,11 +1938,11 @@ diff backup - cannot resume - disabled / no repo link (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --hardlink --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/backup/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1928,6 +1953,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --no-compress --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-007.log
+++ b/test/expect/full-synthetic-007.log
@@ -99,6 +99,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -109,34 +113,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -203,9 +207,7 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemot
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -391,6 +393,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -407,6 +411,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -418,39 +430,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp.gz, pg_data/PG_VERSION.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/file.tmp.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/file.tmp.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -502,22 +514,20 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1073,6 +1083,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1083,9 +1101,9 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1097,8 +1115,8 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
@@ -1126,18 +1144,16 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1336,6 +1352,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1361,6 +1379,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1374,12 +1400,12 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = ()
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = false, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
@@ -1391,11 +1417,11 @@ P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/17
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/global/pg_control to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Backup->processManifest: reference pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
@@ -1429,21 +1455,19 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1637,11 +1661,11 @@ diff backup - cannot resume - new diff (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --repo-path=[TEST_PATH]/backup/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1652,6 +1676,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1813,11 +1838,11 @@ diff backup - cannot resume - disabled / no repo link (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/backup/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1828,6 +1853,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/expect/full-synthetic-008.log
+++ b/test/expect/full-synthetic-008.log
@@ -99,6 +99,10 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ()
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = [undef], hDatabaseMap = [undef], hTablespaceMap = [undef], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = [undef], strParentPath = [undef], strPath = [TEST_PATH]/db-master/db/base
@@ -109,34 +113,34 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-FULL-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, [undef], 1, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 16384, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --buffer-size=16384 --cmd-ssh=/usr/bin/ssh --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -203,9 +207,7 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemot
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
 P00   INFO: new backup label = [BACKUP-FULL-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = false, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = false
@@ -392,6 +394,8 @@ P00  DEBUG:     Backup::Info->new(): bRequired = <true>, bValidate = <true>, str
 P00  DEBUG:     Backup::Info->reconstruct(): bRequired = <true>, bSave = <true>, iCatalogVersion = [undef], iControlVersion = [undef], strDbVersion = [undef], ullDbSysId = [undef]
 P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-FULL-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-FULL-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -408,6 +412,14 @@ P00  DEBUG:     File->new(): oProtocol = [object], strDefaultFileMode = <0640>, 
 P00  DEBUG:     Db->info=>: iDbCatalogVersion = 201409291, iDbControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check(): bRequired = <true>, iCatalogVersion = 201409291, iControlVersion = 942, strDbVersion = 9.4, ullDbSysId = 6353949018581704918
 P00  DEBUG:     Backup::Info->check=>: iDbHistoryId = 1
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = true
 P00   WARN: --no-online passed and postmaster.pid exists but --force was passed so backup will continue though it looks like the postmaster is running and the backup will probably not be consistent
@@ -419,39 +431,39 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_stat, st
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = false, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [undef], strLevel = pg_data/postgresql.conf, strParentPath = [TEST_PATH]/db-master/db/base, strPath = ../pg_config/postgresql.conf
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/pg_config/postgresql.conf, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-FULL-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (file.tmp.gz, pg_data/PG_VERSION.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/file.tmp.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]/file.tmp.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-FULL-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = full
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33001, pg_data/base/32768/33001, 65536, 6bf316f11d28c28914ea9be92c00de9bea6d9a6b, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33001, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000.32767, pg_data/base/32768/33000.32767, 32768, 21e2c7c1a326682c07053b7d6a5a40dbd49c2ec5, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000.32767, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/33000, pg_data/base/32768/33000, 32768, 4a383e4fb8b5cd2a4e8fab91ef63dce48e532a2f, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/32768/33000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/17000, pg_data/base/16384/17000, 16384, e0101dd8ffb910c9c202ca35b5f828bcb9697bed, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/16384/17000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/global/pg_control, pg_data/global/pg_control, 8192, 89373d9f2973502940de06bc5212489df3f8a912, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 0, [undef]), strKey = pg_data/global/pg_control, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/12000, pg_data/base/1/12000, 8192, 22c98d248ff548311eda88559e4a8405ed77c003, 1, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_data/base/1/12000, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/postgresql.conf, pg_data/postgresql.conf, 21, 6721d92c9fcdf4248acff1f9a1377127d9064807, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/postgresql.conf, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_stat/global.stat, pg_data/pg_stat/global.stat, 5, e350d5ce0153f3e22d5db21cf2a4eff00f3ee877, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-2], 1, [undef]), strKey = pg_data/pg_stat/global.stat, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/32768/PG_VERSION, pg_data/base/32768/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/32768/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/16384/PG_VERSION, pg_data/base/16384/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/16384/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/base/1/PG_VERSION, pg_data/base/1/PG_VERSION, 3, 184473f470864e067ee3a22e64b47b0a1c356f29, 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/base/1/PG_VERSION, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/PG_VERSION, pg_data/PG_VERSION, 3, [undef], 0, [BACKUP-FULL-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/PG_VERSION, strOp = backupFile, strQueue = pg_data
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -503,22 +515,20 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-FULL-2]/pg_data/pg_tblspc, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-FULL-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-FULL-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-FULL-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-FULL-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-FULL-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-FULL-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1075,6 +1085,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-FULL-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1085,53 +1103,53 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/base, strPa
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/1, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts1
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts1, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00  DEBUG:     Backup::Backup->process: create temp backup path [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->process: create backup path [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
+P00  DEBUG:     File->pathCreate(): bCreateParents = true, bIgnoreExists = false, strMode = <0750>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-1], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/pg_tblspc/1, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, [undef], 0, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, [undef], 1, [BACKUP-INCR-1], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-1]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1154,26 +1172,24 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-1]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-1]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-1]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-1], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-1]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-1]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-1].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-1]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1373,6 +1389,8 @@ P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferenti
 P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
 P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->current=>: bTest = true
+P00  DEBUG:     Backup::Info->current(): strBackup = [BACKUP-INCR-2]
+P00  DEBUG:     Backup::Info->current=>: bTest = false
 P00   WARN: backup [BACKUP-INCR-1] missing in repository removed from backup.info
 P00  DEBUG:     Backup::Info->delete(): strBackupLabel = [BACKUP-INCR-1]
 P00  DEBUG:     Db->new(): iRemoteIdx = 1
@@ -1398,6 +1416,14 @@ P00  DEBUG:     Backup::Info->last=>: strBackup = [BACKUP-FULL-2]
 P00  DEBUG:     Backup::Info->dbHistoryList=>: hDbHash = [hash]
 P00  DEBUG:     Backup::Info->confirmDb=>: bConfirmDb = true
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
+P00  DEBUG:     Backup::Common::backupRegExpGet(): bAnchor = <true>, bDifferential = true, bFull = true, bIncremental = true
+P00  DEBUG:     Backup::Common::backupRegExpGet=>: strRegExp = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$
+P00  DEBUG:     File->list(): bIgnoreMissing = <false>, strExpression = ^[0-9]{8}\-[0-9]{6}F(\_[0-9]{8}\-[0-9]{6}(D|I)){0,1}$, strPath = [undef], strPathType = backup:cluster, strSortOrder = reverse
+P00  DEBUG:     File->list=>: stryFileList = ([BACKUP-INCR-2], [BACKUP-FULL-2])
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest.copy, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = true
+P00  DEBUG:     File->exists(): strPath = [BACKUP-INCR-2]/backup.manifest, strPathType = backup:cluster
+P00  DEBUG:     File->exists=>: bExists = false
 P00  DEBUG:     File->exists(): strPath = [TEST_PATH]/db-master/db/base/postmaster.pid, strPathType = db:absolute
 P00  DEBUG:     File->exists=>: bExists = false
 P00   WARN: incr backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
@@ -1411,75 +1437,75 @@ P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/
 P00  DEBUG:     Manifest->build(): bOnline = false, bTablespace = true, hDatabaseMap = [undef], hTablespaceMap = [hash], oFile = [object], oLastManifest = [undef], strDbVersion = 9.4, strFilter = [TS_PATH-1], strLevel = pg_tblspc/2, strParentPath = [TEST_PATH]/db-master/db/base/pg_tblspc/pg_tblspc, strPath = [TEST_PATH]/db-master/db/tablespace/ts2
 P00  DEBUG:     File->manifest(): strPath = [TEST_PATH]/db-master/db/tablespace/ts2, strPathType = db:absolute
 P00  DEBUG:     File->wait(): bWait = false, strPathType = db:absolute
-P00   WARN: aborted backup of same type exists, will be cleaned to remove invalid files and resumed
+P00   WARN: aborted backup [BACKUP-INCR-2] of same type exists, will be cleaned to remove invalid files and resumed
 P00   TEST:         PgBaCkReStTeSt-BACKUP-RESUME-PgBaCkReStTeSt
-P00 DETAIL: clean backup temp path: [TEST_PATH]/backup/repo/temp/db.tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
+P00 DETAIL: clean resumed backup path: [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
 P00  DEBUG:     Backup::Backup->fileNotInManifest=>: stryFile = (pg_data/PG_VERSION.gz, pg_data/base/1/12000.gz, pg_data/base/1/PG_VERSION.gz, pg_data/base/16384/17000.gz, pg_data/base/16384/PG_VERSION.gz, pg_data/base/32768/33000.32767.gz, pg_data/base/32768/33000.gz, pg_data/base/32768/33001.gz, pg_data/base/32768/PG_VERSION.gz, pg_data/global/pg_control.gz, pg_data/pg_stat/global.stat.gz, pg_data/pg_tblspc/1, pg_data/postgresql.conf.gz)
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/postgresql.conf.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/pg_tblspc/1
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/pg_stat/global.stat.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/global/pg_control.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33001.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/32768/33000.32767.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/16384/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/16384/17000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/1/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/base/1/12000.gz
-P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/temp/db.tmp/pg_data/PG_VERSION.gz
-P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/postgresql.conf.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_tblspc/1
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/pg_stat/global.stat.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/global/pg_control.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33001.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/32768/33000.32767.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/16384/17000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/base/1/12000.gz
+P00  DEBUG:     Backup::Backup->tmpClean: remove file [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]/pg_data/PG_VERSION.gz
+P00  DEBUG:     Backup::Backup->processManifest(): bCompress = true, bHardLink = true, oBackupManifest = [object], oFileMaster = [object], strBackupLabel = [BACKUP-INCR-2], strDbCopyPath = [TEST_PATH]/db-master/db/base, strDbMasterPath = [TEST_PATH]/db-master/db/base, strDbVersion = 9.4, strLsnStart = [undef], strType = incr
 P00  DEBUG:     Protocol::Helper::protocolGet(): bCache = <true>, iProcessIdx = [undef], iRemoteIdx = 1, strBackRestBin = [undef], strCommand = <backup>, strRemoteType = db
 P00  DEBUG:     Protocol::Helper::protocolGet: found cached protocol
 P00  DEBUG:     Protocol::Local::Process->new(): bConfessError = <true>, iSelectTimeout = <915>, strBackRestBin = <[BACKREST-BIN]>, strHostType = db
 P00  DEBUG:     Protocol::Local::Process->hostAdd(): iHostConfigIdx = 1, iProcessMax = 1
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/1, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/1, strSourcePathType = backup:tmp
-P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = pg_data/pg_tblspc/2, strDestinationPathType = backup:tmp, strSourceFile = pg_tblspc/2, strSourcePathType = backup:tmp
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathCreate(): bCreateParents = <false>, bIgnoreExists = true, strMode = <0750>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/1, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/1, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = false, bPathCreate = <true>, bRelative = true, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_tblspc/2, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/pg_tblspc/2, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33001, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33001, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33001, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000.32767, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000.32767, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000.32767, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/33000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/33000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/33000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/17000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/17000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/17000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/17000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/global/pg_control, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/global/pg_control, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/global/pg_control, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/12000, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/12000, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/12000, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/postgresql.conf, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/postgresql.conf, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/postgresql.conf, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/badchecksum.txt, pg_data/badchecksum.txt, 11, bogus, 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_data/badchecksum.txt, strOp = backupFile, strQueue = pg_data
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, 7, [undef], 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, 7, d85de07d6421d90aa9191c11c889bfde43680f0f, 1, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, {iWalId => 65535, iWalOffset => 65535}), strKey = pg_tblspc/1/[TS_PATH-1]/16384/tablespace1.txt, strOp = backupFile, strQueue = pg_tblspc/1
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/pg_stat/global.stat, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
-P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/pg_stat/global.stat, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/pg_stat/global.stat, strSourcePathType = backup:cluster
+P00  DEBUG:     Protocol::Local::Process->queueJob(): iHostConfigIdx = 1, rParam = ([TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, 4, [undef], 0, [BACKUP-INCR-2], 1, [MODIFICATION-TIME-1], 1, [undef]), strKey = pg_tblspc/2/[TS_PATH-1]/32768/pg_internal.init, strOp = backupFile, strQueue = pg_tblspc/2
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/32768/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/32768/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/16384/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/16384/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/base/1/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/base/1/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/base/1/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Backup::Backup->processManifest: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = pg_data/PG_VERSION, strDestinationPathType = backup:tmp, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
+P00  DEBUG:     File->linkCreate(): bHard = true, bPathCreate = true, bRelative = false, strDestinationFile = [BACKUP-INCR-2]/pg_data/PG_VERSION, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-FULL-2]/pg_data/PG_VERSION, strSourcePathType = backup:cluster
 P00  DEBUG:     Protocol::Local::Process->hostConnect: start local process: iHostConfigIdx = 1, iHostIdx = 0, iHostProcessIdx = 0, iProcessId = 1, strHostType = db
 P00  DEBUG:     Protocol::Local::Master->new(): iProcessIdx = 1, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local
 P00  DEBUG:     Protocol::Command::Master->new(): iBufferMax = 4194304, iCompressLevel = 6, iCompressLevelNetwork = 3, iProtocolTimeout = 1830, strCommand = [BACKREST-BIN] --command=backup --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-user=[USER-1] --host-id=1 --lock-path=[TEST_PATH]/backup/repo/lock --log-path=[TEST_PATH]/backup/repo/log --process=1 --repo-path=[TEST_PATH]/backup/repo --stanza=db --type=db local, strId = local-1, strName = local, strRemoteType = none
@@ -1509,29 +1535,27 @@ P00  DEBUG:     Protocol::Helper::protocolDestroy(): bComplete = true, iRemoteId
 P00  DEBUG:     Protocol::Helper::protocolDestroy: found cached protocol: iRemoteIdx = 1, strRemoteType = db
 P00  DEBUG:     Protocol::Command::Master->close=>: iExitStatus = 0
 P00  DEBUG:     Protocol::Helper::protocolDestroy=>: iExitStatus = 0
-P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->manifest(): strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [undef], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/base/32768, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/global, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_clog, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_stat, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_data/pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2, strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1], strPathType = backup:tmp
-P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:tmp
+P00  DEBUG:     File->pathSync(): bRecursive = true, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->manifest(): strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/base/32768, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/global, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_clog, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_stat, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_data/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/1/[TS_PATH-1]/16384, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2, strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1], strPathType = backup:cluster
+P00  DEBUG:     File->pathSync(): bRecursive = <false>, strPath = [BACKUP-INCR-2]/pg_tblspc/2/[TS_PATH-1]/32768, strPathType = backup:cluster
 P00   INFO: new backup label = [BACKUP-INCR-2]
-P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = <true>, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = backup.manifest.gz, strDestinationPathType = backup:tmp, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = backup.manifest, strSourcePathType = backup:tmp, strUser = [undef]
-P00  DEBUG:     Backup::Backup->process: move [TEST_PATH]/backup/repo/temp/db.tmp to [TEST_PATH]/backup/repo/backup/db/[BACKUP-INCR-2]
-P00  DEBUG:     File->move(): bDestinationPathCreate = <false>, bPathSync = <false>, strDestinationFile = [BACKUP-INCR-2], strDestinationPathType = backup:cluster, strSourceFile = [undef], strSourcePathType = backup:tmp
+P00  DEBUG:     File->copy(): bAppendChecksum = <false>, bDestinationCompress = true, bDestinationPathCreate = <false>, bIgnoreMissingSource = <false>, bPathSync = <false>, bSourceCompressed = <false>, bTempFile = false, lModificationTime = [undef], rExtraParam = [undef], strDestinationFile = [BACKUP-INCR-2]/backup.manifest.gz, strDestinationPathType = backup:cluster, strExtraFunction = [undef], strGroup = [undef], strMode = <0640>, strSourceFile = [BACKUP-INCR-2]/backup.manifest, strSourcePathType = backup:cluster, strUser = [undef]
 P00  DEBUG:     File->move(): bDestinationPathCreate = true, bPathSync = true, strDestinationFile = backup.history/[YEAR-1]/[BACKUP-INCR-2].manifest.gz, strDestinationPathType = backup:cluster, strSourceFile = [BACKUP-INCR-2]/backup.manifest.gz, strSourcePathType = backup:cluster
 P00  DEBUG:     File->remove(): bIgnoreMissing = <true>, bPathSync = <false>, bTemp = [undef], strPath = latest, strPathType = backup:cluster
 P00  DEBUG:     File->remove=>: bRemoved = true
@@ -1726,11 +1750,11 @@ diff backup - cannot resume - new diff (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --hardlink --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --repo-path=[TEST_PATH]/backup/repo --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-INCR-2] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-INCR-2] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-INCR-2] exists, but cannot be resumed (new backup-type 'diff' does not match aborted backup-type 'incr') - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1741,6 +1765,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-1]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-INCR-2]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 
@@ -1903,11 +1928,11 @@ diff backup - cannot resume - disabled / no repo link (backup host)
 P00   INFO: backup command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --db-path=[TEST_PATH]/db-master/db/base --db-user=[USER-1] --hardlink --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --no-online --no-repo-link --repo-path=[TEST_PATH]/backup/repo --no-resume --stanza=db --start-fast --test --test-delay=0.2 --test-point=backup-noresume=y --type=diff
 P00   WARN: option retention-full is not set, the repository may run out of space
             HINT: to retain full backups indefinitely (without warning), set option 'retention-full' to the maximum.
-P00   WARN: backup [BACKUP-DIFF-1] missing in repository removed from backup.info
+P00   WARN: backup [BACKUP-DIFF-1] missing manifest removed from backup.info
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
-P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
-P00   WARN: aborted backup exists, but cannot be resumed (resume is disabled) - will be dropped and recreated
+P00   WARN: aborted backup [BACKUP-DIFF-1] exists, but cannot be resumed (resume is disabled) - will be dropped
 P00   TEST:         PgBaCkReStTeSt-BACKUP-NORESUME-PgBaCkReStTeSt
+P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/badchecksum.txt (11B, 37%) checksum f927212cd08d11a42a666b2f04235398e9ceeb51
 P01   INFO: backup file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 62%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file db-master:[TEST_PATH]/db-master/db/base/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
@@ -1918,6 +1943,7 @@ P00   INFO: diff backup size = 29B
 P00   INFO: new backup label = [BACKUP-DIFF-2]
 P00   INFO: backup command end: completed successfully
 P00   INFO: expire command begin [BACKREST-VERSION]: --config=[TEST_PATH]/backup/pgbackrest.conf --db-cmd=[BACKREST-BIN] --db-config=[TEST_PATH]/db-master/pgbackrest.conf --db-host=db-master --lock-path=[TEST_PATH]/backup/repo/lock --log-level-console=detail --log-level-file=trace --log-level-stderr=off --log-path=[TEST_PATH]/backup/repo/log --repo-path=[TEST_PATH]/backup/repo --stanza=db
+P00   INFO: remove expired backup [BACKUP-DIFF-1]
 P00   INFO: option 'retention-archive' is not set - archive logs will not be expired
 P00   INFO: expire command end: completed successfully
 

--- a/test/lib/pgBackRestTest/Common/FileTest.pm
+++ b/test/lib/pgBackRestTest/Common/FileTest.pm
@@ -100,37 +100,6 @@ sub testPathRemove
 push(@EXPORT, qw(testPathRemove));
 
 ####################################################################################################################################
-# testPathCopy
-#
-# Copy a path.
-####################################################################################################################################
-sub testPathCopy
-{
-    my $strSourcePath = shift;
-    my $strDestinationPath = shift;
-    my $bSuppressError = shift;
-
-    executeTest("cp -RpP ${strSourcePath} ${strDestinationPath}", {bSuppressError => $bSuppressError});
-}
-
-####################################################################################################################################
-# testPathMove
-#
-# Copy a path.
-####################################################################################################################################
-sub testPathMove
-{
-    my $strSourcePath = shift;
-    my $strDestinationPath = shift;
-    my $bSuppressError = shift;
-
-    testPathCopy($strSourcePath, $strDestinationPath, $bSuppressError);
-    testPathRemove($strSourcePath, $bSuppressError);
-}
-
-push(@EXPORT, qw(testPathMove));
-
-####################################################################################################################################
 # testFileCreate
 #
 # Create a file specifying content, mode, and time.

--- a/test/lib/pgBackRestTest/Module/File/FileUnitTest.pm
+++ b/test/lib/pgBackRestTest/Module/File/FileUnitTest.pm
@@ -60,9 +60,6 @@ sub run
         $self->testException(
             sub {$oLocalFile->pathGet(PATH_BACKUP_ARCHIVE_OUT, undef, true)},
             ERROR_ASSERT, "strFile must be defined when temp file specified");
-        $self->testException(
-            sub {$oLocalFile->pathGet(PATH_BACKUP_TMP, undef, true)},
-            ERROR_ASSERT, "strFile must be defined when temp file specified");
 
         # Test absolute path
         $self->testException(
@@ -78,17 +75,8 @@ sub run
 
         # Error when stanza not defined
         $self->testException(
-            sub {(new pgBackRest::File(undef, $self->testPath(), $self->local()))->pathGet(PATH_BACKUP_TMP)},
+            sub {(new pgBackRest::File(undef, $self->testPath(), $self->local()))->pathGet(PATH_BACKUP_CLUSTER)},
             ERROR_ASSERT, "strStanza not defined");
-
-        # Test backup tmp path
-        $self->testResult(
-            sub {$oLocalFile->pathGet(PATH_BACKUP_TMP, 'file', true)}, $self->testPath() . '/temp/db.tmp/file.pgbackrest.tmp',
-            'backup temp path temp file');
-        $self->testResult(
-            sub {$oLocalFile->pathGet(PATH_BACKUP_TMP, 'file')}, $self->testPath() . '/temp/db.tmp/file', 'backup temp path file');
-        $self->testResult(
-            sub {$oLocalFile->pathGet(PATH_BACKUP_TMP, undef)}, $self->testPath() . '/temp/db.tmp', 'backup temp path');
 
         # Test archive path
         $self->testResult(


### PR DESCRIPTION
Backups will now be stored in their final directory while in progress and the presence of backup.manifest used to determine if it is complete.  The backup label is now based on the start time.

backup.manifest.copy will be used to determine if a backup can be resumed.