### PR TITLE
Fix detection of keepalive options on Linux

### DIFF
--- a/src/common/io/tls/client.c
+++ b/src/common/io/tls/client.c
@@ -16,6 +16,11 @@ TLS Client
 #include <netinet/in.h>
 #endif
 
+#ifdef __linux__
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#endif
+
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>

--- a/src/common/io/tls/client.c
+++ b/src/common/io/tls/client.c
@@ -619,7 +619,7 @@ tlsClientOpen(TlsClient *this)
                     int socketValue = 1;
 
                     THROW_ON_SYS_ERROR(
-                        setsockopt(this->socket, SOL_SOCKET, SO_KEEPALIVE, &socketValue, sizeof(int)) == -1, ProtocolError,
+                        setsockopt(this->socket, IPPROTO_TCP, SO_KEEPALIVE, &socketValue, sizeof(int)) == -1, ProtocolError,
                          "unable set SO_KEEPALIVE");
 
                     // Set per-connection keepalive options if they are available
@@ -627,18 +627,18 @@ tlsClientOpen(TlsClient *this)
                     socketValue = 3;
 
                     THROW_ON_SYS_ERROR(
-                        setsockopt(this->socket, SOL_SOCKET, TCP_KEEPIDLE, &socketValue, sizeof(int)) == -1, ProtocolError,
+                        setsockopt(this->socket, IPPROTO_TCP, TCP_KEEPCNT, &socketValue, sizeof(int)) == -1, ProtocolError,
+                         "unable set SO_KEEPCNT");
+
+		    socketValue = this->timeout / 4; /* first try + 3 failures to get to the timeout */
+
+		    THROW_ON_SYS_ERROR(
+                        setsockopt(this->socket, IPPROTO_TCP, TCP_KEEPIDLE, &socketValue, sizeof(int)) == -1, ProtocolError,
                          "unable set SO_KEEPIDLE");
 
                     THROW_ON_SYS_ERROR(
-                        setsockopt(this->socket, SOL_SOCKET, TCP_KEEPINTVL, &socketValue, sizeof(int)) == -1, ProtocolError,
+                        setsockopt(this->socket, IPPROTO_TCP, TCP_KEEPINTVL, &socketValue, sizeof(int)) == -1, ProtocolError,
                          "unable set SO_KEEPINTVL");
-
-                    socketValue = this->timeout / socketValue;
-
-                    THROW_ON_SYS_ERROR(
-                        setsockopt(this->socket, SOL_SOCKET, TCP_KEEPCNT, &socketValue, sizeof(int)) == -1, ProtocolError,
-                         "unable set SO_KEEPCNT");
 #endif
 
                     // Negotiate TLS


### PR DESCRIPTION
Hi,

keepalive was at 2 hours on Linux. That's because TCP_KEEPIDLE wasn't defined, as netinet/tcp.h wasn't included.

By the way, the SO_KEEPIDLE and SO_KEEPINTVL hard set at 3 seem weird, though they'll probably be ok most of the time.