### PR TITLE
Limit reads during backup to file size recorded in manifest.

### DIFF
--- a/doc/xml/contributing.xml
+++ b/doc/xml/contributing.xml
@@ -50,6 +50,7 @@
 * Before starting work on an existing on an issue create a card for it an move to "in progress".
 * If only a card exists then move it to "in progress" and covert the card to an issue (or reopen the original issues if it was closed when the card was created).
 * When submitting a PR link it to the original issue.
+* WHEN MOVE TO IN PROGRESS ADD OWNER
 
     <!-- ======================================================================================================================= -->
     <section id="environment">

--- a/doc/xml/contributing.xml
+++ b/doc/xml/contributing.xml
@@ -43,6 +43,14 @@
         <p>This documentation is intended to assist contributors to <backrest/> by outlining some basic steps and guidelines for contributing to the project.  Coding standards to follow are defined in <link url="{[github-url-master]}/CODING.md">CODING.md</link>. At a minimum, unit tests must be written and run and the documentation generated before submitting a Pull Request; see the <link section="/testing">Testing</link> section below for details.</p>
     </section>
 
+!!!
+
+*
+
+* Before starting work on an existing on an issue create a card for it an move to "in progress".
+* If only a card exists then move it to "in progress" and covert the card to an issue (or reopen the original issues if it was closed when the card was created).
+* When submitting a PR link it to the original issue.
+
     <!-- ======================================================================================================================= -->
     <section id="environment">
         <title>Building a Development Environment</title>


### PR DESCRIPTION
Files can grow or shrink during backups which is normal. However, we would prefer not to copy the portion of files that have grown since the manifest was built because that portion will contain all-new blocks that might be torn and will need to be tested to be sure they are in a valid range for the backup. So, we will limit reads to the size reported when the manifest was build and skip all the new blocks.  The blocks will be rewritten by Postgres during recovery so storing them also wastes space.

Also have a look at f2548f45ce4c1e44 since that's where the feature was added to the storage layer.