### PR TITLE
Add note to db-timeout description to reference protocol-timeout.

### DIFF
--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -157,7 +157,7 @@
                     <config-key id="db-timeout" name="Database Timeout">
                         <summary>Database query timeout.</summary>
 
-                        <text>Sets the timeout, in seconds, for queries against the database.  This includes the <code>pg_start_backup()</code> and <code>pg_stop_backup()</code> functions which can each take a substantial amount of time.  Because of this the timeout should be kept high unless you know that these functions will return quickly (i.e. if you have set <setting>startfast=y</setting> and you know that the database cluster will not generate many WAL segments during the backup).</text>
+                        <text>Sets the timeout, in seconds, for queries against the database.  This includes the <code>pg_start_backup()</code> and <code>pg_stop_backup()</code> functions which can each take a substantial amount of time.  Because of this the timeout should be kept high unless you know that these functions will return quickly (i.e. if you have set <setting>startfast=y</setting> and you know that the database cluster will not generate many WAL segments during the backup). <admonition type="note">The <br-option>db-timeout</br-option> option must be less than the <br-option>protocol-timeout</br-option> option.</admonition></text>
 
                         <example>600</example>
                     </config-key>
@@ -223,7 +223,7 @@
                     <config-key id="protocol-timeout" name="Protocol Timeout">
                         <summary>Protocol timeout.</summary>
 
-                        <text>Sets the timeout, in seconds, that the local or remote process will wait for a new message to be received on the protocol layer.  This prevents processes from waiting indefinitely for a message.  The <br-option>protocol-timeout</br-option> option must be greater than the <br-option>db-timeout</br-option> option.</text>
+                        <text>Sets the timeout, in seconds, that the local or remote process will wait for a new message to be received on the protocol layer.  This prevents processes from waiting indefinitely for a message. <admonition type="note">The <br-option>protocol-timeout</br-option> option must be greater than the <br-option>db-timeout</br-option> option.</admonition></text>
 
                         <example>630</example>
                     </config-key>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -32,6 +32,19 @@
                     </release-item>
                 </release-development-list>
             </release-core-list>
+
+            <release-doc-list>
+                <release-improvement-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="james.chanco.jr"/>
+                            <release-item-contributor id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Add note to <br-option>db-timeout</br-option> description to reference the relationship with <br-option>protocol-timeout</br-option>.</p>
+                    </release-item>
+                </release-improvement-list>
+            </release-doc-list>
         </release>
 
         <release date="2019-09-03" version="2.17" title="C Migrations and Bug Fixes">


### PR DESCRIPTION
The relationship between db-timeout and protocol-timeout options was detailed only in the protocol-timeout reference section in the documentation which resulted in confusion. Define the relationship in the db-timeout section also to avoid confusion.