### PR TITLE
Renamed parameter processId to processIdx in harnessFork.h macros

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -30,6 +30,14 @@
 
                         <p>Add helper function for adding <code>CipherBlock</code> filters to groups.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Rename parameter <code>processId</code> to <code>processIdx</code> in <file>harnessFork.h</file> for clarity.</p>
+                    </release-item>
                 </release-development-list>
             </release-core-list>
         </release>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -33,7 +33,7 @@
 
                     <release-item>
                         <release-item-contributor-list>
-                            <release-item-reviewer id="cynthia.shang"/>
+                            <release-item-contributor id="cynthia.shang"/>
                         </release-item-contributor-list>
 
                         <p>Rename parameter <code>processId</code> to <code>processIdx</code> in <file>harnessFork.h</file> for clarity.</p>

--- a/test/src/common/harnessFork.h
+++ b/test/src/common/harnessFork.h
@@ -60,48 +60,48 @@ Return the process index of the child (i.e. the index in the total)
 /***********************************************************************************************************************************
 Return the id of the child process, 0 if in the child process
 ***********************************************************************************************************************************/
-#define HARNESS_FORK_PROCESS_ID(processId)                                                                                         \
-    HARNESS_FORK_processIdList[processId]
+#define HARNESS_FORK_PROCESS_ID(processIdx)                                                                                         \
+    HARNESS_FORK_processIdList[processIdx]
 
 /***********************************************************************************************************************************
 Return the pipe for the child process
 ***********************************************************************************************************************************/
-#define HARNESS_FORK_PIPE(processId)                                                                                               \
-    HARNESS_FORK_pipe[processId]
+#define HARNESS_FORK_PIPE(processIdx)                                                                                               \
+    HARNESS_FORK_pipe[processIdx]
 
 /***********************************************************************************************************************************
 Is the pipe required for this child process?
 ***********************************************************************************************************************************/
-#define HARNESS_FORK_PIPE_REQUIRED(processId)                                                                                      \
-    HARNESS_FORK_pipeRequired[processId]
+#define HARNESS_FORK_PIPE_REQUIRED(processIdx)                                                                                      \
+    HARNESS_FORK_pipeRequired[processIdx]
 
 /***********************************************************************************************************************************
 Get read/write pipe handles
 ***********************************************************************************************************************************/
-#define HARNESS_FORK_CHILD_READ_PROCESS(processId)                                                                                 \
-    HARNESS_FORK_PIPE(processId)[1][0]
+#define HARNESS_FORK_CHILD_READ_PROCESS(processIdx)                                                                                 \
+    HARNESS_FORK_PIPE(processIdx)[1][0]
 
 #define HARNESS_FORK_CHILD_READ()                                                                                                  \
     HARNESS_FORK_CHILD_READ_PROCESS(HARNESS_FORK_PROCESS_IDX())
 
-#define HARNESS_FORK_CHILD_WRITE_PROCESS(processId)                                                                                \
-    HARNESS_FORK_PIPE(processId)[0][1]
+#define HARNESS_FORK_CHILD_WRITE_PROCESS(processIdx)                                                                                \
+    HARNESS_FORK_PIPE(processIdx)[0][1]
 
 #define HARNESS_FORK_CHILD_WRITE()                                                                                                 \
     HARNESS_FORK_CHILD_WRITE_PROCESS(HARNESS_FORK_PROCESS_IDX())
 
-#define HARNESS_FORK_PARENT_READ_PROCESS(processId)                                                                                \
-    HARNESS_FORK_PIPE(processId)[0][0]
+#define HARNESS_FORK_PARENT_READ_PROCESS(processIdx)                                                                                \
+    HARNESS_FORK_PIPE(processIdx)[0][0]
 
-#define HARNESS_FORK_PARENT_WRITE_PROCESS(processId)                                                                               \
-    HARNESS_FORK_PIPE(processId)[1][1]
+#define HARNESS_FORK_PARENT_WRITE_PROCESS(processIdx)                                                                               \
+    HARNESS_FORK_PIPE(processIdx)[1][1]
 
 /***********************************************************************************************************************************
 At the end of the HARNESS_FORK block the parent will wait for the child to exit.  By default an exit code of 0 is expected but that
 can be modified when the child begins.
 ***********************************************************************************************************************************/
-#define HARNESS_FORK_CHILD_EXPECTED_EXIT_STATUS(processId)                                                                         \
-    HARNESS_FORK_expectedExitStatus[processId]
+#define HARNESS_FORK_CHILD_EXPECTED_EXIT_STATUS(processIdx)                                                                         \
+    HARNESS_FORK_expectedExitStatus[processIdx]
 
 /***********************************************************************************************************************************
 Begin the fork block


### PR DESCRIPTION
For clarify, when passing the processId which is actually a processIdx to a harnessFork macros, the parameter has been renamed to processIdx.