### PR TITLE
Enforce not null for most string options.

### DIFF
--- a/src/command/archive/get/get.c
+++ b/src/command/archive/get/get.c
@@ -261,7 +261,7 @@ cmdArchiveGet(void)
             // Get the archive file
             result = archiveGetFile(
                 storageLocalWrite(), walSegment, walDestination, false, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
         }
 
         // Log whether or not the file was found

--- a/src/command/archive/get/protocol.c
+++ b/src/command/archive/get/protocol.c
@@ -46,7 +46,7 @@ archiveGetProtocol(const String *command, const VariantList *paramList, Protocol
                 VARINT(
                     archiveGetFile(
                         storageSpoolWrite(), walSegment, strNewFmt(STORAGE_SPOOL_ARCHIVE_IN "/%s", strPtr(walSegment)), true,
-                        cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStr(cfgOptRepoCipherPass))));
+                        cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStrNull(cfgOptRepoCipherPass))));
         }
         else
             found = false;

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -271,7 +271,7 @@ cmdArchivePush(void)
         lockStopTest();
 
         // Get the segment name
-        String *walFile = walPath(strLstGet(commandParam, 0), cfgOptionStr(cfgOptPgPath), STR(cfgCommandName(cfgCommand())));
+        String *walFile = walPath(strLstGet(commandParam, 0), cfgOptionStrNull(cfgOptPgPath), STR(cfgCommandName(cfgCommand())));
         String *archiveFile = strBase(walFile);
 
         if (cfgOptionBool(cfgOptArchiveAsync))
@@ -343,7 +343,7 @@ cmdArchivePush(void)
 
             // Get archive info
             ArchivePushCheckResult archiveInfo = archivePushCheck(
-                cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStr(cfgOptRepoCipherPass));
+                cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStrNull(cfgOptRepoCipherPass));
 
             // Check if the push queue has been exceeded
             if (cfgOptionTest(cfgOptArchivePushQueueMax) &&
@@ -486,7 +486,7 @@ cmdArchivePushAsync(void)
 
                 // Get archive info
                 jobData.archiveInfo = archivePushCheck(
-                    cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStr(cfgOptRepoCipherPass));
+                    cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStrNull(cfgOptRepoCipherPass));
 
                 // Create the parallel executor
                 ProtocolParallel *parallelExec = protocolParallelNew(

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -243,13 +243,13 @@ backupInit(const InfoBackup *infoBackup)
             result->pgIdStandby = dbInfo.standbyId;
             result->dbStandby = dbInfo.standby;
             result->storageStandby = storagePgId(result->pgIdStandby);
-            result->hostStandby = cfgOptionStr(cfgOptPgHost + result->pgIdStandby - 1);
+            result->hostStandby = cfgOptionStrNull(cfgOptPgHost + result->pgIdStandby - 1);
         }
     }
 
     // Add primary info
     result->storagePrimary = storagePgId(result->pgIdPrimary);
-    result->hostPrimary = cfgOptionStr(cfgOptPgHost + result->pgIdPrimary - 1);
+    result->hostPrimary = cfgOptionStrNull(cfgOptPgHost + result->pgIdPrimary - 1);
 
     // Get pg_control info from the primary
     PgControl pgControl = pgControlFromFile(result->storagePrimary);
@@ -1754,7 +1754,7 @@ backupArchiveCheckCopy(Manifest *manifest, unsigned int walSegmentSize, const St
             // Loop through all the segments in the lsn range
             InfoArchive *infoArchive = infoArchiveLoadFile(
                 storageRepo(), INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
             const String *archiveId = infoArchiveId(infoArchive);
 
             StringList *walSegmentList = pgLsnRangeToWalSegmentList(
@@ -1908,7 +1908,7 @@ backupComplete(InfoBackup *const infoBackup, Manifest *const manifest)
 
         infoBackupSaveFile(
             infoBackup, storageRepoWrite(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
     }
     MEM_CONTEXT_TEMP_END();
 
@@ -1932,7 +1932,7 @@ cmdBackup(void)
         // Load backup.info
         InfoBackup *infoBackup = infoBackupLoadFileReconstruct(
             storageRepo(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
         InfoPgData infoPg = infoPgDataCurrent(infoBackupPg(infoBackup));
         const String *cipherPassBackup = infoPgCipherPass(infoBackupPg(infoBackup));
 

--- a/src/command/check/check.c
+++ b/src/command/check/check.c
@@ -81,7 +81,7 @@ checkStandby(const DbGetResult dbGroup, unsigned int pgPathDefinedTotal)
         // Check that the backup and archive info files exist and are valid for the current database of the stanza
         checkStanzaInfoPg(
             storageRepo(), pgControl.version, pgControl.systemId, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
 
         LOG_INFO("switch wal not performed because this is a standby");
 
@@ -119,12 +119,12 @@ checkPrimary(const DbGetResult dbGroup)
         // Check that the backup and archive info files exist and are valid for the current database of the stanza
         checkStanzaInfoPg(
             storageRepo(), pgControl.version, pgControl.systemId, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
 
         // Attempt to load the archive info file and retrieve the archiveId
         InfoArchive *archiveInfo = infoArchiveLoadFile(
             storageRepo(), INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
         const String *archiveId = infoArchiveId(archiveInfo);
 
         // Perform a WAL switch

--- a/src/command/control/start.c
+++ b/src/command/control/start.c
@@ -18,7 +18,7 @@ cmdStart(void)
     MEM_CONTEXT_TEMP_BEGIN()
     {
         // Remove the stop file so processes can run
-        String *stopFile = lockStopFileName(cfgOptionStr(cfgOptStanza));
+        String *stopFile = lockStopFileName(cfgOptionStrNull(cfgOptStanza));
 
         // If the stop file exists, then remove it
         if (storageExistsP(storageLocal(), stopFile))

--- a/src/command/control/stop.c
+++ b/src/command/control/stop.c
@@ -26,7 +26,7 @@ cmdStop(void)
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        String *stopFile = lockStopFileName(cfgOptionStr(cfgOptStanza));
+        String *stopFile = lockStopFileName(cfgOptionStrNull(cfgOptStanza));
 
         // If the stop file does not already exist, then create it
         if (!storageExistsP(storageLocal(), stopFile))

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -356,7 +356,7 @@ removeExpiredArchive(InfoBackup *infoBackup)
                 // Attempt to load the archive info file
                 InfoArchive *infoArchive = infoArchiveLoadFile(
                     storageRepo(), INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                    cfgOptionStr(cfgOptRepoCipherPass));
+                    cfgOptionStrNull(cfgOptRepoCipherPass));
 
                 InfoPg *infoArchivePgData = infoArchivePg(infoArchive);
 
@@ -776,7 +776,7 @@ cmdExpire(void)
         // Load the backup.info
         InfoBackup *infoBackup = infoBackupLoadFileReconstruct(
             storageRepo(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
 
         const String *adhocBackupLabel = NULL;
 
@@ -797,7 +797,7 @@ cmdExpire(void)
         {
             infoBackupSaveFile(
                 infoBackup, storageRepoWrite(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
         }
 
         // Remove all files on disk that are now expired

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -396,7 +396,7 @@ stanzaInfoList(const String *stanza, StringList *stanzaList, const String *backu
             // Attempt to load the backup info file
             info = infoBackupLoadFile(
                 storageRepo(), strNewFmt(STORAGE_PATH_BACKUP "/%s/%s", strPtr(stanzaListName), INFO_BACKUP_FILE),
-                cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStr(cfgOptRepoCipherPass));
+                cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStrNull(cfgOptRepoCipherPass));
         }
         CATCH(FileMissingError)
         {
@@ -443,7 +443,7 @@ stanzaInfoList(const String *stanza, StringList *stanzaList, const String *backu
                 // Get the archive info for the DB from the archive.info file
                 InfoArchive *info = infoArchiveLoadFile(
                     storageRepo(), strNewFmt(STORAGE_PATH_ARCHIVE "/%s/%s", strPtr(stanzaListName), INFO_ARCHIVE_FILE),
-                    cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStr(cfgOptRepoCipherPass));
+                    cipherType(cfgOptionStr(cfgOptRepoCipherType)), cfgOptionStrNull(cfgOptRepoCipherPass));
                 archiveDbList(stanzaListName, &pgData, archiveSection, info, (pgIdx == 0 ? true : false));
             }
 
@@ -738,10 +738,10 @@ infoRender(void)
     MEM_CONTEXT_TEMP_BEGIN()
     {
         // Get stanza if specified
-        const String *stanza = cfgOptionTest(cfgOptStanza) ? cfgOptionStr(cfgOptStanza) : NULL;
+        const String *stanza = cfgOptionStrNull(cfgOptStanza);
 
         // Get the backup label if specified
-        const String *backupLabel = cfgOptionTest(cfgOptSet) ? cfgOptionStr(cfgOptSet) : NULL;
+        const String *backupLabel = cfgOptionStrNull(cfgOptSet);
 
         // Get the repo storage in case it is remote and encryption settings need to be pulled down
         storageRepo();

--- a/src/command/repo/get.c
+++ b/src/command/repo/get.c
@@ -47,7 +47,7 @@ storageGetProcess(IoWrite *destination)
             if (repoCipherType != cipherTypeNone)
             {
                 // Check for a passphrase parameter
-                const String *cipherPass = cfgOptionStr(cfgOptCipherPass);
+                const String *cipherPass = cfgOptionStrNull(cfgOptCipherPass);
 
                 // If not passed as a parameter use the repo passphrase
                 if (cipherPass == NULL)

--- a/src/command/repo/ls.c
+++ b/src/command/repo/ls.c
@@ -167,8 +167,8 @@ storageListRender(IoWrite *write)
 
         // List content of the path
         storageInfoListP(
-            storageRepo(), path, storageListRenderCallback, &data, .sortOrder = sortOrder, .expression = cfgOptionStr(cfgOptFilter),
-            .recurse = cfgOptionBool(cfgOptRecurse));
+            storageRepo(), path, storageListRenderCallback, &data, .sortOrder = sortOrder,
+            .expression = cfgOptionStrNull(cfgOptFilter), .recurse = cfgOptionBool(cfgOptRecurse));
     }
 
     if (data.json)

--- a/src/command/repo/put.c
+++ b/src/command/repo/put.c
@@ -44,7 +44,7 @@ storagePutProcess(IoRead *source)
             if (repoCipherType != cipherTypeNone)
             {
                 // Check for a passphrase parameter
-                const String *cipherPass = cfgOptionStr(cfgOptCipherPass);
+                const String *cipherPass = cfgOptionStrNull(cfgOptCipherPass);
 
                 // If not passed as a parameter use the repo passphrase
                 if (cipherPass == NULL)

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -352,7 +352,7 @@ restoreManifestMap(Manifest *manifest)
         // Remap tablespaces
         // -------------------------------------------------------------------------------------------------------------------------
         KeyValue *tablespaceMap = varKv(cfgOption(cfgOptTablespaceMap));
-        const String *tablespaceMapAllPath = cfgOptionStr(cfgOptTablespaceMapAll);
+        const String *tablespaceMapAllPath = cfgOptionStrNull(cfgOptTablespaceMapAll);
 
         if (tablespaceMap != NULL || tablespaceMapAllPath != NULL)
         {
@@ -2017,7 +2017,7 @@ cmdRestore(void)
         // Load backup.info
         InfoBackup *infoBackup = infoBackupLoadFile(
             storageRepo(), INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
 
         // Get the backup set
         const String *backupSet = restoreBackupSet(infoBackup);

--- a/src/command/stanza/create.c
+++ b/src/command/stanza/create.c
@@ -74,7 +74,7 @@ cmdStanzaCreate(void)
 
             infoArchiveSaveFile(
                 infoArchive, storageRepoWriteStanza, INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
 
             // If the repo is encrypted, generate a cipher passphrase for encrypting subsequent backup files
             cipherPassSub = cipherPassGen(cipherType(cfgOptionStr(cfgOptRepoCipherType)));
@@ -84,7 +84,7 @@ cmdStanzaCreate(void)
 
             infoBackupSaveFile(
                 infoBackup, storageRepoWriteStanza, INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
         }
         // Else if at least one archive and one backup info file exists, then ensure both are valid
         else if ((archiveInfoFileExists || archiveInfoFileCopyExists) && (backupInfoFileExists || backupInfoFileCopyExists))
@@ -93,7 +93,7 @@ cmdStanzaCreate(void)
             // current database
             checkStanzaInfoPg(
                 storageRepoReadStanza, pgControl.version, pgControl.systemId, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
 
             // The files are valid - upgrade
             const String *sourceFile = NULL;

--- a/src/command/stanza/upgrade.c
+++ b/src/command/stanza/upgrade.c
@@ -46,12 +46,12 @@ cmdStanzaUpgrade(void)
         // Load the info files (errors if missing)
         InfoArchive *infoArchive = infoArchiveLoadFile(
             storageRepoReadStanza, INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
         InfoPgData archiveInfo = infoPgData(infoArchivePg(infoArchive), infoPgDataCurrentId(infoArchivePg(infoArchive)));
 
         InfoBackup *infoBackup = infoBackupLoadFile(
             storageRepoReadStanza, INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-            cfgOptionStr(cfgOptRepoCipherPass));
+            cfgOptionStrNull(cfgOptRepoCipherPass));
         InfoPgData backupInfo = infoPgData(infoBackupPg(infoBackup), infoPgDataCurrentId(infoBackupPg(infoBackup)));
 
         // Since the file save of archive.info and backup.info are not atomic, then check and update each separately.
@@ -80,7 +80,7 @@ cmdStanzaUpgrade(void)
         {
             infoArchiveSaveFile(
                 infoArchive, storageRepoWriteStanza, INFO_ARCHIVE_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
         }
 
         // Save backup info
@@ -88,7 +88,7 @@ cmdStanzaUpgrade(void)
         {
             infoBackupSaveFile(
                 infoBackup, storageRepoWriteStanza, INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),
-                cfgOptionStr(cfgOptRepoCipherPass));
+                cfgOptionStrNull(cfgOptRepoCipherPass));
         }
 
         if (!(infoArchiveUpgrade || infoBackupUpgrade))

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -831,8 +831,8 @@ cfgOptionInternal(ConfigOption optionId, VariantType typeRequested, bool nullAll
         }
     }
     // Else check the option is allowed to be NULL
-    else
-        CHECK(nullAllowed);
+    else if (!nullAllowed)
+        THROW_FMT(AssertError, "option '%s' is null but non-null was requested", cfgOptionName(optionId));
 
     FUNCTION_TEST_RETURN(result);
 }
@@ -943,6 +943,16 @@ cfgOptionLst(ConfigOption optionId)
 
 const String *
 cfgOptionStr(ConfigOption optionId)
+{
+    FUNCTION_LOG_BEGIN(logLevelTrace);
+        FUNCTION_LOG_PARAM(ENUM, optionId);
+    FUNCTION_LOG_END();
+
+    FUNCTION_LOG_RETURN_CONST(STRING, varStr(cfgOptionInternal(optionId, varTypeString, false)));
+}
+
+const String *
+cfgOptionStrNull(ConfigOption optionId)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(ENUM, optionId);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -105,6 +105,7 @@ int64_t cfgOptionInt64(ConfigOption optionId);
 const KeyValue *cfgOptionKv(ConfigOption optionId);
 const VariantList *cfgOptionLst(ConfigOption optionId);
 const String *cfgOptionStr(ConfigOption optionId);
+const String *cfgOptionStrNull(ConfigOption optionId);
 unsigned int cfgOptionUInt(ConfigOption optionId);
 uint64_t cfgOptionUInt64(ConfigOption optionId);
 

--- a/src/db/helper.c
+++ b/src/db/helper.c
@@ -30,8 +30,8 @@ dbGetId(unsigned int pgId)
         {
             result = dbNew(
                 pgClientNew(
-                    cfgOptionStr(cfgOptPgSocketPath + pgId - 1), cfgOptionUInt(cfgOptPgPort + pgId - 1), PG_DB_POSTGRES_STR,
-                    cfgOptionStr(cfgOptPgUser + pgId - 1), (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC)),
+                    cfgOptionStrNull(cfgOptPgSocketPath + pgId - 1), cfgOptionUInt(cfgOptPgPort + pgId - 1), PG_DB_POSTGRES_STR,
+                    cfgOptionStrNull(cfgOptPgUser + pgId - 1), (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC)),
                 NULL, applicationName);
         }
         else

--- a/src/db/protocol.c
+++ b/src/db/protocol.c
@@ -64,8 +64,8 @@ dbProtocol(const String *command, const VariantList *paramList, ProtocolServer *
             {
                 // Only a single db is passed to the remote
                 PgClient *pgClient = pgClientNew(
-                    cfgOptionStr(cfgOptPgSocketPath), cfgOptionUInt(cfgOptPgPort), PG_DB_POSTGRES_STR, cfgOptionStr(cfgOptPgUser),
-                    (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC));
+                    cfgOptionStrNull(cfgOptPgSocketPath), cfgOptionUInt(cfgOptPgPort), PG_DB_POSTGRES_STR,
+                    cfgOptionStrNull(cfgOptPgUser), (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC));
                 pgClientOpen(pgClient);
 
                 lstAdd(dbProtocolLocal.pgClientList, &pgClient);

--- a/src/storage/helper.c
+++ b/src/storage/helper.c
@@ -383,10 +383,8 @@ storageRepoGet(const String *type, bool write)
             cfgOptionStr(cfgOptRepoPath), write, storageRepoPathExpression, cfgOptionStr(cfgOptRepoS3Bucket), endPoint,
             strEqZ(cfgOptionStr(cfgOptRepoS3UriStyle), STORAGE_S3_URI_STYLE_HOST) ? storageS3UriStyleHost : storageS3UriStylePath,
             cfgOptionStr(cfgOptRepoS3Region), cfgOptionStr(cfgOptRepoS3Key), cfgOptionStr(cfgOptRepoS3KeySecret),
-            cfgOptionTest(cfgOptRepoS3Token) ? cfgOptionStr(cfgOptRepoS3Token) : NULL, STORAGE_S3_PARTSIZE_MIN,
-            STORAGE_S3_DELETE_MAX, host, port, ioTimeoutMs(), cfgOptionBool(cfgOptRepoS3VerifyTls),
-            cfgOptionTest(cfgOptRepoS3CaFile) ? cfgOptionStr(cfgOptRepoS3CaFile) : NULL,
-            cfgOptionTest(cfgOptRepoS3CaPath) ? cfgOptionStr(cfgOptRepoS3CaPath) : NULL);
+            cfgOptionStrNull(cfgOptRepoS3Token), STORAGE_S3_PARTSIZE_MIN, STORAGE_S3_DELETE_MAX, host, port, ioTimeoutMs(),
+            cfgOptionBool(cfgOptRepoS3VerifyTls), cfgOptionStrNull(cfgOptRepoS3CaFile), cfgOptionStrNull(cfgOptRepoS3CaPath));
     }
     else
         THROW_FMT(AssertError, "invalid storage type '%s'", strPtr(type));

--- a/src/storage/helper.c
+++ b/src/storage/helper.c
@@ -106,12 +106,12 @@ storageHelperStanzaInit(const bool stanzaRequired)
     // If the stanza is NULL and the storage has not already been initialized then initialize the stanza
     if (!storageHelper.stanzaInit)
     {
-        if (stanzaRequired && cfgOptionStr(cfgOptStanza) == NULL)
+        if (stanzaRequired && cfgOptionStrNull(cfgOptStanza) == NULL)
             THROW(AssertError, "stanza cannot be NULL for this storage object");
 
         MEM_CONTEXT_BEGIN(storageHelper.memContext)
         {
-            storageHelper.stanza = strDup(cfgOptionStr(cfgOptStanza));
+            storageHelper.stanza = strDup(cfgOptionStrNull(cfgOptStanza));
             storageHelper.stanzaInit = true;
         }
         MEM_CONTEXT_END();

--- a/test/src/module/config/configTest.c
+++ b/test/src/module/config/configTest.c
@@ -199,7 +199,8 @@ testRun(void)
 
         TEST_ERROR(cfgOptionStr(cfgOptStanza), AssertError, "option 'stanza' is not valid for the current command");
         TEST_RESULT_VOID(cfgOptionValidSet(cfgOptStanza, true), "set stanza valid");
-        TEST_RESULT_PTR(cfgOptionStr(cfgOptStanza), NULL, "stanza defaults to null");
+        TEST_ERROR(cfgOptionStr(cfgOptStanza), AssertError, "option 'stanza' is null but non-null was requested");
+        TEST_RESULT_PTR(cfgOptionStrNull(cfgOptStanza), NULL, "stanza defaults to null");
         TEST_ERROR(
             cfgOptionSet(cfgOptStanza, cfgSourceParam, varNewDbl(1.1)), AssertError,
             "option 'stanza' must be set with String variant");

--- a/test/src/module/config/loadTest.c
+++ b/test/src/module/config/loadTest.c
@@ -75,7 +75,7 @@ testRun(void)
         TEST_RESULT_VOID(cfgLoadUpdateOption(), "pg remote command is updated");
         TEST_RESULT_STR(cfgOptionStr(cfgOptPgHostCmd), exe, "    check pg1-host-cmd");
         TEST_RESULT_STR(cfgOptionStr(cfgOptPgHostCmd + 1), exeOther, "    check pg2-host-cmd is already set");
-        TEST_RESULT_STR(cfgOptionStr(cfgOptPgHostCmd + 2), NULL, "    check pg3-host-cmd is not set");
+        TEST_RESULT_STR(cfgOptionStrNull(cfgOptPgHostCmd + 2), NULL, "    check pg3-host-cmd is not set");
         TEST_RESULT_STR(cfgOptionStr(cfgOptPgHostCmd + cfgOptionIndexTotal(cfgOptPgHost) - 1), exe, "    check pgX-host-cmd");
 
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/protocol/protocolTest.c
+++ b/test/src/module/protocol/protocolTest.c
@@ -920,7 +920,7 @@ testRun(void)
         strLstAdd(argList, strNewFmt("--repo1-path=%s", testPath()));
         harnessCfgLoad(cfgCmdInfo, argList);
 
-        TEST_RESULT_PTR(cfgOptionStr(cfgOptRepoCipherPass), NULL, "check cipher pass before");
+        TEST_RESULT_PTR(cfgOptionStrNull(cfgOptRepoCipherPass), NULL, "check cipher pass before");
         TEST_ASSIGN(client, protocolRemoteGet(protocolStorageTypeRepo, 1), "get remote protocol");
         TEST_RESULT_STR_Z(cfgOptionStr(cfgOptRepoCipherPass), "dcba", "check cipher pass after");
 


### PR DESCRIPTION
There have been a number of segfaults reported because a string option expected to be non-null was actually null. This is generally due to options that are expected to be set but are in fact optional.

Protect against this by creating cfgOptionStrNull() to get options that can be null, while changing cfgOptionStr() to always expect non-null. There are relatively few places where nulls are expected.

There is definitely a chance for breakage here as null options might currently be working in the field but will be caught by this new check. Hopefully introducing the check early in the release cycle will allow us to catch any issues.