### PR TITLE
Expire dry run

### DIFF
--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -59,12 +59,15 @@ expireBackup(InfoBackup *infoBackup, String *removeBackupLabel, String *backupEx
     ASSERT(removeBackupLabel != NULL);
     ASSERT(backupExpired != NULL);
 
-    storageRemoveNP(storageRepoWrite(), strNewFmt(STORAGE_REPO_BACKUP "/%s/" MANIFEST_FILE, strPtr(removeBackupLabel)));
-    storageRemoveNP(
-        storageRepoWrite(), strNewFmt(STORAGE_REPO_BACKUP "/%s/" MANIFEST_FILE INFO_COPY_EXT, strPtr(removeBackupLabel)));
+    if ( ! cfgOptionBool(cfgOptDryRun) ){
+      storageRemoveNP(storageRepoWrite(), strNewFmt(STORAGE_REPO_BACKUP "/%s/" MANIFEST_FILE, strPtr(removeBackupLabel)));
+      storageRemoveNP(
+                      storageRepoWrite(), strNewFmt(STORAGE_REPO_BACKUP "/%s/" MANIFEST_FILE INFO_COPY_EXT, strPtr(removeBackupLabel)));
 
-    // Remove the backup from the info file
-    infoBackupDataDelete(infoBackup, removeBackupLabel);
+
+      // Remove the backup from the info file
+      infoBackupDataDelete(infoBackup, removeBackupLabel);
+    }
 
     if (strSize(backupExpired) == 0)
         strCat(backupExpired, strPtr(removeBackupLabel));
@@ -650,3 +653,4 @@ cmdExpire(void)
 
     FUNCTION_LOG_RETURN_VOID();
 }
+

--- a/src/config/config.auto.c
+++ b/src/config/config.auto.c
@@ -470,7 +470,7 @@ STRING_EXTERN(CFGOPT_TEST_STR,                                      CFGOPT_TEST)
 STRING_EXTERN(CFGOPT_TEST_DELAY_STR,                                CFGOPT_TEST_DELAY);
 STRING_EXTERN(CFGOPT_TEST_POINT_STR,                                CFGOPT_TEST_POINT);
 STRING_EXTERN(CFGOPT_TYPE_STR,                                      CFGOPT_TYPE);
-
+STRING_EXTERN(CFGOPT_DRY_RUN_STR,                                   CFGOPT_DRY_RUN);
 /***********************************************************************************************************************************
 Option data
 ***********************************************************************************************************************************/
@@ -1819,4 +1819,12 @@ static ConfigOptionData configOptionData[CFG_OPTION_TOTAL] = CONFIG_OPTION_LIST
         CONFIG_OPTION_INDEX(0)
         CONFIG_OPTION_DEFINE_ID(cfgDefOptType)
     )
+
+
+    CONFIG_OPTION
+    (
+     CONFIG_OPTION_NAME(CFGOPT_DRY_RUN)
+     CONFIG_OPTION_INDEX(0)
+     CONFIG_OPTION_DEFINE_ID(cfgDefOptDryRun)
+     )
 )

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -389,8 +389,10 @@ Option constants
     STRING_DECLARE(CFGOPT_TEST_POINT_STR);
 #define CFGOPT_TYPE                                                 "type"
     STRING_DECLARE(CFGOPT_TYPE_STR);
+#define CFGOPT_DRY_RUN                                              "dry-run"
+    STRING_DECLARE(CFGOPT_DRY_RUN_STR);
 
-#define CFG_OPTION_TOTAL                                            168
+#define CFG_OPTION_TOTAL                                            169
 
 /***********************************************************************************************************************************
 Command enum
@@ -592,6 +594,7 @@ typedef enum
     cfgOptTestDelay,
     cfgOptTestPoint,
     cfgOptType,
+    cfgOptDryRun,
 } ConfigOption;
 
 #endif

--- a/src/config/define.auto.c
+++ b/src/config/define.auto.c
@@ -4812,4 +4812,35 @@ static ConfigDefineOptionData configDefineOptionData[] = CFGDEFDATA_OPTION_LIST
             )
         )
     )
+
+        // -----------------------------------------------------------------------------------------------------------------------------
+    CFGDEFDATA_OPTION
+    (
+        CFGDEFDATA_OPTION_NAME("dry-run")
+        CFGDEFDATA_OPTION_REQUIRED(false)
+        CFGDEFDATA_OPTION_SECTION(cfgDefSectionGlobal)
+        CFGDEFDATA_OPTION_TYPE(cfgDefOptTypeBoolean)
+        CFGDEFDATA_OPTION_INTERNAL(false)
+
+        CFGDEFDATA_OPTION_INDEX_TOTAL(1)
+        CFGDEFDATA_OPTION_SECURE(false)
+
+        CFGDEFDATA_OPTION_HELP_SECTION("general")
+        CFGDEFDATA_OPTION_HELP_SUMMARY("Execute a dry-run execution.")
+        CFGDEFDATA_OPTION_HELP_DESCRIPTION
+        (
+            "Do not change anything, simply show what the execution will be."
+        )
+
+        CFGDEFDATA_OPTION_COMMAND_LIST
+        (
+           CFGDEFDATA_OPTION_COMMAND(cfgDefCmdExpire)
+        )
+
+        CFGDEFDATA_OPTION_OPTIONAL_LIST
+        (
+            CFGDEFDATA_OPTION_OPTIONAL_DEFAULT("0")
+        )
+    )
+
 )

--- a/src/config/define.auto.h
+++ b/src/config/define.auto.h
@@ -150,6 +150,7 @@ typedef enum
     cfgDefOptTestDelay,
     cfgDefOptTestPoint,
     cfgDefOptType,
+    cfgDefOptDryRun,
 } ConfigDefineOption;
 
 #endif

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -2270,6 +2270,12 @@ static const struct option optionList[] =
         .has_arg = required_argument,
         .val = PARSE_OPTION_FLAG | cfgOptType,
     },
+    // dry-run option
+    // -----------------------------------------------------------------------------------------------------------------------------
+    {
+     .name = CFGOPT_DRY_RUN,
+     .val = PARSE_OPTION_FLAG | cfgOptDryRun,
+    },
     // Terminate option list
     {
         .name = NULL
@@ -2449,4 +2455,5 @@ static const ConfigOption optionResolveOrder[] =
     cfgOptTargetAction,
     cfgOptTargetExclusive,
     cfgOptTargetTimeline,
+    cfgOptDryRun,
 };


### PR DESCRIPTION
This is a possible implementation of the `expire --dry-run` as requested in issue #838 .
I've added a "global" `dry-run` option, since it could be useful for other commands.
In the `expire` implementation, I've wrapped the backup removal into a conditional against the value of the `dry-run` option.
Since this is my first attempt in implementing it, and I'm not sure that the option has been defined well, I will look for suggestions.

Tested on Fedora 30 against PostgreSQL 11.5