### PR TITLE
Modify stanza-create so that it logs an INFO message instead of throwing an error

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -69,6 +69,14 @@
                     <release-item>
                         <p>The <file>{[project-exe]}</file> executable is now a C binary instead of Perl. This allows certain time-critical commands (like async <cmd>archive-push</cmd>) to run more quickly.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="shang.cynthia"/>
+                        </release-item-contributor-list>
+
+                        <p>Improve <cmd>stanza-create</cmd> command so that it does not error when the stanza already exists.</p>
+                    </release-item>
                 </release-improvement-list>
 
                 <release-development-list>

--- a/lib/pgBackRest/Stanza.pm
+++ b/lib/pgBackRest/Stanza.pm
@@ -151,7 +151,7 @@ sub stanzaCreate
 
         if (!$bArchiveInfoFileExists)
         {
-            $bArchiveInfoFileExists .= &INI_COPY_EXT;
+            $strArchiveInfoFile .= &INI_COPY_EXT;
             $bArchiveInfoFileExists = grep(/^$strArchiveInfoFile$/i, @stryFileListArchive);
         }
 

--- a/test/expect/mock-all-001.log
+++ b/test/expect/mock-all-001.log
@@ -2912,7 +2912,7 @@ stanza-create db - fail on backup directory missing backup.info (db-master host)
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base-2 --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
 P00  ERROR: [055]: backup information missing
-            HINT: use stanza-create --force to force the stanza data to be created.
+            HINT: use stanza-create --force to force the stanza data to be recreated.
 P00   INFO: stanza-create command end: aborted with exception [055]
 
 + supplemental file: [TEST_PATH]/db-master/repo/archive/db/archive.info

--- a/test/expect/mock-stanza-001.log
+++ b/test/expect/mock-stanza-001.log
@@ -57,13 +57,12 @@ db-version="9.3"
 [db:history]
 1={"db-id":1000000000000000093,"db-version":"9.3"}
 
-stanza-create db - fail on rerun of stanza-create - info files exist (db-master host)
+stanza-create db - do not fail on rerun of stanza-create - info files exist and DB section ok (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-P00  ERROR: [040]: backup directory and/or archive directory not empty
-            HINT: use stanza-create --force to force the stanza data to be created.
-P00   INFO: stanza-create command end: aborted with exception [040]
+P00   INFO: stanza-create was already performed
+P00   INFO: stanza-create command end: completed successfully
 
 + supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
 ---------------------------------------------------------------------
@@ -228,7 +227,7 @@ stanza-create db - fail on archive info file missing from non-empty dir (db-mast
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
 P00  ERROR: [055]: archive information missing
-            HINT: use stanza-create --force to force the stanza data to be created.
+            HINT: use stanza-create --force to force the stanza data to be recreated.
 P00   INFO: stanza-create command end: aborted with exception [055]
 
 + supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
@@ -277,46 +276,6 @@ stanza-create db - force create archive.info from gz file (db-master host)
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --force --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
 P00   INFO: stanza-create command end: completed successfully
-
-+ supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
----------------------------------------------------------------------
-[backrest]
-backrest-checksum="[CHECKSUM]"
-backrest-format=5
-backrest-version="[VERSION-1]"
-
-[db]
-db-catalog-version=201306121
-db-control-version=937
-db-id=1
-db-system-id=1000000000000000093
-db-version="9.3"
-
-[db:history]
-1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":1000000000000000093,"db-version":"9.3"}
-
-+ supplemental file: [TEST_PATH]/db-master/repo/archive/db/archive.info
------------------------------------------------------------------------
-[backrest]
-backrest-checksum="[CHECKSUM]"
-backrest-format=5
-backrest-version="[VERSION-1]"
-
-[db]
-db-id=1
-db-system-id=1000000000000000093
-db-version="9.3"
-
-[db:history]
-1={"db-id":1000000000000000093,"db-version":"9.3"}
-
-stanza-create db - repeat create - error that files exist (db-master host)
-> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
-------------------------------------------------------------------------------------------------------------------------------------
-P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
-P00  ERROR: [040]: backup directory and/or archive directory not empty
-            HINT: use stanza-create --force to force the stanza data to be created.
-P00   INFO: stanza-create command end: aborted with exception [040]
 
 + supplemental file: [TEST_PATH]/db-master/repo/backup/db/backup.info
 ---------------------------------------------------------------------
@@ -730,7 +689,7 @@ stanza-create db - fail no force to recreate the stanza from backups (db-master 
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=[TEST_PATH]/db-master/repo --stanza=db
 P00  ERROR: [055]: backup information missing
-            HINT: use stanza-create --force to force the stanza data to be created.
+            HINT: use stanza-create --force to force the stanza data to be recreated.
 P00   INFO: stanza-create command end: aborted with exception [055]
 
 + supplemental file: [TEST_PATH]/db-master/repo/archive/db/archive.info

--- a/test/expect/mock-stanza-002.log
+++ b/test/expect/mock-stanza-002.log
@@ -63,13 +63,12 @@ db-version="9.3"
 [db:history]
 1={"db-id":1000000000000000093,"db-version":"9.3"}
 
-stanza-create db - fail on rerun of stanza-create - info files exist (backup host)
+stanza-create db - do not fail on rerun of stanza-create - info files exist and DB section ok (backup host)
 > [CONTAINER-EXEC] backup [BACKREST-BIN] --config=[TEST_PATH]/backup/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --compress-level-network=1 --config=[TEST_PATH]/backup/pgbackrest.conf --db1-cmd=[BACKREST-BIN] --db1-config=[TEST_PATH]/db-master/pgbackrest.conf --db1-host=db-master --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --db1-user=[USER-1] --lock-path=[TEST_PATH]/backup/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/log --no-online --protocol-timeout=60 --repo-cipher-pass=<redacted> --repo-cipher-type=aes-256-cbc --repo-path=[TEST_PATH]/backup/repo --stanza=db
-P00  ERROR: [040]: backup directory and/or archive directory not empty
-            HINT: use stanza-create --force to force the stanza data to be created.
-P00   INFO: stanza-create command end: aborted with exception [040]
+P00   INFO: stanza-create was already performed
+P00   INFO: stanza-create command end: completed successfully
 
 + supplemental file: [TEST_PATH]/backup/repo/backup/db/backup.info
 ------------------------------------------------------------------
@@ -270,33 +269,6 @@ stanza-create db - force create archive.info from gz file (backup host)
 > [CONTAINER-EXEC] backup [BACKREST-BIN] --config=[TEST_PATH]/backup/pgbackrest.conf --stanza=db --log-level-console=detail --no-online --force stanza-create
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --compress-level-network=1 --config=[TEST_PATH]/backup/pgbackrest.conf --db1-cmd=[BACKREST-BIN] --db1-config=[TEST_PATH]/db-master/pgbackrest.conf --db1-host=db-master --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --db1-user=[USER-1] --force --lock-path=[TEST_PATH]/backup/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/log --no-online --protocol-timeout=60 --repo-cipher-pass=<redacted> --repo-cipher-type=aes-256-cbc --repo-path=[TEST_PATH]/backup/repo --stanza=db
-P00  ERROR: [055]: archive information missing and repo is encrypted and info file(s) are missing, --force cannot be used
-P00   INFO: stanza-create command end: aborted with exception [055]
-
-+ supplemental file: [TEST_PATH]/backup/repo/backup/db/backup.info
-------------------------------------------------------------------
-[backrest]
-backrest-checksum="[CHECKSUM]"
-backrest-format=5
-backrest-version="[VERSION-1]"
-
-[cipher]
-cipher-pass=[CIPHER-PASS-1]
-
-[db]
-db-catalog-version=201306121
-db-control-version=937
-db-id=1
-db-system-id=1000000000000000093
-db-version="9.3"
-
-[db:history]
-1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":1000000000000000093,"db-version":"9.3"}
-
-stanza-create db - repeat create - error that files exist (backup host)
-> [CONTAINER-EXEC] backup [BACKREST-BIN] --config=[TEST_PATH]/backup/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
-------------------------------------------------------------------------------------------------------------------------------------
-P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --compress-level-network=1 --config=[TEST_PATH]/backup/pgbackrest.conf --db1-cmd=[BACKREST-BIN] --db1-config=[TEST_PATH]/db-master/pgbackrest.conf --db1-host=db-master --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --db1-user=[USER-1] --lock-path=[TEST_PATH]/backup/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/backup/log --no-online --protocol-timeout=60 --repo-cipher-pass=<redacted> --repo-cipher-type=aes-256-cbc --repo-path=[TEST_PATH]/backup/repo --stanza=db
 P00  ERROR: [055]: archive information missing and repo is encrypted and info file(s) are missing, --force cannot be used
 P00   INFO: stanza-create command end: aborted with exception [055]
 

--- a/test/expect/mock-stanza-003.log
+++ b/test/expect/mock-stanza-003.log
@@ -57,13 +57,12 @@ db-version="9.3"
 [db:history]
 1={"db-id":1000000000000000093,"db-version":"9.3"}
 
-stanza-create db - fail on rerun of stanza-create - info files exist (db-master host)
+stanza-create db - do not fail on rerun of stanza-create - info files exist and DB section ok (db-master host)
 > [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=/ --repo-s3-bucket=pgbackrest-dev --repo-s3-endpoint=s3.amazonaws.com --repo-s3-key=<redacted> --repo-s3-key-secret=<redacted> --repo-s3-region=us-east-1 --no-repo-s3-verify-ssl --repo-type=s3 --stanza=db
-P00  ERROR: [040]: backup directory and/or archive directory not empty
-            HINT: use stanza-create --force to force the stanza data to be created.
-P00   INFO: stanza-create command end: aborted with exception [040]
+P00   INFO: stanza-create was already performed
+P00   INFO: stanza-create command end: completed successfully
 
 + supplemental file: /backup/db/backup.info
 -------------------------------------------
@@ -228,7 +227,7 @@ stanza-create db - fail on archive info file missing from non-empty dir (db-mast
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=/ --repo-s3-bucket=pgbackrest-dev --repo-s3-endpoint=s3.amazonaws.com --repo-s3-key=<redacted> --repo-s3-key-secret=<redacted> --repo-s3-region=us-east-1 --no-repo-s3-verify-ssl --repo-type=s3 --stanza=db
 P00  ERROR: [055]: archive information missing
-            HINT: use stanza-create --force to force the stanza data to be created.
+            HINT: use stanza-create --force to force the stanza data to be recreated.
 P00   INFO: stanza-create command end: aborted with exception [055]
 
 + supplemental file: /backup/db/backup.info
@@ -253,46 +252,6 @@ stanza-create db - force create archive.info from gz file (db-master host)
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --force --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=/ --repo-s3-bucket=pgbackrest-dev --repo-s3-endpoint=s3.amazonaws.com --repo-s3-key=<redacted> --repo-s3-key-secret=<redacted> --repo-s3-region=us-east-1 --no-repo-s3-verify-ssl --repo-type=s3 --stanza=db
 P00   INFO: stanza-create command end: completed successfully
-
-+ supplemental file: /backup/db/backup.info
--------------------------------------------
-[backrest]
-backrest-checksum="[CHECKSUM]"
-backrest-format=5
-backrest-version="[VERSION-1]"
-
-[db]
-db-catalog-version=201306121
-db-control-version=937
-db-id=1
-db-system-id=1000000000000000093
-db-version="9.3"
-
-[db:history]
-1={"db-catalog-version":201306121,"db-control-version":937,"db-system-id":1000000000000000093,"db-version":"9.3"}
-
-+ supplemental file: /archive/db/archive.info
----------------------------------------------
-[backrest]
-backrest-checksum="[CHECKSUM]"
-backrest-format=5
-backrest-version="[VERSION-1]"
-
-[db]
-db-id=1
-db-system-id=1000000000000000093
-db-version="9.3"
-
-[db:history]
-1={"db-id":1000000000000000093,"db-version":"9.3"}
-
-stanza-create db - repeat create - error that files exist (db-master host)
-> [CONTAINER-EXEC] db-master [BACKREST-BIN] --config=[TEST_PATH]/db-master/pgbackrest.conf --stanza=db --log-level-console=detail --no-online stanza-create
-------------------------------------------------------------------------------------------------------------------------------------
-P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=/ --repo-s3-bucket=pgbackrest-dev --repo-s3-endpoint=s3.amazonaws.com --repo-s3-key=<redacted> --repo-s3-key-secret=<redacted> --repo-s3-region=us-east-1 --no-repo-s3-verify-ssl --repo-type=s3 --stanza=db
-P00  ERROR: [040]: backup directory and/or archive directory not empty
-            HINT: use stanza-create --force to force the stanza data to be created.
-P00   INFO: stanza-create command end: aborted with exception [040]
 
 + supplemental file: /backup/db/backup.info
 -------------------------------------------
@@ -712,7 +671,7 @@ stanza-create db - fail no force to recreate the stanza from backups (db-master 
 ------------------------------------------------------------------------------------------------------------------------------------
 P00   INFO: stanza-create command begin [BACKREST-VERSION]: --compress-level=3 --config=[TEST_PATH]/db-master/pgbackrest.conf --db1-path=[TEST_PATH]/db-master/db/base --db-timeout=45 --lock-path=[TEST_PATH]/db-master/lock --log-level-console=detail --log-level-file=trace --log-path=[TEST_PATH]/db-master/log --no-online --protocol-timeout=60 --repo-path=/ --repo-s3-bucket=pgbackrest-dev --repo-s3-endpoint=s3.amazonaws.com --repo-s3-key=<redacted> --repo-s3-key-secret=<redacted> --repo-s3-region=us-east-1 --no-repo-s3-verify-ssl --repo-type=s3 --stanza=db
 P00  ERROR: [055]: backup information missing
-            HINT: use stanza-create --force to force the stanza data to be created.
+            HINT: use stanza-create --force to force the stanza data to be recreated.
 P00   INFO: stanza-create command end: aborted with exception [055]
 
 + supplemental file: /archive/db/archive.info

--- a/test/lib/pgBackRestTest/Module/Mock/MockStanzaTest.pm
+++ b/test/lib/pgBackRestTest/Module/Mock/MockStanzaTest.pm
@@ -81,11 +81,11 @@ sub run
         #--------------------------------------------------------------------------------------------------------------------------
         $oHostBackup->stanzaCreate('successfully create the stanza', {strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE)});
 
-        # Rerun stanza-create and confirm failure - need use force since archive.info and backup.info exist
+        # Rerun stanza-create and confirm it does not fail
         #--------------------------------------------------------------------------------------------------------------------------
         $oHostBackup->stanzaCreate(
-            'fail on rerun of stanza-create - info files exist',
-            {iExpectedExitStatus => ERROR_PATH_NOT_EMPTY, strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE)});
+            'do not fail on rerun of stanza-create - info files exist and DB section ok',
+            {strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE)});
 
         # Stanza Create fails when not using force - database mismatch with pg_control file
         #--------------------------------------------------------------------------------------------------------------------------
@@ -130,7 +130,6 @@ sub run
 
         if (!$bRepoEncrypt)
         {
-
             $oHostBackup->stanzaCreate('fail on archive info file missing from non-empty dir',
                 {iExpectedExitStatus => ERROR_FILE_MISSING, strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE)});
         }
@@ -165,10 +164,10 @@ sub run
             {strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE) . ' --' . cfgOptionName(CFGOPT_FORCE),
                 iExpectedExitStatus => $bRepoEncrypt ? ERROR_FILE_MISSING : undef});
 
-        # Rerun without the force to ensure the files exist
-        $oHostBackup->stanzaCreate('repeat create - error that files exist',
-            {iExpectedExitStatus => $bRepoEncrypt ? ERROR_FILE_MISSING : ERROR_PATH_NOT_EMPTY,
-                strOptionalParam => '--no-' . cfgOptionName(CFGOPT_ONLINE)});
+        if (!$bRepoEncrypt)
+        {
+            $self->testResult(sub {storageRepo()->exists($strArchiveInfoFile)}, true, "    archive.info file was created");
+        }
 
         # Stanza Create succeeds when using force - recreates archive.info from uncompressed archive file
         #--------------------------------------------------------------------------------------------------------------------------

--- a/test/lib/pgBackRestTest/Module/Stanza/StanzaAllTest.pm
+++ b/test/lib/pgBackRestTest/Module/Stanza/StanzaAllTest.pm
@@ -171,6 +171,15 @@ sub run
         $self->testResult(sub {$oStanza->stanzaCreate()}, 0,
             "no error on missing backup.info since backup.info.copy exists and DB section OK");
 
+        # No force. No backup.info file (backup.info.copy only) and no backup sub-directories or files. No archive.info file
+        # (archive.info.copy only) and no archive sub-directories or files
+        #---------------------------------------------------------------------------------------------------------------------------
+        forceStorageRemove(storageRepo(), STORAGE_REPO_ARCHIVE . qw{/} . ARCHIVE_INFO_FILE);
+        (new pgBackRest::Archive::Info($self->{strArchivePath}, false, {bIgnoreMissing => true}))->create(PG_VERSION_94,
+            $self->dbSysId(PG_VERSION_94), true);
+        $self->testResult(sub {$oStanza->stanzaCreate()}, 0,
+            "no error on missing archive.info since archive.info.copy exists and DB section OK");
+
         # No force. No backup.info files and no backup sub-directories or files. Archive.info exists and no
         # archive sub-directories or files
         #---------------------------------------------------------------------------------------------------------------------------

--- a/test/lib/pgBackRestTest/Module/Stanza/StanzaAllTest.pm
+++ b/test/lib/pgBackRestTest/Module/Stanza/StanzaAllTest.pm
@@ -136,21 +136,21 @@ sub run
         storageRepo()->pathCreate(STORAGE_REPO_ARCHIVE . "/9.4-1");
         $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_PATH_NOT_EMPTY,
             "archive directory not empty" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # No force. Archive dir not empty. No archive.info file. Backup directory not empty. No backup.info file.
         #---------------------------------------------------------------------------------------------------------------------------
         storageRepo()->pathCreate(STORAGE_REPO_BACKUP . "/12345");
         $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_PATH_NOT_EMPTY,
             "backup directory and/or archive directory not empty" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # No force. Archive dir empty. No archive.info file. Backup directory not empty. No backup.info file.
         #---------------------------------------------------------------------------------------------------------------------------
         forceStorageRemove(storageRepo(), STORAGE_REPO_ARCHIVE . "/9.4-1", {bRecurse => true});
         $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_PATH_NOT_EMPTY,
             "backup directory not empty" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # No force. No archive.info file and no archive sub-directories or files. Backup.info exists and no backup sub-directories
         # or files
@@ -160,7 +160,7 @@ sub run
              $self->dbSysId(PG_VERSION_94), $iDbControl, $iDbCatalog, true);
         $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_FILE_MISSING,
             "archive information missing" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # No force. No backup.info file (backup.info.copy only) and no backup sub-directories or files. Archive.info exists and no
         # archive sub-directories or files
@@ -168,9 +168,18 @@ sub run
         forceStorageRemove(storageRepo(), STORAGE_REPO_BACKUP . qw{/} . FILE_BACKUP_INFO);
         (new pgBackRest::Archive::Info($self->{strArchivePath}, false, {bIgnoreMissing => true}))->create(PG_VERSION_94,
             $self->dbSysId(PG_VERSION_94), true);
+        $self->testResult(sub {$oStanza->stanzaCreate()}, 0,
+            "no error on missing backup.info since backup.info.copy exists and DB section OK");
+
+        # No force. No backup.info files and no backup sub-directories or files. Archive.info exists and no
+        # archive sub-directories or files
+        #---------------------------------------------------------------------------------------------------------------------------
+        forceStorageRemove(storageRepo(), STORAGE_REPO_BACKUP . qw{/} . FILE_BACKUP_INFO . INI_COPY_EXT);
+        (new pgBackRest::Archive::Info($self->{strArchivePath}, false, {bIgnoreMissing => true}))->create(PG_VERSION_94,
+            $self->dbSysId(PG_VERSION_94), true);
         $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_FILE_MISSING,
             "backup information missing" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # No force. archive.info DB mismatch. backup.info correct DB.
         #---------------------------------------------------------------------------------------------------------------------------
@@ -201,16 +210,14 @@ sub run
 
         # No force with .info and .info.copy files already existing
         #--------------------------------------------------------------------------------------------------------------------------
-        $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_PATH_NOT_EMPTY,
-            "backup directory and/or archive directory not empty" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+        $self->testResult(sub {$oStanza->stanzaCreate()}, 0,
+            "info files exist and check out ok - stanza create not needed");
 
-        # No force. Remove only backup.info.copy file - confirm stanza create still throws an error since force was not used
+        # No force. Remove only backup.info.copy file - confirm stanza create does not throw an error since copy is still valid
         #---------------------------------------------------------------------------------------------------------------------------
         forceStorageRemove(storageRepo(), $strBackupInfoFileCopy);
-        $self->testException(sub {$oStanza->stanzaCreate()}, ERROR_PATH_NOT_EMPTY,
-            "backup directory and/or archive directory not empty" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+        $self->testResult(sub {$oStanza->stanzaCreate()}, 0,
+            "info.copy file exists and check out ok - stanza create not needed");
 
         # Force on. Valid archive.info exists. Invalid backup.info exists.
         #---------------------------------------------------------------------------------------------------------------------------
@@ -222,6 +229,7 @@ sub run
             $self->dbSysId(PG_VERSION_93), $iDbControl, $iDbCatalog, true);
 
         $self->testResult(sub {$oStanza->stanzaCreate()}, 0, 'successfully created stanza with force and existing info files');
+
         $self->testResult(sub {(new pgBackRest::Backup::Info($self->{strBackupPath}))->check(PG_VERSION_94,
             $iDbControl, $iDbCatalog, $self->dbSysId(PG_VERSION_94))}, 2, '    backup.info reconstructed');
 
@@ -446,7 +454,7 @@ sub run
             storageRepo()->pathGet(STORAGE_REPO_BACKUP . qw{/} . FILE_BACKUP_INFO) .
             " does not exist and is required to perform a backup." .
             "\nHINT: has a stanza-create been performed?" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.");
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.");
 
         # Force.
         #---------------------------------------------------------------------------------------------------------------------------
@@ -655,7 +663,7 @@ sub run
         my $oStanza = new pgBackRest::Stanza();
 
         my $strMessage = "archive information missing" .
-            "\nHINT: use stanza-create --force to force the stanza data to be created.";
+            "\nHINT: use stanza-create --force to force the stanza data to be recreated.";
 
         $self->testException(sub {$oStanza->errorForce($strMessage, ERROR_FILE_MISSING, undef, true,
             $self->{strArchivePath}, $self->{strBackupPath})}, ERROR_FILE_MISSING, $strMessage);


### PR DESCRIPTION
…when info files exist and their DB sections match the current database.