### PR TITLE
Improve performance of memResize().

### DIFF
--- a/src/common/memContext.c
+++ b/src/common/memContext.c
@@ -39,21 +39,11 @@ typedef struct MemContextAlloc
 
 // Make sure the allocation is valid for the current memory context.  This check only works correctly if the allocation is valid but
 // belongs to another context.  Otherwise, there is likely to be a segfault.
-#ifdef DEBUG
-    #define ASSERT_ALLOC_VALID(alloc)                                                                                              \
-        do                                                                                                                         \
-        {                                                                                                                          \
-            MemContext *memContext = memContextStack[memContextCurrentStackIdx].memContext;                                        \
-                                                                                                                                   \
-            ASSERT(alloc != NULL);                                                                                                 \
-            ASSERT(alloc != MEM_CONTEXT_ALLOC_HEADER(NULL));                                                                       \
-            ASSERT(alloc->allocIdx < memContext->allocListSize);                                                                   \
-            ASSERT(memContext->allocList[alloc->allocIdx] == alloc);                                                               \
-        }                                                                                                                          \
-        while (0)
-#else
-    #define ASSERT_ALLOC_VALID(memContext, alloc)
-#endif
+#define ASSERT_ALLOC_VALID(alloc)                                                                                                  \
+    ASSERT(                                                                                                                        \
+        alloc != NULL && alloc != MEM_CONTEXT_ALLOC_HEADER(NULL) &&                                                                \
+        alloc->allocIdx < memContextStack[memContextCurrentStackIdx].memContext->allocListSize &&                                  \
+        memContextStack[memContextCurrentStackIdx].memContext->allocList[alloc->allocIdx]);
 
 /***********************************************************************************************************************************
 Contains information about the memory context

--- a/test/src/module/common/memContextTest.c
+++ b/test/src/module/common/memContextTest.c
@@ -219,7 +219,8 @@ testRun(void)
         TEST_RESULT_VOID(memNew(3), "new allocation");
         TEST_RESULT_UINT(memContextCurrent()->allocFreeIdx, MEM_CONTEXT_ALLOC_INITIAL_SIZE + 3, "check alloc free idx");
 
-        TEST_ERROR(memFree(NULL), AssertError, "assertion 'buffer != NULL' failed");
+        TEST_ERROR(
+            memFree(NULL), AssertError, "assertion '((MemContextAlloc *)buffer - 1) != MEM_CONTEXT_ALLOC_HEADER(NULL)' failed");
         memFree(buffer);
 
         memContextSwitch(memContextTop());

--- a/test/src/module/common/memContextTest.c
+++ b/test/src/module/common/memContextTest.c
@@ -220,7 +220,13 @@ testRun(void)
         TEST_RESULT_UINT(memContextCurrent()->allocFreeIdx, MEM_CONTEXT_ALLOC_INITIAL_SIZE + 3, "check alloc free idx");
 
         TEST_ERROR(
-            memFree(NULL), AssertError, "assertion '((MemContextAlloc *)buffer - 1) != MEM_CONTEXT_ALLOC_HEADER(NULL)' failed");
+            memFree(NULL), AssertError,
+            "assertion '((MemContextAlloc *)buffer - 1) != NULL"
+                " && ((MemContextAlloc *)buffer - 1) != MEM_CONTEXT_ALLOC_HEADER(NULL)"
+                " && ((MemContextAlloc *)buffer - 1)->allocIdx <"
+                " memContextStack[memContextCurrentStackIdx].memContext->allocListSize"
+                " && memContextStack[memContextCurrentStackIdx].memContext->allocList[((MemContextAlloc *)buffer - 1)->allocIdx]'"
+                " failed");
         memFree(buffer);
 
         memContextSwitch(memContextTop());


### PR DESCRIPTION
The major bottleneck was finding the memory allocation to be resized since it required a sequential search through a list.

Instead, put the allocation header at the beginning of the allocation and return an offset to the user for their buffer. This allows us to use pointer arithmetic to get back to the allocation header quickly when resizing. A side effect is to make memFree() faster as well.  The downside is we won't detect garbage pointers passed to memResize()/memFree(), which is also true for MemContext pointers.

The performance benefits can be pretty large in certain cases, in particular when loading and saving manifests. The following are the before and after  performance tests on a 900K file manifest.

Before:
```
run 003 - manifestNewLoad()/manifestSave()
    000.000s l0125 - generate manifest
    183.411s l0236 -     101.2MB manifest generated with 900000 files
    183.411s l0239 - load manifest
    403.816s l0243 -     completed in 220405ms
    403.816s l0245 -        check file total
    403.816s l0248 - save manifest
    670.217s l0253 -     completed in 266401ms
    670.217s l0256 - find all files
    671.263s l0266 -     completed in 1046ms
```
After:
```
run 003 - manifestNewLoad()/manifestSave()
    000.000s l0125 - generate manifest
    007.730s l0236 -     101.2MB manifest generated with 900000 files
    007.730s l0239 - load manifest
    033.431s l0243 -     completed in 25701ms
    033.431s l0245 -        check file total
    033.431s l0248 - save manifest
    057.755s l0253 -     completed in 24324ms
    057.755s l0256 - find all files
    058.689s l0266 -     completed in 934ms
```