### PR TITLE
Expire test refactor to replace unnecessary disk writes/reads to speed testing.

### DIFF
--- a/test/define.yaml
+++ b/test/define.yaml
@@ -600,6 +600,9 @@ unit:
         coverage:
           command/expire/expire: full
 
+        include:
+          - info/infoBackup
+
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: help
         total: 4

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -1,6 +1,7 @@
 /***********************************************************************************************************************************
 Test Expire Command
 ***********************************************************************************************************************************/
+#include "common/io/bufferRead.h"
 #include "storage/posix/storage.h"
 
 #include "common/harnessConfig.h"
@@ -83,74 +84,79 @@ testRun(void)
     StringList *argListAvoidWarn = strLstDup(argListBase);
     strLstAddZ(argListAvoidWarn, "--repo1-retention-full=1");  // avoid warning
 
-    String *backupInfoBase = strNew(
-             "[backup:current]\n"
-            "20181119-152138F={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
-            "\"backup-archive-start\":\"000000010000000000000002\",\"backup-archive-stop\":\"000000010000000000000002\","
-            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
-            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
-            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "20181119-152800F={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
-            "\"backup-archive-start\":\"000000010000000000000004\",\"backup-archive-stop\":\"000000010000000000000004\","
-            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
-            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
-            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "20181119-152800F_20181119-152152D={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000005\","
-            "\"backup-archive-stop\":\"000000010000000000000005\",\"backup-info-repo-size\":2369186,"
-            "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
-            "\"backup-prior\":\"20181119-152800F\",\"backup-reference\":[\"20181119-152800F\"],"
-            "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"diff\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "20181119-152800F_20181119-152155I={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000006\","
-            "\"backup-archive-stop\":\"000000010000000000000006\",\"backup-info-repo-size\":2369186,"
-            "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
-            "\"backup-prior\":\"20181119-152800F_20181119-152152D\","
-            "\"backup-reference\":[\"20181119-152800F\",\"20181119-152800F_20181119-152152D\"],"
-            "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"incr\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "20181119-152900F={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
-            "\"backup-archive-start\":\"000000010000000000000007\",\"backup-archive-stop\":\"000000010000000000000007\","
-            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
-            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
-            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "20181119-152900F_20181119-152600D={"
-            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000008\","
-            "\"backup-archive-stop\":\"000000010000000000000008\",\"backup-info-repo-size\":2369186,"
-            "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
-            "\"backup-prior\":\"20181119-152138F\",\"backup-reference\":[\"20181119-152900F\"],"
-            "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"diff\","
-            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-            "\n"
-            "[db]\n"
-            "db-catalog-version=201409291\n"
-            "db-control-version=942\n"
-            "db-id=1\n"
-            "db-system-id=6625592122879095702\n"
-            "db-version=\"9.4\"\n"
-            "\n"
-            "[db:history]\n"
-            "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
-                "\"db-version\":\"9.4\"}");
+    const Buffer *backupInfoBase = harnessInfoChecksumZ
+    (
+         "[backup:current]\n"
+        "20181119-152138F={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
+        "\"backup-archive-start\":\"000000010000000000000002\",\"backup-archive-stop\":\"000000010000000000000002\","
+        "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
+        "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
+        "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "20181119-152800F={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
+        "\"backup-archive-start\":\"000000010000000000000004\",\"backup-archive-stop\":\"000000010000000000000004\","
+        "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
+        "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
+        "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "20181119-152800F_20181119-152152D={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000005\","
+        "\"backup-archive-stop\":\"000000010000000000000005\",\"backup-info-repo-size\":2369186,"
+        "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
+        "\"backup-prior\":\"20181119-152800F\",\"backup-reference\":[\"20181119-152800F\"],"
+        "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"diff\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "20181119-152800F_20181119-152155I={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000006\","
+        "\"backup-archive-stop\":\"000000010000000000000006\",\"backup-info-repo-size\":2369186,"
+        "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
+        "\"backup-prior\":\"20181119-152800F_20181119-152152D\","
+        "\"backup-reference\":[\"20181119-152800F\",\"20181119-152800F_20181119-152152D\"],"
+        "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"incr\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "20181119-152900F={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
+        "\"backup-archive-start\":\"000000010000000000000007\",\"backup-archive-stop\":\"000000010000000000000007\","
+        "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
+        "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
+        "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "20181119-152900F_20181119-152600D={"
+        "\"backrest-format\":5,\"backrest-version\":\"2.08dev\",\"backup-archive-start\":\"000000010000000000000008\","
+        "\"backup-archive-stop\":\"000000010000000000000008\",\"backup-info-repo-size\":2369186,"
+        "\"backup-info-repo-size-delta\":346,\"backup-info-size\":20162900,\"backup-info-size-delta\":8428,"
+        "\"backup-prior\":\"20181119-152138F\",\"backup-reference\":[\"20181119-152900F\"],"
+        "\"backup-timestamp-start\":1542640912,\"backup-timestamp-stop\":1542640915,\"backup-type\":\"diff\","
+        "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+        "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+        "\n"
+        "[db]\n"
+        "db-catalog-version=201409291\n"
+        "db-control-version=942\n"
+        "db-id=1\n"
+        "db-system-id=6625592122879095702\n"
+        "db-version=\"9.4\"\n"
+        "\n"
+        "[db:history]\n"
+        "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
+            "\"db-version\":\"9.4\"}"
+    );
 
     // *****************************************************************************************************************************
     if (testBegin("expireBackup()"))
     {
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("manifest file removal");
+
         // Create backup.info
-        storagePutP(storageNewWriteP(storageTest, backupInfoFileName), harnessInfoChecksum(backupInfoBase));
+        TEST_RESULT_VOID(storagePutP(storageNewWriteP(storageTest, backupInfoFileName), backupInfoBase), "write backup.info");
 
         InfoBackup *infoBackup = NULL;
         TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
@@ -184,7 +190,7 @@ testRun(void)
         TEST_RESULT_VOID(expireBackup(infoBackup, full1, backupExpired), "expire backup with both manifest files");
         TEST_RESULT_BOOL(
             (strLstSize(storageListP(storageTest, full1Path)) && strLstExistsZ(storageListP(storageTest, full1Path), "bogus")),
-            true, "  full1 - only manifest files removed");
+            true, "full1 - only manifest files removed");
 
         TEST_RESULT_VOID(expireBackup(infoBackup, full2, backupExpired), "expire backup with no manifest - does not error");
 
@@ -199,10 +205,11 @@ testRun(void)
     if (testBegin("expireFullBackup()"))
     {
         // Create backup.info
-        storagePutP(storageNewWriteP(storageTest, backupInfoFileName), harnessInfoChecksum(backupInfoBase));
-
         InfoBackup *infoBackup = NULL;
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoBase)), "get backup.info");
+
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-full not set - nothing expired");
 
         // Load Parameters
         StringList *argList = strLstDup(argListBase);
@@ -215,33 +222,39 @@ testRun(void)
             "set option 'repo1-retention-full' to the maximum.");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-full set - full backup no dependencies expired");
+
         strLstAddZ(argList, "--repo1-retention-full=2");
         harnessCfgLoad(cfgCmdExpire, argList);
 
         TEST_RESULT_UINT(expireFullBackup(infoBackup), 1, "retention-full=2 - one full backup expired");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 5, "  current backups reduced by 1 full - no dependencies");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 5, "current backups reduced by 1 full - no dependencies");
         TEST_RESULT_STR_Z(
             strLstJoin(infoBackupDataLabelList(infoBackup, NULL), ", "),
             "20181119-152800F, 20181119-152800F_20181119-152152D, 20181119-152800F_20181119-152155I"
                 ", 20181119-152900F, 20181119-152900F_20181119-152600D",
-            "  remaining backups correct");
+            "remaining backups correct");
         harnessLogResult("P00   INFO: expire full backup 20181119-152138F");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-full set - full backup with dependencies expired");
+
         argList = strLstDup(argListBase);
         strLstAddZ(argList, "--repo1-retention-full=1");
         harnessCfgLoad(cfgCmdExpire, argList);
 
         TEST_RESULT_UINT(expireFullBackup(infoBackup), 3, "retention-full=1 - one full backup and dependencies expired");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "  current backups reduced by 1 full and dependencies");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "current backups reduced by 1 full and dependencies");
         TEST_RESULT_STR_Z(
             strLstJoin(infoBackupDataLabelList(infoBackup, NULL), ", "), "20181119-152900F, 20181119-152900F_20181119-152600D",
-            "  remaining backups correct");
+            "remaining backups correct");
         harnessLogResult(
             "P00   INFO: expire full backup set: 20181119-152800F, 20181119-152800F_20181119-152152D, "
             "20181119-152800F_20181119-152155I");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-full set - no backups expired");
+
         TEST_RESULT_UINT(expireFullBackup(infoBackup), 0, "retention-full=1 - not enough backups to expire any");
         TEST_RESULT_STR_Z(
             strLstJoin(infoBackupDataLabelList(infoBackup, NULL), ", "), "20181119-152900F, 20181119-152900F_20181119-152600D",
@@ -252,44 +265,51 @@ testRun(void)
     if (testBegin("expireDiffBackup()"))
     {
         // Create backup.info
-        storagePutP(storageNewWriteP(storageTest, backupInfoFileName), harnessInfoChecksum(backupInfoBase));
-
         InfoBackup *infoBackup = NULL;
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoBase)), "get backup.info");
+
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-diff not set");
 
         // Load Parameters
         StringList *argList = strLstDup(argListAvoidWarn);
         harnessCfgLoad(cfgCmdExpire, argList);
 
         TEST_RESULT_UINT(expireDiffBackup(infoBackup), 0, "retention-diff not set - nothing expired");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 6, "  current backups not expired");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 6, "current backups not expired");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-diff set - nothing yet to expire");
+
         // Add retention-diff
         StringList *argListTemp = strLstDup(argList);
         strLstAddZ(argListTemp, "--repo1-retention-diff=6");
         harnessCfgLoad(cfgCmdExpire, argListTemp);
 
         TEST_RESULT_UINT(expireDiffBackup(infoBackup), 0, "retention-diff set - too soon to expire");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 6, "  current backups not expired");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 6, "current backups not expired");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-diff set - diff and dependent incr expired");
+
         strLstAddZ(argList, "--repo1-retention-diff=2");
         harnessCfgLoad(cfgCmdExpire, argList);
 
-        TEST_RESULT_UINT(expireDiffBackup(infoBackup), 2, "retention-diff set - full considered in diff");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 4, "  current backups reduced by 1 diff and dependent increment");
+        TEST_RESULT_UINT(expireDiffBackup(infoBackup), 2, "retention-diff=2 - full considered in diff");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 4, "current backups reduced by 1 diff and dependent increment");
         TEST_RESULT_STR_Z(
             strLstJoin(infoBackupDataLabelList(infoBackup, NULL), ", "),
             "20181119-152138F, 20181119-152800F, 20181119-152900F, 20181119-152900F_20181119-152600D",
-            "  remaining backups correct");
+            "remaining backups correct");
         harnessLogResult(
             "P00   INFO: expire diff backup set: 20181119-152800F_20181119-152152D, 20181119-152800F_20181119-152155I");
 
         TEST_RESULT_UINT(expireDiffBackup(infoBackup), 0, "retention-diff=2 but no more to expire");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 4, "  current backups not reduced");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 4, "current backups not reduced");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-diff set - diff with no dependents expired");
+
         // Create backup.info with two diff - oldest to be expired - no "set:"
         storagePutP(
             storageNewWriteP(storageTest, backupInfoFileName),
@@ -338,10 +358,10 @@ testRun(void)
         harnessCfgLoad(cfgCmdExpire, argList);
 
         TEST_RESULT_UINT(expireDiffBackup(infoBackup), 1, "retention-diff set - only oldest diff expired");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "  current backups reduced by one");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "current backups reduced by one");
         TEST_RESULT_STR_Z(
             strLstJoin(infoBackupDataLabelList(infoBackup, NULL), ", "), "20181119-152800F, 20181119-152800F_20181119-152155D",
-            "  remaining backups correct");
+            "remaining backups correct");
         harnessLogResult(
             "P00   INFO: expire diff backup 20181119-152800F_20181119-152152D");
     }
@@ -349,6 +369,9 @@ testRun(void)
     // *****************************************************************************************************************************
     if (testBegin("removeExpiredBackup()"))
     {
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("remove expired backup from disk - backup not in current backup");
+
         // Create backup.info
         storagePutP(
             storageNewWriteP(storageTest, backupInfoFileName),
@@ -410,9 +433,11 @@ testRun(void)
         TEST_RESULT_STR_Z(
             strLstJoin(strLstSort(storageListP(storageTest, backupStanzaPath), sortOrderAsc), ", "),
             "20181118-152100F_20181119-152152D.save, 20181119-152138F, backup.info, bogus",
-            "  remaining file/directories correct");
+            "remaining file/directories correct");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("remove expired backup from disk - no current backups");
+
         // Create backup.info without current backups
         storagePutP(
             storageNewWriteP(storageTest, backupInfoFileName),
@@ -428,19 +453,22 @@ testRun(void)
                 "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
                     "\"db-version\":\"9.4\"}"));
 
-        TEST_ASSIGN(infoBackup,infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
 
         TEST_RESULT_VOID(removeExpiredBackup(infoBackup), "remove backups - backup.info current empty");
 
         harnessLogResult("P00   INFO: remove expired backup 20181119-152138F");
         TEST_RESULT_STR_Z(
             strLstJoin(strLstSort(storageListP(storageTest, backupStanzaPath), sortOrderAsc), ", "),
-            "20181118-152100F_20181119-152152D.save, backup.info, bogus", "  remaining file/directories correct");
+            "20181118-152100F_20181119-152152D.save, backup.info, bogus", "remaining file/directories correct");
     }
 
     // *****************************************************************************************************************************
     if (testBegin("removeExpiredArchive() & cmdExpire()"))
     {
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive not set");
+
         // Load Parameters
         StringList *argList = strLstDup(argListBase);
         harnessCfgLoad(cfgCmdExpire, argList);
@@ -471,6 +499,8 @@ testRun(void)
             "P00   INFO: option 'repo1-retention-archive' is not set - archive logs will not be expired");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive set - no current backups");
+
         // Set archive retention, archive retention type default but no current backups - code path test
         strLstAddZ(argList, "--repo1-retention-archive=4");
         harnessCfgLoad(cfgCmdExpire, argList);
@@ -482,6 +512,8 @@ testRun(void)
             "set option 'repo1-retention-full' to the maximum.");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive set - no archive on disk");
+
         // Create backup.info with current backups spread over different timelines
         storagePutP(storageNewWriteP(storageTest, backupInfoFileName),
             harnessInfoChecksumZ(
@@ -574,6 +606,8 @@ testRun(void)
         TEST_RESULT_VOID(removeExpiredArchive(infoBackup), "no archive on disk");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive set - remove archives across timelines");
+
         archiveGenerate(storageTest, archiveStanzaPath, 1, 10, "9.4-1", "0000000100000000");
         archiveGenerate(storageTest, archiveStanzaPath, 1, 10, "9.4-1", "0000000200000000");
         archiveGenerate(storageTest, archiveStanzaPath, 1, 10, "10-2", "0000000100000000");
@@ -583,22 +617,24 @@ testRun(void)
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(2, 10, "0000000100000000"), "  only 9.4-1/0000000100000000/000000010000000000000001 removed");
+            archiveExpectList(2, 10, "0000000100000000"), "only 9.4-1/0000000100000000/000000010000000000000001 removed");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000200000000")), sortOrderAsc), ", "),
             archiveExpectList(1, 10, "0000000200000000"),
-            "  none removed from 9.4-1/0000000200000000 - crossing timelines to play through PITR");
+            "none removed from 9.4-1/0000000200000000 - crossing timelines to play through PITR");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(3, 10, "0000000100000000"),
-            "  000000010000000000000001 and 000000010000000000000002 removed from 10-2/0000000100000000");
+            "000000010000000000000001 and 000000010000000000000002 removed from 10-2/0000000100000000");
         harnessLogResult(
             "P00   INFO: full backup total < 4 - using oldest full backup for 9.4-1 archive retention\n"
             "P00   INFO: full backup total < 4 - using oldest full backup for 10-2 archive retention");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive set - latest archive not expired");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=2");
         harnessCfgLoad(cfgCmdExpire, argList);
@@ -609,19 +645,21 @@ testRun(void)
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 2, "0000000100000000"),
-            "  only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
+            "only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000200000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 10, "0000000200000000"),
-            "  only 9.4-1/0000000200000000/000000010000000000000001 removed from major wal 2");
+            "only 9.4-1/0000000200000000/000000010000000000000001 removed from major wal 2");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(3, 10, "0000000100000000"),
-            "  none removed from 10-2/0000000100000000");
+            "none removed from 10-2/0000000100000000");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive set to lowest - keep PITR for each archiveId");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=1");
         harnessCfgLoad(cfgCmdExpire, argList);
@@ -632,18 +670,20 @@ testRun(void)
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 2, "0000000100000000"),
-            "  only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
+            "only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000200000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 10, "0000000200000000"),
-            "  nothing removed from 9.4-1/0000000200000000 major wal 2 - each archiveId must have one backup to play through PITR");
+            "nothing removed from 9.4-1/0000000200000000 major wal 2 - each archiveId must have one backup to play through PITR");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(3, 10, "0000000100000000"), "  none removed from 10-2/0000000100000000");
+            archiveExpectList(3, 10, "0000000100000000"), "none removed from 10-2/0000000100000000");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive, retention-archive-type=diff, retention-diff set");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=2");
         strLstAddZ(argList, "--repo1-retention-archive-type=diff");
@@ -667,17 +707,19 @@ testRun(void)
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 2, "0000000100000000"),
-            "  only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
+            "only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000200000000")), sortOrderAsc), ", "),
-            result, "  all in-between removed from 9.4-1/0000000200000000 major wal 2 - last backup able to play through PITR");
+            result, "all in-between removed from 9.4-1/0000000200000000 major wal 2 - last backup able to play through PITR");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(3, 10, "0000000100000000"), "  none removed from 10-2/0000000100000000");
+            archiveExpectList(3, 10, "0000000100000000"), "none removed from 10-2/0000000100000000");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive, retention-archive-type=incr");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=4");
         strLstAddZ(argList, "--repo1-retention-archive-type=incr");
@@ -700,17 +742,19 @@ testRun(void)
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(2, 2, "0000000100000000"),
-            "  only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
+            "only 9.4-1/0000000100000000/000000010000000000000002 remains in major wal 1");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000200000000")), sortOrderAsc), ", "),
-            result, "  incremental and after remain in 9.4-1/0000000200000000 major wal 2");
+            result, "incremental and after remain in 9.4-1/0000000200000000 major wal 2");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(3, 10, "0000000100000000"), "  none removed from 10-2/0000000100000000");
+            archiveExpectList(3, 10, "0000000100000000"), "none removed from 10-2/0000000100000000");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire command - dry run");
+
         argList = strLstDup(argListBase);
         strLstAddZ(argList, "--repo1-retention-full=2");
         strLstAddZ(argList, "--repo1-retention-diff=3");
@@ -745,10 +789,10 @@ testRun(void)
         TEST_RESULT_VOID(cmdExpire(), "expire (dry-run) do not remove last backup in archive sub path or sub path");
         TEST_RESULT_BOOL(
             storagePathExistsP(storageTest, strNewFmt("%s/%s", strPtr(archiveStanzaPath), "9.4-1/0000000100000000")),
-            true, "  archive sub path not removed");
+            true, "archive sub path not removed");
         TEST_RESULT_BOOL(
             storageExistsP(storageTest, strNewFmt("%s/20181119-152138F/" BACKUP_MANIFEST_FILE, strPtr(backupStanzaPath))),
-            true, "  backup not removed");
+            true, "backup not removed");
         harnessLogResult(
             "P00   INFO: [DRY-RUN] expire full backup 20181119-152138F\n"
             "P00   INFO: [DRY-RUN] remove expired backup 20181119-152138F");
@@ -762,6 +806,8 @@ testRun(void)
             storageNewWriteP(storageTest, strNewFmt("%s%s", strPtr(archiveInfoFileName), ".save")));
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire via backup command");
+
         argList = strLstDup(argListBase);
         strLstAddZ(argList, "--repo1-retention-full=2");
         strLstAddZ(argList, "--repo1-retention-diff=3");
@@ -773,12 +819,14 @@ testRun(void)
         TEST_RESULT_VOID(cmdExpire(), "via backup command: expire last backup in archive sub path and remove sub path");
         TEST_RESULT_BOOL(
             storagePathExistsP(storageTest, strNewFmt("%s/%s", strPtr(archiveStanzaPath), "9.4-1/0000000100000000")),
-            false, "  archive sub path removed");
+            false, "archive sub path removed");
         harnessLogResult(
             "P00   INFO: expire full backup 20181119-152138F\n"
             "P00   INFO: remove expired backup 20181119-152138F");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire command - no dry run");
+
         argList = strLstDup(argListBase);
         strLstAddZ(argList, "--repo1-retention-full=2");
         strLstAddZ(argList, "--repo1-retention-diff=3");
@@ -803,12 +851,14 @@ testRun(void)
         TEST_RESULT_VOID(cmdExpire(), "expire last backup in archive sub path and remove sub path");
         TEST_RESULT_BOOL(
             storagePathExistsP(storageTest, strNewFmt("%s/%s", strPtr(archiveStanzaPath), "9.4-1/0000000100000000")),
-            false, "  archive sub path removed");
+            false, "archive sub path removed");
         harnessLogResult(
             "P00   INFO: expire full backup 20181119-152138F\n"
             "P00   INFO: remove expired backup 20181119-152138F");
 
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire command - dry run: archive and backups not removed");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=1");
         strLstAddZ(argList, "--dry-run");
@@ -817,7 +867,7 @@ testRun(void)
         TEST_RESULT_VOID(cmdExpire(), "expire (dry-run) - log expired backups and archive path to remove");
         TEST_RESULT_BOOL(
             storagePathExistsP(storageTest, strNewFmt("%s/%s", strPtr(archiveStanzaPath), "9.4-1")),
-            true, "  archive path not removed");
+            true, "archive path not removed");
         TEST_RESULT_BOOL(
             (storageExistsP(storageTest, strNewFmt("%s/20181119-152800F/" BACKUP_MANIFEST_FILE, strPtr(backupStanzaPath))) &&
             storageExistsP(
@@ -826,7 +876,7 @@ testRun(void)
                 storageTest, strNewFmt("%s/20181119-152800F_20181119-152155I/" BACKUP_MANIFEST_FILE, strPtr(backupStanzaPath))) &&
             storageExistsP(
                 storageTest, strNewFmt("%s/20181119-152800F_20181119-152252D/" BACKUP_MANIFEST_FILE, strPtr(backupStanzaPath)))),
-            true, "  backup not removed");
+            true, "backup not removed");
         harnessLogResult(strPtr(strNewFmt(
             "P00   INFO: [DRY-RUN] expire full backup set: 20181119-152800F, 20181119-152800F_20181119-152152D, "
             "20181119-152800F_20181119-152155I, 20181119-152800F_20181119-152252D\n"
@@ -836,6 +886,9 @@ testRun(void)
             "P00   INFO: [DRY-RUN] remove expired backup 20181119-152800F\n"
             "P00   INFO: [DRY-RUN] remove archive path: %s/%s/9.4-1", testPath(), strPtr(archiveStanzaPath))));
 
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire via backup command - archive and backups removed");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=1");
         strLstAdd(argList, strNewFmt("--pg1-path=%s/pg", testPath()));
@@ -844,7 +897,7 @@ testRun(void)
         TEST_RESULT_VOID(cmdExpire(), "via backup command: expire backups and remove archive path");
         TEST_RESULT_BOOL(
             storagePathExistsP(storageTest, strNewFmt("%s/%s", strPtr(archiveStanzaPath), "9.4-1")),
-            false, "  archive path removed");
+            false, "archive path removed");
 
         harnessLogResult(strPtr(strNewFmt(
             "P00   INFO: expire full backup set: 20181119-152800F, 20181119-152800F_20181119-152152D, "
@@ -855,11 +908,14 @@ testRun(void)
             "P00   INFO: remove expired backup 20181119-152800F\n"
             "P00   INFO: remove archive path: %s/%s/9.4-1", testPath(), strPtr(archiveStanzaPath))));
 
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "  get backup.info");
-        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "  backup.info updated on disk");
+        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_RESULT_UINT(infoBackupDataTotal(infoBackup), 2, "backup.info updated on disk");
         TEST_RESULT_STR_Z(
             strLstJoin(strLstSort(infoBackupDataLabelList(infoBackup, NULL), sortOrderAsc), ", "),
-            "20181119-152900F, 20181119-152900F_20181119-152500I", "  remaining current backups correct");
+            "20181119-152900F, 20181119-152900F_20181119-152500I", "remaining current backups correct");
+
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("expire command - archive removed");
 
         archiveGenerate(storageTest, archiveStanzaPath, 1, 1, "9.4-1", "0000000100000000");
         argList = strLstDup(argListAvoidWarn);
@@ -915,6 +971,9 @@ testRun(void)
 
         archiveGenerate(storageTest, archiveStanzaPath, 1, 5, "9.4-1", "0000000100000000");
 
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention backup no archive-start");
+
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=2");
         strLstAddZ(argList, "--repo1-retention-archive-type=full");
@@ -925,7 +984,10 @@ testRun(void)
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(1, 5, "0000000100000000"), "  nothing removed from 9.4-1/0000000100000000");
+            archiveExpectList(1, 5, "0000000100000000"), "nothing removed from 9.4-1/0000000100000000");
+
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("retention-archive-type=incr");
 
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=4");
@@ -937,9 +999,12 @@ testRun(void)
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "9.4-1", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(2, 5, "0000000100000000"), "  only removed archive prior to first full");
+            archiveExpectList(2, 5, "0000000100000000"), "only removed archive prior to first full");
         harnessLogResult(
             "P00   INFO: full backup total < 4 - using oldest full backup for 9.4-1 archive retention");
+
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("prior backup has no archive-start");
 
         argList = strLstDup(argListAvoidWarn);
         strLstAddZ(argList, "--repo1-retention-archive=1");
@@ -960,13 +1025,14 @@ testRun(void)
     // *****************************************************************************************************************************
     if (testBegin("info files mismatch"))
     {
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("archive.info has only current db with different db history id as backup.info");
+
         // Load Parameters
         StringList *argList = strLstDup(argListBase);
         strLstAddZ(argList, "--repo1-retention-full=2");
         harnessCfgLoad(cfgCmdExpire, argList);
 
-        // archive.info has only current db with different db history id as backup.info
-        //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(storageNewWriteP(storageTest, backupInfoFileName),
             harnessInfoChecksumZ(
                 "[backup:current]\n"
@@ -1043,14 +1109,15 @@ testRun(void)
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-1", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(1, 7, "0000000100000000"), "  none removed from 10-1/0000000100000000");
+            archiveExpectList(1, 7, "0000000100000000"), "none removed from 10-1/0000000100000000");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(1, 7, "0000000100000000"), "  none removed from 10-2/0000000100000000");
+            archiveExpectList(1, 7, "0000000100000000"), "none removed from 10-2/0000000100000000");
 
-        // archive.info old history db system id not the same as backup.info
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("archive.info old history db system id not the same as backup.info");
+
         storagePutP(
             storageNewWriteP(storageTest, archiveInfoFileName),
             harnessInfoChecksumZ(
@@ -1065,8 +1132,9 @@ testRun(void)
 
         TEST_ERROR(cmdExpire(), FormatError, "archive expiration cannot continue - archive and backup history lists do not match");
 
-        // archive.info old history db version not the same as backup.info
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("archive.info old history db version not the same as backup.info");
+
         storagePutP(
             storageNewWriteP(storageTest, archiveInfoFileName),
             harnessInfoChecksumZ(
@@ -1081,8 +1149,9 @@ testRun(void)
 
         TEST_ERROR(cmdExpire(), FormatError, "archive expiration cannot continue - archive and backup history lists do not match");
 
-        // archive.info has only current db with same db history id as backup.info
         //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("archive.info has only current db with same db history id as backup.info");
+
         storagePutP(storageNewWriteP(storageTest, backupInfoFileName),
             harnessInfoChecksumZ(
                 "[backup:current]\n"
@@ -1164,17 +1233,20 @@ testRun(void)
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-1", "0000000100000000")), sortOrderAsc), ", "),
-            archiveExpectList(1, 7, "0000000100000000"), "  none removed from 10-1/0000000100000000");
+            archiveExpectList(1, 7, "0000000100000000"), "none removed from 10-1/0000000100000000");
         TEST_RESULT_STR(
             strLstJoin(strLstSort(storageListP(
                 storageTest, strNewFmt("%s/%s/%s", strPtr(archiveStanzaPath), "10-2", "0000000100000000")), sortOrderAsc), ", "),
             archiveExpectList(6, 7, "0000000100000000"),
-            "  all prior to 000000010000000000000006 removed from 10-2/0000000100000000");
+            "all prior to 000000010000000000000006 removed from 10-2/0000000100000000");
     }
 
     // *****************************************************************************************************************************
     if (testBegin("archiveIdComparator()"))
     {
+        //--------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("archiveId comparator sorting");
+
         StringList *list = strLstNewParam(archiveIdComparator);
 
         strLstAddZ(list, "10-4");

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -311,9 +311,8 @@ testRun(void)
         TEST_TITLE("retention-diff set - diff with no dependents expired");
 
         // Create backup.info with two diff - oldest to be expired - no "set:"
-        storagePutP(
-            storageNewWriteP(storageTest, backupInfoFileName),
-            harnessInfoChecksumZ(
+        const Buffer *backupInfoContent = harnessInfoChecksumZ
+        (
             "[backup:current]\n"
             "20181119-152800F={"
             "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
@@ -349,8 +348,10 @@ testRun(void)
             "\n"
             "[db:history]\n"
             "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
-                "\"db-version\":\"9.4\"}"));
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+                "\"db-version\":\"9.4\"}"
+        );
+
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoContent)), "get backup.info");
 
         // Load parameters
         argList = strLstDup(argListAvoidWarn);
@@ -376,25 +377,25 @@ testRun(void)
         storagePutP(
             storageNewWriteP(storageTest, backupInfoFileName),
             harnessInfoChecksumZ(
-                "[backup:current]\n"
-                "20181119-152138F={"
-                "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
-                "\"backup-archive-start\":\"000000010000000000000002\",\"backup-archive-stop\":\"000000010000000000000002\","
-                "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
-                "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
-                "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
-                "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
-                "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
-                "\n"
-                "[db]\n"
-                "db-catalog-version=201409291\n"
-                "db-control-version=942\n"
-                "db-id=1\n"
-                "db-system-id=6625592122879095702\n"
-                "db-version=\"9.4\"\n"
-                "\n"
-                "[db:history]\n"
-                "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
+            "[backup:current]\n"
+            "20181119-152138F={"
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
+            "\"backup-archive-start\":\"000000010000000000000002\",\"backup-archive-stop\":\"000000010000000000000002\","
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+            "\n"
+            "[db]\n"
+            "db-catalog-version=201409291\n"
+            "db-control-version=942\n"
+            "db-id=1\n"
+            "db-system-id=6625592122879095702\n"
+            "db-version=\"9.4\"\n"
+            "\n"
+            "[db:history]\n"
+            "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
                     "\"db-version\":\"9.4\"}"));
 
         InfoBackup *infoBackup = NULL;
@@ -439,21 +440,21 @@ testRun(void)
         TEST_TITLE("remove expired backup from disk - no current backups");
 
         // Create backup.info without current backups
-        storagePutP(
-            storageNewWriteP(storageTest, backupInfoFileName),
-            harnessInfoChecksumZ(
-                "[db]\n"
-                "db-catalog-version=201409291\n"
-                "db-control-version=942\n"
-                "db-id=1\n"
-                "db-system-id=6625592122879095702\n"
-                "db-version=\"9.4\"\n"
-                "\n"
-                "[db:history]\n"
-                "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
-                    "\"db-version\":\"9.4\"}"));
+        const Buffer *backupInfoContent = harnessInfoChecksumZ
+        (
+            "[db]\n"
+            "db-catalog-version=201409291\n"
+            "db-control-version=942\n"
+            "db-id=1\n"
+            "db-system-id=6625592122879095702\n"
+            "db-version=\"9.4\"\n"
+            "\n"
+            "[db:history]\n"
+            "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
+                "\"db-version\":\"9.4\"}"
+        );
 
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoContent)), "get backup.info");
 
         TEST_RESULT_VOID(removeExpiredBackup(infoBackup), "remove backups - backup.info current empty");
 
@@ -474,22 +475,22 @@ testRun(void)
         harnessCfgLoad(cfgCmdExpire, argList);
 
         // Create backup.info without current backups
-        storagePutP(
-            storageNewWriteP(storageTest, backupInfoFileName),
-            harnessInfoChecksumZ(
-                "[db]\n"
-                "db-catalog-version=201409291\n"
-                "db-control-version=942\n"
-                "db-id=1\n"
-                "db-system-id=6625592122879095702\n"
-                "db-version=\"9.4\"\n"
-                "\n"
-                "[db:history]\n"
-                "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
-                    "\"db-version\":\"9.4\"}"));
+        const Buffer *backupInfoContent = harnessInfoChecksumZ
+        (
+            "[db]\n"
+            "db-catalog-version=201409291\n"
+            "db-control-version=942\n"
+            "db-id=1\n"
+            "db-system-id=6625592122879095702\n"
+            "db-version=\"9.4\"\n"
+            "\n"
+            "[db:history]\n"
+            "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702,"
+                "\"db-version\":\"9.4\"}"
+        );
 
         InfoBackup *infoBackup = NULL;
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoContent)), "get backup.info");
 
         TEST_RESULT_VOID(removeExpiredArchive(infoBackup), "archive retention not set");
         harnessLogResult(

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -156,10 +156,8 @@ testRun(void)
         TEST_TITLE("manifest file removal");
 
         // Create backup.info
-        TEST_RESULT_VOID(storagePutP(storageNewWriteP(storageTest, backupInfoFileName), backupInfoBase), "write backup.info");
-
         InfoBackup *infoBackup = NULL;
-        TEST_ASSIGN(infoBackup, infoBackupLoadFile(storageTest, backupInfoFileName, cipherTypeNone, NULL), "get backup.info");
+        TEST_ASSIGN(infoBackup, infoBackupNewLoad(ioBufferReadNew(backupInfoBase)), "get backup.info");
 
         // Create backup directories and manifest files
         String *full1 = strNew("20181119-152138F");


### PR DESCRIPTION
There are several tests in which we can now use ioRead objects instead of writing the info files to disk. This PR replaces those disk writes with ioRead objects in order to speed up testing and streamline the tests a bit.