### PR TITLE
Directly check for ok/error status files

### DIFF
--- a/src/command/archive/common.c
+++ b/src/command/archive/common.c
@@ -30,23 +30,29 @@ archiveAsyncStatus(ArchiveMode archiveMode, const String *walSegment, bool confe
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
+        bool okFileExists;
+        bool errorFileExists;
+
         String *spoolQueue = strNew(archiveMode == archiveModeGet ? STORAGE_SPOOL_ARCHIVE_IN : STORAGE_SPOOL_ARCHIVE_OUT);
+        String *okFile = strNewFmt("%s/%s.ok", strPtr(spoolQueue), strPtr(walSegment));
+        String *errorFile = strNewFmt("%s/%s.error", strPtr(spoolQueue), strPtr(walSegment));
 
-        StringList *fileList = storageListP(
-            storageSpool(), spoolQueue, .expression = strNewFmt("^%s\\.(ok|error)$", strPtr(walSegment)));
+        okFileExists = storageExistsP(storageSpool(), okFile);
+        errorFileExists = storageExistsP(storageSpool(), errorFile);
 
-        if (fileList != NULL && strLstSize(fileList) > 0)
+        // If both status files are found then assert - this could be a bug in the async process
+        if (okFileExists && errorFileExists)
         {
-            // If more than one status file was found then assert - this could be a bug in the async process
-            if (strLstSize(fileList) != 1)
-            {
-                THROW_FMT(
-                    AssertError, "multiple status files found in '%s' for WAL segment '%s'",
-                    strPtr(storagePath(storageSpool(), spoolQueue)), strPtr(walSegment));
-            }
+            THROW_FMT(
+                AssertError, "multiple status files found in '%s' for WAL segment '%s'",
+                strPtr(storagePath(storageSpool(), spoolQueue)), strPtr(walSegment));
+        }
 
+        // If either of them exists then check what happened and report back.
+        if (okFileExists || errorFileExists)
+        {
             // Get the status file content
-            const String *statusFile = strLstGet(fileList, 0);
+            const String *statusFile = okFileExists ? okFile: errorFile;
 
             String *content = strNewBuf(
                 storageGetNP(storageNewReadNP(storageSpool(), strNewFmt("%s/%s", strPtr(spoolQueue), strPtr(statusFile)))));
@@ -74,7 +80,7 @@ archiveAsyncStatus(ArchiveMode archiveMode, const String *walSegment, bool confe
             }
 
             // Process OK files
-            if (strEndsWithZ(statusFile, ".ok"))
+            if (okFileExists)
             {
                 // If there is content in the status file it is a warning
                 if (strSize(content) != 0)


### PR DESCRIPTION
Prior to this commit, an expression was used to search the spool
directory for ok/error files for a specific WAL segment.  This involved
setting up a regular expression and using opendir/readdir.

Instead, directly probe for the status files, checking directly if a
'.ok' or '.error' file exists, avoiding the regular expression and
eliminating the directory scan.

Only the two files now probed for could have ever matched the regular
expression which had been provided and it's unlikely that many more
additional files will be added, so this is a good improvement, and
optimization, with little downside.