### PR TITLE
Ignore the src/pgbackrest that gets built when doing make...

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,2 @@
+*.o
+src/pgbackrest


### PR DESCRIPTION
Would be nice to have this so that a 'make' doesn't make it look like there's something to commit. :)