### PR TITLE
Fix archive-push when pg1-path is not set and WAL path is absolute.

### DIFF
--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -134,7 +134,7 @@ testRun(void)
                 "1={\"db-id\":5555555555555555555,\"db-version\":\"9.4\"}\n"));
 
         TEST_ERROR(
-            archivePushCheck(cipherTypeNone, NULL), ArchiveMismatchError,
+            archivePushCheck(true, cipherTypeNone, NULL), ArchiveMismatchError,
             "PostgreSQL version 9.6, system-id 18072658121562454734 do not match stanza version 9.4, system-id 5555555555555555555"
                 "\nHINT: are you archiving to the correct stanza?");
 
@@ -149,7 +149,7 @@ testRun(void)
                 "1={\"db-id\":5555555555555555555,\"db-version\":\"9.6\"}\n"));
 
         TEST_ERROR(
-            archivePushCheck(cipherTypeNone, NULL), ArchiveMismatchError,
+            archivePushCheck(true, cipherTypeNone, NULL), ArchiveMismatchError,
             "PostgreSQL version 9.6, system-id 18072658121562454734 do not match stanza version 9.6, system-id 5555555555555555555"
                 "\nHINT: are you archiving to the correct stanza?");
 
@@ -164,11 +164,10 @@ testRun(void)
                 "1={\"db-id\":18072658121562454734,\"db-version\":\"9.6\"}\n"));
 
         ArchivePushCheckResult result = {0};
-        TEST_ASSIGN(result, archivePushCheck(cipherTypeNone, NULL), "get archive check result");
+        TEST_ASSIGN(result, archivePushCheck(true, cipherTypeNone, NULL), "get archive check result");
 
         TEST_RESULT_UINT(result.pgVersion, PG_VERSION_96, "check pg version");
         TEST_RESULT_UINT(result.pgSystemId, 0xFACEFACEFACEFACE, "check pg system id");
-        TEST_RESULT_UINT(result.pgWalSegmentSize, 16 * 1024 * 1024, "check wal segment size");
         TEST_RESULT_STR_Z(result.archiveId, "9.6-1", "check archive id");
         TEST_RESULT_STR_Z(result.archiveCipherPass, NULL, "check archive cipher pass (not set in this test)");
     }
@@ -292,12 +291,17 @@ testRun(void)
 
         TEST_ERROR(cmdArchivePush(), ArchiveDuplicateError, "WAL file '000000010000000100000001' already exists in the archive");
 
-        // Save it to a new file instead
-        argListTemp = strLstDup(argList);
-        strLstAddZ(argListTemp, "pg_wal/000000010000000100000002");
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("WAL with absolute path and no pg1-path");
+
+        argListTemp = strLstNew();
+        strLstAddZ(argListTemp, "--" CFGOPT_STANZA "=test");
+        // strLstAdd(argListTemp, strNewFmt("--" CFGOPT_PG1_PATH "=%s/pg", testPath()));
+        strLstAdd(argListTemp, strNewFmt("--" CFGOPT_REPO1_PATH "=%s/repo", testPath()));
+        strLstAdd(argListTemp, strNewFmt("%s/pg/pg_wal/000000010000000100000002", testPath()));
         harnessCfgLoad(cfgCmdArchivePush, argListTemp);
 
-        storagePutP(storageNewWriteP(storagePgWrite(), strNew("pg_wal/000000010000000100000002")), walBuffer2);
+        TEST_RESULT_VOID(storagePutP(storageNewWriteP(storageTest, strNew("pg/pg_wal/000000010000000100000002")), walBuffer2), "write WAL");
 
         TEST_RESULT_VOID(cmdArchivePush(), "push the WAL segment");
         harnessLogResult("P00   INFO: pushed WAL file '000000010000000100000002' to the archive");


### PR DESCRIPTION
This issue was reported in #999. Setting `pg1-path` worked for the user, but it raises the question of how to fix the underlying issue.

The `archive-push` command does not require `pg1-path` to be set if the WAL to the archive has an absolute path. However, at some point we added a check against pg_control that requires `pg1-path`. Since it's NULL in this case, segfault.

The main question is, do we want to continue to allow this behavior? The original idea was that we should be able to push a segment adhoc into the repo as long as the version/system-id matches and it does not conflict with existing WAL. This still seems like a useful capability even if it has not really come up.

The same functionality is definitely useful for archive-get. i.e. get a WAL segment and place it anywhere without needing to have pg1-path set or check against pg_control. If nothing else it is great for testing and analysis.

If we have it I think it should work for both. Does that make sense? 

I fixed the issue to restore the old behavior and added a test to prevent a future regression. Also remove an unused struct member, `pgWalSegmentSize`.

If we decide to keep this feature I'll go add tests for archive-get to make sure it is working as expected.

Another thing -- we've had more than a few segfaults related to options being NULL unexpectedly. I think we should make `cfgOptionStr()` throw a clear error in this case and add a new function, `cfgOptionStrNullable()` or something, to signal that we expect that the value can be NULL. So most calls would stay the same and we change to `Nullable` where needed.