### PR TITLE
change hour format for AWS x-amz-date header to %H from %k to match ISO-8601

### DIFF
--- a/lib/pgBackRest/Storage/S3/Auth.pm
+++ b/lib/pgBackRest/Storage/S3/Auth.pm
@@ -62,7 +62,7 @@ sub s3DateTime
     return logDebugReturn
     (
         $strOperation,
-        {name => 'strDateTime', value => strftime("%Y%m%dT%k%M%SZ", gmtime($lTime)), trace => true}
+        {name => 'strDateTime', value => strftime("%Y%m%dT%H%M%SZ", gmtime($lTime)), trace => true}
     );
 }
 

--- a/test/lib/pgBackRestTest/Module/Storage/StorageS3AuthPerlTest.pm
+++ b/test/lib/pgBackRestTest/Module/Storage/StorageS3AuthPerlTest.pm
@@ -35,7 +35,7 @@ sub run
 
         #---------------------------------------------------------------------------------------------------------------------------
         waitRemainder();
-        $self->testResult(sub {s3DateTime()}, strftime("%Y%m%dT%k%M%SZ", gmtime()), 'format current date/time');
+        $self->testResult(sub {s3DateTime()}, strftime("%Y%m%dT%H%M%SZ", gmtime()), 'format current date/time');
     }
 
     ################################################################################################################################


### PR DESCRIPTION
The [AWS docs](https://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html) specify ISO-8601 as the format for the `x-amz-date` header:

> The time stamp must be in UTC and in the following ISO 8601 format: YYYYMMDD'T'HHMMSS'Z'. For example, 20150830T123600Z is a valid time stamp. Do not include milliseconds in the time stamp.

The current `strftime` format string uses `%k` for the hour, 

> %k The hour (24-hour clock) as a decimal number (range 0 to 23); single digits are preceded by a blank. (See also %H.) (Calculated from tm_hour.)  (TZ)

which for single digit hours, inserts a space before the digit. Some S3 API implementations are strict about this format which causes failures during these hours. You can imagine the headaches debugging :).

The PR proposes changing the format string hour to `%H` to match ISO-8601

> %H The hour as a decimal number using a 24-hour clock (range 00 to 23). (Calculated from tm_hour.)