### PR TITLE
Change execRead to return a size_t

### DIFF
--- a/src/common/exec.c
+++ b/src/common/exec.c
@@ -214,7 +214,7 @@ execCheck(Exec *this)
 /***********************************************************************************************************************************
 Read from the process
 ***********************************************************************************************************************************/
-void
+size_t
 execRead(Exec *this, Buffer *buffer, bool block)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
@@ -226,9 +226,11 @@ execRead(Exec *this, Buffer *buffer, bool block)
     ASSERT(this != NULL);
     ASSERT(buffer != NULL);
 
+    size_t result = 0;
+
     TRY_BEGIN()
     {
-        ioHandleRead(this->ioReadHandle, buffer, block);
+        result = ioHandleRead(this->ioReadHandle, buffer, block);
     }
     CATCH_ANY()
     {
@@ -237,7 +239,7 @@ execRead(Exec *this, Buffer *buffer, bool block)
     }
     TRY_END();
 
-    FUNCTION_LOG_RETURN_VOID();
+    FUNCTION_LOG_RETURN(SIZE, result);
 }
 
 /***********************************************************************************************************************************

--- a/src/common/exec.h
+++ b/src/common/exec.h
@@ -28,7 +28,7 @@ Exec *execNew(const String *command, const StringList *param, const String *name
 Functions
 ***********************************************************************************************************************************/
 void execOpen(Exec *this);
-void execRead(Exec *this, Buffer *buffer, bool block);
+size_t execRead(Exec *this, Buffer *buffer, bool block);
 void execWrite(Exec *this, Buffer *buffer);
 
 /***********************************************************************************************************************************


### PR DESCRIPTION
execRead should be returning a size_t, not a void.  Thankfully, this
isn't actually used much and therefore shouldn't be an issue, but we
should fix it anyway.