### PR TITLE
Info command : Check that the wal segments needed for the backups exist on disk

### DIFF
--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -382,19 +382,15 @@ stanzaInfoList(const String *stanza, StringList *stanzaList)
                 String *archiveId = strLstGet(archiveDbListReturnList, 0);
                 String *archiveStop = strLstGet(archiveDbListReturnList, 1);
 
-                // Does minNeededWalSeg and maxNeededWalSeg exists on disk?
+                // Does minNeededWalSeg and maxNeededWalSeg exists on disk? Is archiveStop >= maxNeededWalSeg?
                 String *foundMinNeededWalSeg = walSegmentFind(storageRepo(), strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), minNeededWalSeg);
                 String *foundMaxNeededWalSeg = walSegmentFind(storageRepo(), strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), maxNeededWalSeg);
-                if (foundMinNeededWalSeg == NULL || foundMaxNeededWalSeg == NULL)
+                if (foundMinNeededWalSeg == NULL || foundMaxNeededWalSeg == NULL || strCmp(archiveStop, maxNeededWalSeg) < 0)
                     stanzaStatus(INFO_STANZA_STATUS_CODE_MISSING_WAL_SEG, INFO_STANZA_STATUS_MESSAGE_MISSING_WAL_SEG_STR, stanzaInfo);
 
-                // Is archiveStop >= maxNeededWalSeg?
-                if (strCmp(archiveStop, maxNeededWalSeg) < 0)
-                    stanzaStatus(INFO_STANZA_STATUS_CODE_MISSING_WAL_SEG, INFO_STANZA_STATUS_MESSAGE_MISSING_WAL_SEG_STR, stanzaInfo);
+                // TODO: Validate the chain of wal segments between minNeededWalSeg and maxNeededWalSeg?
 
-                // Validate the chain of wal segments between minNeededWalSeg and maxNeededWalSeg?
-
-                // Validate the chain of wal segments between maxNeededWalSeg and archiveStop?
+                // TODO: Validate the chain of wal segments between maxNeededWalSeg and archiveStop?
             }
         }
 

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -119,7 +119,7 @@ archiveDbList(const String *stanza, const InfoPgData *pgData, VariantList *archi
     // If there is no match, an error will be thrown.
     const String *archiveId = infoArchiveIdHistoryMatch(info, pgData->id, pgData->version, pgData->systemId);
 
-    String *archivePath = strNewFmt("%s/%s/%s", STORAGE_REPO_ARCHIVE, strPtr(stanza), strPtr(archiveId));
+    String *archivePath = strNewFmt("%s/%s/%s", STORAGE_PATH_ARCHIVE, strPtr(stanza), strPtr(archiveId));
     String *archiveStart = NULL;
     String *archiveStop = NULL;
     Variant *archiveInfo = varNewKv();
@@ -383,14 +383,17 @@ stanzaInfoList(const String *stanza, StringList *stanzaList)
                 String *archiveStop = strLstGet(archiveDbListReturnList, 1);
 
                 // Does minNeededWalSeg and maxNeededWalSeg exists on disk? Is archiveStop >= maxNeededWalSeg?
-                String *foundMinNeededWalSeg = walSegmentFind(storageRepo(), strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), minNeededWalSeg);
-                String *foundMaxNeededWalSeg = walSegmentFind(storageRepo(), strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), maxNeededWalSeg);
-                if (foundMinNeededWalSeg == NULL || foundMaxNeededWalSeg == NULL || strCmp(archiveStop, maxNeededWalSeg) < 0)
-                    stanzaStatus(INFO_STANZA_STATUS_CODE_MISSING_WAL_SEG, INFO_STANZA_STATUS_MESSAGE_MISSING_WAL_SEG_STR, stanzaInfo);
+                if(minNeededWalSeg && maxNeededWalSeg && archiveStop)
+                {
+                    String *foundMinNeededWalSeg = walSegmentFind(storageRepo(), stanzaFound ? archiveId : strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), minNeededWalSeg);
+                    String *foundMaxNeededWalSeg = walSegmentFind(storageRepo(), stanzaFound ? archiveId : strNewFmt("%s/%s", strPtr(stanzaListName), strPtr(archiveId)), maxNeededWalSeg);
+                    if (foundMinNeededWalSeg == NULL || foundMaxNeededWalSeg == NULL || strCmp(archiveStop, maxNeededWalSeg) < 0)
+                        stanzaStatus(INFO_STANZA_STATUS_CODE_MISSING_WAL_SEG, INFO_STANZA_STATUS_MESSAGE_MISSING_WAL_SEG_STR, stanzaInfo);
 
-                // TODO: Validate the chain of wal segments between minNeededWalSeg and maxNeededWalSeg?
+                    // TODO: Validate the chain of wal segments between minNeededWalSeg and maxNeededWalSeg?
 
-                // TODO: Validate the chain of wal segments between maxNeededWalSeg and archiveStop?
+                    // TODO: Validate the chain of wal segments between maxNeededWalSeg and archiveStop?
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

I would like to suggest the following PR.

Commit msg:

```
check that the wal segments needed for the backups exist on disk 
```

In the info command, archiveDbList only look at the oldest and newest archived wal segment found on disk.

The idea here is to keep track of the first and last needed archive for the consistency of the backups given by the backupList and check if it exists on disk.

A next step would be to validate the archive chain to make sure there's nothing missing. Maybe in the info command itself with some "--validate-archive-chain" parameter or in a new separated command. Maybe should I open a separated issue to discuss this idea?

Kind regards