### PR TITLE
src/Makefile.in: Add CPPFLAGS

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -23,7 +23,7 @@ CINCLUDE = @CINCLUDE@
 CLIBRARY = @CLIBRARY@
 
 # Concatenate options for easy usage
-CMAKE = $(CSTANDARD) $(COPTIMIZE) $(CWARNING) $(CINCLUDE) $(CLIBRARY)
+CMAKE = $(CPPFLAGS) $(CSTANDARD) $(COPTIMIZE) $(CWARNING) $(CINCLUDE) $(CLIBRARY)
 
 ####################################################################################################################################
 # Linker options


### PR DESCRIPTION
Debian's build log hardening check (blhc) noticed that
-D_FORTIFY_SOURCE=2 is missing in the gcc invocations. This is from
CPPFLAGS, add it to the CMAKE variable.

Cc: @disco-stu