### PR TITLE
Fix issue checking if file links are contained in path links.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -17,6 +17,14 @@
                 <release-bug-list>
                     <release-item>
                         <release-item-contributor-list>
+                             <release-item-ideator id="christophe.cavallie"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix issue checking if file links are contained in path links.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                              <release-item-contributor id="cynthia.shang"/>
                         </release-item-contributor-list>
 
@@ -8038,6 +8046,11 @@
         <contributor id="christoph.berg">
             <contributor-name-display>Christoph Berg</contributor-name-display>
             <contributor-id type="github">ChristophBerg</contributor-id>
+        </contributor>
+
+        <contributor id="christophe.cavallie">
+            <contributor-name-display>Christophe Cavalli&amp;eacute;</contributor-name-display>
+            <contributor-id type="github">ChristCava</contributor-id>
         </contributor>
 
         <contributor id="christophe.courtois">

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -2378,8 +2378,14 @@ manifestLinkCheck(const Manifest *this)
 
                 if (link2->type == manifestTargetTypeLink && link1 != link2)
                 {
-                    if (!(link1->file != NULL && link2->file != NULL) &&
-                        strBeginsWith(
+                    // Don't check link1 against a file link. If link1 is a file there's no need to compare because they cannot have
+                    // conflicting paths. If link1 is a path we want to make sure that the file link is not located within it but to
+                    // do that we need to wait until the file link is link1 and the path link is link2, which happens on another
+                    // interation of the outer loop.
+                    if (link2->file != NULL)
+                        continue;
+
+                    if (strBeginsWith(
                             strNewFmt("%s/", strPtr(manifestTargetPath(this, link1))),
                             strNewFmt("%s/", strPtr(manifestTargetPath(this, link2)))))
                     {

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -1875,6 +1875,15 @@ testRun(void)
                 " link 'base/1' (/pg/base-1)");
         manifestTargetRemove(manifest, STRDEF("pg_data/base/2"));
 
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("check that a file link in the parent path of a path link does not conflict");
+
+        manifestTargetAdd(
+            manifest, &(ManifestTarget){
+               .name = STRDEF("pg_data/test.sh"), .type = manifestTargetTypeLink, .path = STRDEF(".."), .file = STRDEF("test.sh")});
+        TEST_RESULT_VOID(manifestLinkCheck(manifest), "successful link check");
+        manifestTargetRemove(manifest, STRDEF("pg_data/test.sh"));
+
         // ManifestFile getters
         const ManifestFile *file = NULL;
         TEST_ERROR(


### PR DESCRIPTION
There is no conflict if the path containing a file link is a parent path of a path link. The Perl code apparently had this right but the migration to C missed it. Exclude this case when checking for link violations.