### PR TITLE
Skip vagrant disksize option if no plugin

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -8,7 +8,9 @@ Vagrant.configure(2) do |config|
     config.vm.box_version = "20180719.0.0"
 
     # vagrant plugin install vagrant-disksize
-    config.disksize.size = '64GB'
+    if Vagrant.has_plugin?('vagrant-disksize')
+      config.disksize.size = '64GB'
+    end
 
     config.vm.provider :virtualbox do |vb|
         vb.name = "pgbackrest-test"


### PR DESCRIPTION
Previously, `vagrant up` would bail if no `vagrant-disksize` plugin was
installed. This option is just a nice-to-have, so skip it rather than
bailing.