### PR TITLE
Throw user-friendly error if expire is not run on repository host.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -14,6 +14,18 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.27dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                             <release-item-contributor id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Throw user-friendly error if <cmd>expire</cmd> is not run on repository host.</p>
+
+                        <p>Running <cmd>expire</cmd> on anything other than the repository host caused a segmentation fault because the command is not yet configured for remote execution. Also disallow execution to proceed if a stop file is present.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-feature-list>
                     <release-item>
                         <release-item-contributor-list>

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -5,6 +5,7 @@ Expire Command
 
 #include "command/archive/common.h"
 #include "command/backup/common.h"
+#include "command/control/common.h"
 #include "common/type/list.h"
 #include "common/debug.h"
 #include "common/regExp.h"
@@ -12,6 +13,7 @@ Expire Command
 #include "info/infoArchive.h"
 #include "info/infoBackup.h"
 #include "info/manifest.h"
+#include "protocol/helper.h"
 #include "storage/helper.h"
 
 #include <stdlib.h>
@@ -640,11 +642,14 @@ cmdExpire(void)
 {
     FUNCTION_LOG_VOID(logLevelDebug);
 
+    // Verify the repo is local
+    repoIsLocalVerify();
+
+    // Test for stop file
+    lockStopTest();
+
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        // Get the repo storage in case it is remote and encryption settings need to be pulled down
-        storageRepo();
-
         // Load the backup.info
         InfoBackup *infoBackup = infoBackupLoadFileReconstruct(
             storageRepo(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),


### PR DESCRIPTION
Running the expire command on anything other than the repository host caused a segmentation fault because the command is not yet configured for remote execution. Also disallow execution to proceed if a stop file is present.