### PR TITLE
Fix time datatype in InfoBackupData structure 

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -56,6 +56,16 @@
                         <p>The <cmd>check</cmd> command is implemented entirely in C.</p>
                     </release-item>
                 </release-improvement-list>
+
+                <release-development-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Modify <code>InfoBackupData</code> structure to use <code>time_t</code> data type for backup start/stop times for consistency.</p>
+                    </release-item>
+                </release-development-list>
             </release-core-list>
 
             <release-doc-list>

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -259,8 +259,8 @@ backupList(VariantList *backupSection, InfoBackup *info, const String *backupLab
         // timestamp section
         KeyValue *timeInfo = kvPutKv(varKv(backupInfo), BACKUP_KEY_TIMESTAMP_VAR);
 
-        kvAdd(timeInfo, KEY_START_VAR, VARUINT64(backupData.backupTimestampStart));
-        kvAdd(timeInfo, KEY_STOP_VAR, VARUINT64(backupData.backupTimestampStop));
+        kvAdd(timeInfo, KEY_START_VAR, VARUINT64((uint64_t)backupData.backupTimestampStart));
+        kvAdd(timeInfo, KEY_STOP_VAR, VARUINT64((uint64_t)backupData.backupTimestampStop));
 
         // If a backup label was specified and this is that label, then get the manifest
         if (backupLabel != NULL && strEq(backupData.backupLabel, backupLabel))

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -259,6 +259,7 @@ backupList(VariantList *backupSection, InfoBackup *info, const String *backupLab
         // timestamp section
         KeyValue *timeInfo = kvPutKv(varKv(backupInfo), BACKUP_KEY_TIMESTAMP_VAR);
 
+        // time_t is considered a signed int so cast it here to uint64 since it can never be negative (before 1970) in our system
         kvAdd(timeInfo, KEY_START_VAR, VARUINT64((uint64_t)backupData.backupTimestampStart));
         kvAdd(timeInfo, KEY_STOP_VAR, VARUINT64((uint64_t)backupData.backupTimestampStop));
 

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -147,6 +147,8 @@ infoBackupLoadCallback(void *data, const String *section, const String *key, con
                 .backupInfoSizeDelta = varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_DELTA_VAR)),
                 .backupLabel = strDup(key),
                 .backupPgId = cvtZToUInt(strPtr(varStrForce(kvGet(backupKv, INFO_KEY_DB_ID_VAR)))),
+
+                // When reading timestamps, read as uint64 to ensure always positive value (guarantee no backups before 1970)
                 .backupTimestampStart = (time_t)varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR)),
                 .backupTimestampStop= (time_t)varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR)),
                 .backupType = varStrForce(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TYPE_VAR)),
@@ -245,8 +247,10 @@ infoBackupSaveCallback(void *data, const String *sectionNext, InfoSave *infoSave
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_REPO_SIZE_DELTA_VAR, VARUINT64(backupData.backupInfoRepoSizeDelta));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_VAR, VARUINT64(backupData.backupInfoSize));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_DELTA_VAR, VARUINT64(backupData.backupInfoSizeDelta));
-            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR, VARUINT64((uint64_t)backupData.backupTimestampStart));
-            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR, VARUINT64((uint64_t)backupData.backupTimestampStop));
+
+            // When storing time_t treat as signed type
+            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR, VARINT64(backupData.backupTimestampStart));
+            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR, VARINT64(backupData.backupTimestampStop));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TYPE_VAR, VARSTR(backupData.backupType));
 
             kvPut(backupDataKv, INFO_BACKUP_KEY_OPT_ARCHIVE_CHECK_VAR, VARBOOL(backupData.optionArchiveCheck));

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -147,8 +147,8 @@ infoBackupLoadCallback(void *data, const String *section, const String *key, con
                 .backupInfoSizeDelta = varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_DELTA_VAR)),
                 .backupLabel = strDup(key),
                 .backupPgId = cvtZToUInt(strPtr(varStrForce(kvGet(backupKv, INFO_KEY_DB_ID_VAR)))),
-                .backupTimestampStart = varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR)),
-                .backupTimestampStop= varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR)),
+                .backupTimestampStart = (time_t)varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR)),
+                .backupTimestampStop= (time_t)varUInt64(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR)),
                 .backupType = varStrForce(kvGet(backupKv, INFO_BACKUP_KEY_BACKUP_TYPE_VAR)),
 
                 // Possible NULL values
@@ -245,8 +245,8 @@ infoBackupSaveCallback(void *data, const String *sectionNext, InfoSave *infoSave
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_REPO_SIZE_DELTA_VAR, VARUINT64(backupData.backupInfoRepoSizeDelta));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_VAR, VARUINT64(backupData.backupInfoSize));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_INFO_SIZE_DELTA_VAR, VARUINT64(backupData.backupInfoSizeDelta));
-            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR, VARUINT64(backupData.backupTimestampStart));
-            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR, VARUINT64(backupData.backupTimestampStop));
+            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_START_VAR, VARUINT64((uint64_t)backupData.backupTimestampStart));
+            kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TIMESTAMP_STOP_VAR, VARUINT64((uint64_t)backupData.backupTimestampStop));
             kvPut(backupDataKv, INFO_BACKUP_KEY_BACKUP_TYPE_VAR, VARSTR(backupData.backupType));
 
             kvPut(backupDataKv, INFO_BACKUP_KEY_OPT_ARCHIVE_CHECK_VAR, VARBOOL(backupData.optionArchiveCheck));
@@ -402,8 +402,8 @@ infoBackupDataAdd(const InfoBackup *this, const Manifest *manifest)
                 .backupInfoSize = backupSize,
                 .backupInfoSizeDelta = backupSizeDelta,
                 .backupPgId = manData->pgId,
-                .backupTimestampStart = (uint64_t)manData->backupTimestampStart,
-                .backupTimestampStop= (uint64_t)manData->backupTimestampStop,
+                .backupTimestampStart = manData->backupTimestampStart,
+                .backupTimestampStop= manData->backupTimestampStop,
                 .backupType = backupTypeStr(manData->backupType),
 
                 .backupArchiveStart = strDup(manData->archiveStart),

--- a/src/info/infoBackup.h
+++ b/src/info/infoBackup.h
@@ -45,8 +45,8 @@ typedef struct InfoBackupData
     unsigned int backupPgId;
     const String *backupPrior;
     StringList *backupReference;
-    uint64_t backupTimestampStart;                                  // ??? Need to fix this so it is time_t
-    uint64_t backupTimestampStop;                                   // ??? Need to fix this so it is time_t
+    time_t backupTimestampStart;
+    time_t backupTimestampStop;
     const String *backupType;
     bool optionArchiveCheck;
     bool optionArchiveCopy;


### PR DESCRIPTION
InfoBackupData structure had backup start and stop time members declared as uint64_t instead of time_t which was inconsistent with other timestamp declarations.