### PR TITLE
Fixed doc generator to display section summaries on Configuration page.

### DIFF
--- a/doc/lib/BackRestDoc/Common/DocConfig.pm
+++ b/doc/lib/BackRestDoc/Common/DocConfig.pm
@@ -763,6 +763,9 @@ sub helpConfigDocGet
 
         my $oSectionDoc = $oConfigDoc->nodeGet('config-section-list')->nodeGetById('config-section', $strSection);
 
+        # Set the summary text for the section
+        $oSectionElement->textSet($oSectionDoc->textGet());
+
         $oSectionElement->
             nodeAdd('title')->textSet(
                 {name => 'text',

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -12,6 +12,16 @@
     <release-list>
         <release date="XXXX-XX-XX" version="1.23dev" title="UNDER DEVELOPMENT">
             <release-doc-list>
+                <release-bug-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="shang.cynthia"/>
+                        </release-item-contributor-list>
+
+                        <p>Fixed the document generation to include the section summaries on the Configuration page.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-refactor-list>
                     <release-item>
                         <p>Move contributor list to the end of <file>release.xml</file> for convenience.</p>


### PR DESCRIPTION
This fix was built on the current master-c but can be applied to master as well.