### PR TITLE
Clarify docs with upper version bound for Auto Stop

### DIFF
--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -606,6 +606,8 @@
 
                         This feature relies on pg_is_in_backup() so only works on <postgres/> >= <id>9.3</id>.
 
+                        This feature is not supported for <postgres/> >= <id>9.6</id> since backups are run in non-exclusive mode.
+
                         The setting is disabled by default because it assumes that <backrest/> is the only process doing exclusive online backups.  It depends on an advisory lock that only <backrest/> sets so it may abort other processes that do exclusive online backups.  Note that <cmd>base_backup</cmd> and <cmd>pg_dump</cmd> are safe to use with this setting because they do not call <code>pg_start_backup()</code> so are not exclusive.</text>
 
                         <example>y</example>

--- a/src/config/define.auto.c
+++ b/src/config/define.auto.c
@@ -4382,6 +4382,8 @@ static ConfigDefineOptionData configDefineOptionData[] = CFGDEFDATA_OPTION_LIST
             "\n"
             "This feature relies on pg_is_in_backup() so only works on PostgreSQL >= 9.3.\n"
             "\n"
+            "This feature is not supported for PostgreSQL >= 9.6 since backups are run in non-exclusive mode.\n"
+            "\n"
             "The setting is disabled by default because it assumes that pgBackRest is the only process doing exclusive online "
                 "backups. It depends on an advisory lock that only pgBackRest sets so it may abort other processes that do "
                 "exclusive online backups. Note that base_backup and pg_dump are safe to use with this setting because they do not "


### PR DESCRIPTION
This feature does not work with Postgres 9.6 or greater, but that is only mentioned in the internal comments in the code.  This seems like it should also be mentioned in the docs.
