### PR TITLE
Fix keepalive on the SSL connection

### DIFF
--- a/lib/pgBackRest/Common/Http/Client.pm
+++ b/lib/pgBackRest/Common/Http/Client.pm
@@ -99,9 +99,11 @@ sub new
 
             eval
             {
-                $oSocket = IO::Socket::SSL->new(
+                $oSocket = IO::Socket::IP->new(PeerHost => $strHost, PeerPort => $iPort);
+                setsockopt($oSocket,SOL_SOCKET,SO_KEEPALIVE,1);
+                IO::Socket::SSL->start_SSL($oSocket,
                     PeerHost => $strHost, PeerPort => $iPort, SSL_verify_mode => $bVerifySsl ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,
-                    SSL_ca_path => $strCaPath, SSL_ca_file => $strCaFile, Sockopts => [[SOL_SOCKET, SO_KEEPALIVE]]);
+                    SSL_ca_path => $strCaPath, SSL_ca_file => $strCaFile);
 
                 return 1;
             }

--- a/lib/pgBackRest/Common/Http/Client.pm
+++ b/lib/pgBackRest/Common/Http/Client.pm
@@ -96,10 +96,18 @@ sub new
         {
             # Connect to the server
             my $oSocket;
-
+            # find out what's available as a lib
             eval
             {
-                $oSocket = IO::Socket::IP->new(PeerHost => $strHost, PeerPort => $iPort);
+                if(eval{require IO::Socket::IP})
+                {
+                    $oSocket = IO::Socket::IP->new(PeerHost => $strHost, PeerPort => $iPort);
+                }
+                else
+                {
+                    require IO::Socket::INET;
+                    $oSocket = IO::Socket::INET->new(PeerHost => $strHost, PeerPort => $iPort);
+                }
                 setsockopt($oSocket,SOL_SOCKET,SO_KEEPALIVE,1);
                 IO::Socket::SSL->start_SSL($oSocket,
                     PeerHost => $strHost, PeerPort => $iPort, SSL_verify_mode => $bVerifySsl ? SSL_VERIFY_PEER : SSL_VERIFY_NONE,


### PR DESCRIPTION
Only perl 5.26+ supports passing sockopts directly to the instantiation
method

Should solve #636