### PR TITLE
Refactor HTTP response code into a separate object.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -78,6 +78,7 @@ SRCS = \
 	common/io/http/common.c \
 	common/io/http/header.c \
 	common/io/http/query.c \
+	common/io/http/response.c \
 	common/io/io.c \
 	common/io/read.c \
 	common/io/socket/client.c \

--- a/src/command/repo/create.c
+++ b/src/command/repo/create.c
@@ -21,7 +21,7 @@ cmdRepoCreate(void)
         if (strEq(storageType(storageRepo()), STORAGE_S3_TYPE_STR))
         {
             storageS3Request(
-                (StorageS3 *)storageDriver(storageRepoWrite()), HTTP_VERB_PUT_STR, FSLASH_STR, NULL, NULL, true, false);
+                (StorageS3 *)storageDriver(storageRepoWrite()), HTTP_VERB_PUT_STR, FSLASH_STR, NULL, NULL, false, false);
         }
     }
     MEM_CONTEXT_TEMP_END();

--- a/src/common/io/http/client.c
+++ b/src/common/io/http/client.c
@@ -16,8 +16,7 @@ Http Client
 /***********************************************************************************************************************************
 Http constants
 ***********************************************************************************************************************************/
-#define HTTP_VERSION                                                "HTTP/1.1"
-    STRING_STATIC(HTTP_VERSION_STR,                                 HTTP_VERSION);
+STRING_EXTERN(HTTP_VERSION_STR,                                     HTTP_VERSION);
 
 STRING_EXTERN(HTTP_VERB_DELETE_STR,                                 HTTP_VERB_DELETE);
 STRING_EXTERN(HTTP_VERB_GET_STR,                                    HTTP_VERB_GET);
@@ -56,138 +55,13 @@ struct HttpClient
 {
     MemContext *memContext;                                         // Mem context
     TimeMSec timeout;                                               // Request timeout
-
     TlsClient *tlsClient;                                           // TLS client
+
     TlsSession *tlsSession;                                         // Current TLS session
-    IoRead *ioRead;                                                 // Read io interface
-
-    unsigned int responseCode;                                      // Response code (e.g. 200, 404)
-    String *responseMessage;                                        // Response message e.g. (OK, Not Found)
-    HttpHeader *responseHeader;                                     // Response headers
-
-    bool contentChunked;                                            // Is the response content chunked?
-    uint64_t contentSize;                                           // Content size (ignored for chunked)
-    uint64_t contentRemaining;                                      // Content remaining (per chunk if chunked)
-    bool closeOnContentEof;                                         // Will server close after content is sent?
-    bool contentEof;                                                // Has all content been read?
+    bool busy;                                                      // Is the HTTP client currently busy?
 };
 
 OBJECT_DEFINE_FREE(HTTP_CLIENT);
-
-/***********************************************************************************************************************************
-Read content
-***********************************************************************************************************************************/
-static size_t
-httpClientRead(THIS_VOID, Buffer *buffer, bool block)
-{
-    THIS(HttpClient);
-
-    FUNCTION_LOG_BEGIN(logLevelTrace);
-        FUNCTION_LOG_PARAM(HTTP_CLIENT, this);
-        FUNCTION_LOG_PARAM(BUFFER, buffer);
-        FUNCTION_LOG_PARAM(BOOL, block);
-    FUNCTION_LOG_END();
-
-    ASSERT(this != NULL);
-    ASSERT(buffer != NULL);
-    ASSERT(!bufFull(buffer));
-
-    // Read if EOF has not been reached
-    size_t actualBytes = 0;
-
-    if (!this->contentEof)
-    {
-        // If close was requested and no content specified then the server may send content up until the eof
-        if (this->closeOnContentEof && !this->contentChunked && this->contentSize == 0)
-        {
-            ioRead(tlsSessionIoRead(this->tlsSession), buffer);
-            this->contentEof = ioReadEof(tlsSessionIoRead(this->tlsSession));
-        }
-        // Else read using specified encoding or size
-        else
-        {
-            do
-            {
-                // If chunked content and no content remaining
-                if (this->contentChunked && this->contentRemaining == 0)
-                {
-                    // Read length of next chunk
-                    MEM_CONTEXT_TEMP_BEGIN()
-                    {
-                        this->contentRemaining = cvtZToUInt64Base(
-                            strPtr(strTrim(ioReadLine(tlsSessionIoRead(this->tlsSession)))), 16);
-                    }
-                    MEM_CONTEXT_TEMP_END();
-
-                    // If content remaining is still zero then eof
-                    if (this->contentRemaining == 0)
-                        this->contentEof = true;
-                }
-
-                // Read if there is content remaining
-                if (this->contentRemaining > 0)
-                {
-                    // If the buffer is larger than the content that needs to be read then limit the buffer size so the read won't
-                    // block or read too far.  Casting to size_t is safe on 32-bit because we know the max buffer size is defined as
-                    // less than 2^32 so content remaining can't be more than that.
-                    if (bufRemains(buffer) > this->contentRemaining)
-                        bufLimitSet(buffer, bufSize(buffer) - (bufRemains(buffer) - (size_t)this->contentRemaining));
-
-                    actualBytes = bufRemains(buffer);
-                    this->contentRemaining -= ioRead(tlsSessionIoRead(this->tlsSession), buffer);
-
-                    // Error if EOF but content read is not complete
-                    if (ioReadEof(tlsSessionIoRead(this->tlsSession)))
-                        THROW(FileReadError, "unexpected EOF reading HTTP content");
-
-                    // Clear limit (this works even if the limit was not set and it is easier than checking)
-                    bufLimitClear(buffer);
-                }
-
-                // If no content remaining
-                if (this->contentRemaining == 0)
-                {
-                    // If chunked then consume the blank line that follows every chunk.  There might be more chunk data so loop back
-                    // around to check.
-                    if (this->contentChunked)
-                    {
-                        ioReadLine(tlsSessionIoRead(this->tlsSession));
-                    }
-                    // If total content size was provided then this is eof
-                    else
-                        this->contentEof = true;
-                }
-            }
-            while (!bufFull(buffer) && !this->contentEof);
-        }
-
-        // If the server notified that it would close the connection after sending content then close the client side
-        if (this->contentEof && this->closeOnContentEof)
-        {
-            tlsSessionFree(this->tlsSession);
-            this->tlsSession = NULL;
-        }
-    }
-
-    FUNCTION_LOG_RETURN(SIZE, (size_t)actualBytes);
-}
-
-/***********************************************************************************************************************************
-Has all content been read?
-***********************************************************************************************************************************/
-static bool
-httpClientEof(THIS_VOID)
-{
-    THIS(HttpClient);
-
-    FUNCTION_LOG_BEGIN(logLevelTrace);
-        FUNCTION_LOG_PARAM(HTTP_CLIENT, this);
-    FUNCTION_LOG_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_LOG_RETURN(BOOL, this->contentEof);
-}
 
 /**********************************************************************************************************************************/
 HttpClient *
@@ -226,10 +100,10 @@ httpClientNew(
 }
 
 /**********************************************************************************************************************************/
-Buffer *
+HttpResponse *
 httpClientRequest(
     HttpClient *this, const String *verb, const String *uri, const HttpQuery *query, const HttpHeader *requestHeader,
-    const Buffer *body, bool returnContent)
+    const Buffer *body)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug)
         FUNCTION_LOG_PARAM(HTTP_CLIENT, this);
@@ -238,15 +112,14 @@ httpClientRequest(
         FUNCTION_LOG_PARAM(HTTP_QUERY, query);
         FUNCTION_LOG_PARAM(HTTP_HEADER, requestHeader);
         FUNCTION_LOG_PARAM(BUFFER, body);
-        FUNCTION_LOG_PARAM(BOOL, returnContent);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
     ASSERT(verb != NULL);
     ASSERT(uri != NULL);
 
-    // Buffer for returned content
-    Buffer *result = NULL;
+    // HTTP Response
+    HttpResponse *result = NULL;
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
@@ -259,20 +132,7 @@ httpClientRequest(
             retry = false;
 
             // Free the read interface
-            httpClientDone(this);
-
-            // Free response status left over from the last request
-            httpHeaderFree(this->responseHeader);
-            this->responseHeader = NULL;
-            strFree(this->responseMessage);
-            this->responseMessage = NULL;
-
-            // Reset all content info
-            this->contentChunked = false;
-            this->contentSize = 0;
-            this->contentRemaining = 0;
-            this->closeOnContentEof = false;
-            this->contentEof = true;
+            httpClientDone(this, false, false);
 
             TRY_BEGIN()
             {
@@ -319,156 +179,152 @@ httpClientRequest(
                 // Flush all writes
                 ioWriteFlush(tlsSessionIoWrite(this->tlsSession));
 
-                // Read status
-                String *status = ioReadLine(tlsSessionIoRead(this->tlsSession));
+                // Set client busy and load request
+                this->busy = true;
 
-                // Check status ends with a CR and remove it to make error formatting easier and more accurate
-                if (!strEndsWith(status, CR_STR))
-                    THROW_FMT(FormatError, "http response status '%s' should be CR-terminated", strPtr(status));
-
-                status = strSubN(status, 0, strSize(status) - 1);
-
-                // Check status is at least the minimum required length to avoid harder to interpret errors later on
-                if (strSize(status) < sizeof(HTTP_VERSION) + 4)
-                    THROW_FMT(FormatError, "http response '%s' has invalid length", strPtr(strTrim(status)));
-
-                // Check status starts with the correct http version
-                 if (!strBeginsWith(status, HTTP_VERSION_STR))
-                    THROW_FMT(FormatError, "http version of response '%s' must be " HTTP_VERSION, strPtr(status));
-
-                // Read status code
-                status = strSub(status, sizeof(HTTP_VERSION));
-
-                int spacePos = strChr(status, ' ');
-
-                if (spacePos != 3)
-                    THROW_FMT(FormatError, "response status '%s' must have a space after the status code", strPtr(status));
-
-                this->responseCode = cvtZToUInt(strPtr(strSubN(status, 0, (size_t)spacePos)));
-
-                // Read reason phrase. A missing reason phrase will be represented as an empty string.
-                MEM_CONTEXT_BEGIN(this->memContext)
+                MEM_CONTEXT_PRIOR_BEGIN()
                 {
-                    this->responseMessage = strSub(status, (size_t)spacePos + 1);
+                    result = httpResponseNew(this, tlsSessionIoRead(this->tlsSession), verb);
                 }
-                MEM_CONTEXT_END();
+                MEM_CONTEXT_PRIOR_END();
 
-                // Read headers
-                MEM_CONTEXT_BEGIN(this->memContext)
-                {
-                    this->responseHeader = httpHeaderNew(NULL);
-                }
-                MEM_CONTEXT_END();
+                // // Read status
+                // String *status = ioReadLine(tlsSessionIoRead(this->tlsSession));
+                //
+                // // Check status ends with a CR and remove it to make error formatting easier and more accurate
+                // if (!strEndsWith(status, CR_STR))
+                //     THROW_FMT(FormatError, "http response status '%s' should be CR-terminated", strPtr(status));
+                //
+                // status = strSubN(status, 0, strSize(status) - 1);
+                //
+                // // Check status is at least the minimum required length to avoid harder to interpret errors later on
+                // if (strSize(status) < sizeof(HTTP_VERSION) + 4)
+                //     THROW_FMT(FormatError, "http response '%s' has invalid length", strPtr(strTrim(status)));
+                //
+                // // Check status starts with the correct http version
+                //  if (!strBeginsWith(status, HTTP_VERSION_STR))
+                //     THROW_FMT(FormatError, "http version of response '%s' must be " HTTP_VERSION, strPtr(status));
+                //
+                // // Read status code
+                // status = strSub(status, sizeof(HTTP_VERSION));
+                //
+                // int spacePos = strChr(status, ' ');
+                //
+                // if (spacePos != 3)
+                //     THROW_FMT(FormatError, "response status '%s' must have a space after the status code", strPtr(status));
+                //
+                // this->responseCode = cvtZToUInt(strPtr(strSubN(status, 0, (size_t)spacePos)));
+                //
+                // // Read reason phrase. A missing reason phrase will be represented as an empty string.
+                // MEM_CONTEXT_BEGIN(this->memContext)
+                // {
+                //     this->responseMessage = strSub(status, (size_t)spacePos + 1);
+                // }
+                // MEM_CONTEXT_END();
+                //
+                // // Read headers
+                // MEM_CONTEXT_BEGIN(this->memContext)
+                // {
+                //     this->responseHeader = httpHeaderNew(NULL);
+                // }
+                // MEM_CONTEXT_END();
+                //
+                // do
+                // {
+                //     // Read the next header
+                //     String *header = strTrim(ioReadLine(tlsSessionIoRead(this->tlsSession)));
+                //
+                //     // If the header is empty then we have reached the end of the headers
+                //     if (strSize(header) == 0)
+                //         break;
+                //
+                //     // Split the header and store it
+                //     int colonPos = strChr(header, ':');
+                //
+                //     if (colonPos < 0)
+                //         THROW_FMT(FormatError, "header '%s' missing colon", strPtr(strTrim(header)));
+                //
+                //     String *headerKey = strLower(strTrim(strSubN(header, 0, (size_t)colonPos)));
+                //     String *headerValue = strTrim(strSub(header, (size_t)colonPos + 1));
+                //
+                //     httpHeaderAdd(this->responseHeader, headerKey, headerValue);
+                //
+                //     // Read transfer encoding (only chunked is supported)
+                //     if (strEq(headerKey, HTTP_HEADER_TRANSFER_ENCODING_STR))
+                //     {
+                //         // Error if transfer encoding is not chunked
+                //         if (!strEq(headerValue, HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR))
+                //         {
+                //             THROW_FMT(
+                //                 FormatError, "only '%s' is supported for '%s' header", HTTP_VALUE_TRANSFER_ENCODING_CHUNKED,
+                //                 HTTP_HEADER_TRANSFER_ENCODING);
+                //         }
+                //
+                //         this->contentChunked = true;
+                //     }
+                //
+                //     // Read content size
+                //     if (strEq(headerKey, HTTP_HEADER_CONTENT_LENGTH_STR))
+                //     {
+                //         this->contentSize = cvtZToUInt64(strPtr(headerValue));
+                //         this->contentRemaining = this->contentSize;
+                //     }
+                //
+                //     // If the server notified of a closed connection then close the client connection after reading content.  This
+                //     // prevents doing a retry on the next request when using the closed connection.
+                //     if (strEq(headerKey, HTTP_HEADER_CONNECTION_STR) && strEq(headerValue, HTTP_VALUE_CONNECTION_CLOSE_STR))
+                //     {
+                //         this->closeOnContentEof = true;
+                //         httpClientStatLocal.close++;
+                //     }
+                // }
+                // while (1);
+                //
+                // // Error if transfer encoding and content length are both set
+                // if (this->contentChunked && this->contentSize > 0)
+                // {
+                //     THROW_FMT(
+                //         FormatError,  "'%s' and '%s' headers are both set", HTTP_HEADER_TRANSFER_ENCODING,
+                //         HTTP_HEADER_CONTENT_LENGTH);
+                // }
+                //
+                // // Was content returned in the response?  HEAD will report content but not actually return any.
+                // bool contentExists =
+                //     (this->contentChunked || this->contentSize > 0 || this->closeOnContentEof) && !strEq(verb, HTTP_VERB_HEAD_STR);
+                // this->contentEof = !contentExists;
 
-                do
-                {
-                    // Read the next header
-                    String *header = strTrim(ioReadLine(tlsSessionIoRead(this->tlsSession)));
-
-                    // If the header is empty then we have reached the end of the headers
-                    if (strSize(header) == 0)
-                        break;
-
-                    // Split the header and store it
-                    int colonPos = strChr(header, ':');
-
-                    if (colonPos < 0)
-                        THROW_FMT(FormatError, "header '%s' missing colon", strPtr(strTrim(header)));
-
-                    String *headerKey = strLower(strTrim(strSubN(header, 0, (size_t)colonPos)));
-                    String *headerValue = strTrim(strSub(header, (size_t)colonPos + 1));
-
-                    httpHeaderAdd(this->responseHeader, headerKey, headerValue);
-
-                    // Read transfer encoding (only chunked is supported)
-                    if (strEq(headerKey, HTTP_HEADER_TRANSFER_ENCODING_STR))
-                    {
-                        // Error if transfer encoding is not chunked
-                        if (!strEq(headerValue, HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR))
-                        {
-                            THROW_FMT(
-                                FormatError, "only '%s' is supported for '%s' header", HTTP_VALUE_TRANSFER_ENCODING_CHUNKED,
-                                HTTP_HEADER_TRANSFER_ENCODING);
-                        }
-
-                        this->contentChunked = true;
-                    }
-
-                    // Read content size
-                    if (strEq(headerKey, HTTP_HEADER_CONTENT_LENGTH_STR))
-                    {
-                        this->contentSize = cvtZToUInt64(strPtr(headerValue));
-                        this->contentRemaining = this->contentSize;
-                    }
-
-                    // If the server notified of a closed connection then close the client connection after reading content.  This
-                    // prevents doing a retry on the next request when using the closed connection.
-                    if (strEq(headerKey, HTTP_HEADER_CONNECTION_STR) && strEq(headerValue, HTTP_VALUE_CONNECTION_CLOSE_STR))
-                    {
-                        this->closeOnContentEof = true;
-                        httpClientStatLocal.close++;
-                    }
-                }
-                while (1);
-
-                // Error if transfer encoding and content length are both set
-                if (this->contentChunked && this->contentSize > 0)
-                {
-                    THROW_FMT(
-                        FormatError,  "'%s' and '%s' headers are both set", HTTP_HEADER_TRANSFER_ENCODING,
-                        HTTP_HEADER_CONTENT_LENGTH);
-                }
-
-                // Was content returned in the response?  HEAD will report content but not actually return any.
-                bool contentExists =
-                    (this->contentChunked || this->contentSize > 0 || this->closeOnContentEof) && !strEq(verb, HTTP_VERB_HEAD_STR);
-                this->contentEof = !contentExists;
-
-                // If all content should be returned from this function then read the buffer.  Also read the response if there has
-                // been an error.
-                if (returnContent || !httpClientResponseCodeOk(this))
-                {
-                    if (contentExists)
-                    {
-                        result = bufNew(0);
-
-                        do
-                        {
-                            bufResize(result, bufSize(result) + ioBufferSize());
-                            httpClientRead(this, result, true);
-                        }
-                        while (!httpClientEof(this));
-                    }
-                }
-                // Else create an io object, even if there is no content.  This makes the logic for readers easier -- they can just
-                // check eof rather than also checking if the io object exists.
-                else
-                {
-                    MEM_CONTEXT_BEGIN(this->memContext)
-                    {
-                        this->ioRead = ioReadNewP(this, .eof = httpClientEof, .read = httpClientRead);
-                        ioReadOpen(this->ioRead);
-                    }
-                    MEM_CONTEXT_END();
-                }
-
-                // If the server notified that it would close the connection and there is no content then close the client side
-                if (this->closeOnContentEof && !contentExists)
-                {
-                    tlsSessionFree(this->tlsSession);
-                    this->tlsSession = NULL;
-                }
-
-                // Retry when response code is 5xx.  These errors generally represent a server error for a request that looks valid.
-                // There are a few errors that might be permanently fatal but they are rare and it seems best not to try and pick
-                // and choose errors in this class to retry.
-                if (httpClientResponseCode(this) / 100 == HTTP_RESPONSE_CODE_RETRY_CLASS)
-                    THROW_FMT(ServiceError, "[%u] %s", httpClientResponseCode(this), strPtr(httpClientResponseMessage(this)));
+                // // If all content should be returned from this function then read the buffer.  Also read the response if there has
+                // // been an error.
+                // if (returnContent || !httpClientResponseCodeOk(this))
+                // {
+                //     if (contentExists)
+                //     {
+                //         result = bufNew(0);
+                //
+                //         do
+                //         {
+                //             bufResize(result, bufSize(result) + ioBufferSize());
+                //             httpClientRead(this, result, true);
+                //         }
+                //         while (!httpClientEof(this));
+                //     }
+                // }
+                // // Else create an io object, even if there is no content.  This makes the logic for readers easier -- they can just
+                // // check eof rather than also checking if the io object exists.
+                // else
+                // {
+                //     MEM_CONTEXT_BEGIN(this->memContext)
+                //     {
+                //         this->ioRead = ioReadNewP(this, .eof = httpClientEof, .read = httpClientRead);
+                //         ioReadOpen(this->ioRead);
+                //     }
+                //     MEM_CONTEXT_END();
+                // }
             }
             CATCH_ANY()
             {
-                tlsSessionFree(this->tlsSession);
-                this->tlsSession = NULL;
+                // Close the client
+                httpClientDone(this, true, false);
 
                 // Retry if wait time has not expired
                 if (waitMore(wait))
@@ -484,9 +340,6 @@ httpClientRequest(
             TRY_END();
         }
         while (retry);
-
-        // Move the result buffer (if any) to the parent context
-        bufMove(result, memContextPrior());
 
         httpClientStatLocal.request++;
     }
@@ -517,26 +370,30 @@ httpClientStatStr(void)
 
 /**********************************************************************************************************************************/
 void
-httpClientDone(HttpClient *this)
+httpClientDone(HttpClient *this, bool close, bool closeRequired)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(HTTP_CLIENT, this);
+        FUNCTION_LOG_PARAM(BOOL, close);
+        FUNCTION_LOG_PARAM(BOOL, closeRequired);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
+    CHECK(this->busy);
+    ASSERT(close || !closeRequired);
 
-    if (this->ioRead != NULL)
+    // If it looks like we were in the middle of a response then close the TLS session so we can start clean next time
+    if (close)
     {
-        // If it looks like we were in the middle of a response then close the TLS session so we can start clean next time
-        if (!this->contentEof)
-        {
-            tlsSessionFree(this->tlsSession);
-            this->tlsSession = NULL;
-        }
+        tlsSessionFree(this->tlsSession);
+        this->tlsSession = NULL;
 
-        ioReadFree(this->ioRead);
-        this->ioRead = NULL;
+        // If a close was required by the server then increment stats
+        if (closeRequired)
+            httpClientStatLocal.close++;
     }
+
+    this->busy = false;
 
     FUNCTION_LOG_RETURN_VOID();
 }
@@ -552,69 +409,4 @@ httpClientBusy(const HttpClient *this)
     ASSERT(this != NULL);
 
     FUNCTION_TEST_RETURN(this->ioRead);
-}
-
-/**********************************************************************************************************************************/
-IoRead *
-httpClientIoRead(const HttpClient *this)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(HTTP_CLIENT, this);
-    FUNCTION_TEST_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_TEST_RETURN(this->ioRead);
-}
-
-/**********************************************************************************************************************************/
-unsigned int
-httpClientResponseCode(const HttpClient *this)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(HTTP_CLIENT, this);
-    FUNCTION_TEST_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_TEST_RETURN(this->responseCode);
-}
-
-/**********************************************************************************************************************************/
-bool
-httpClientResponseCodeOk(const HttpClient *this)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(HTTP_CLIENT, this);
-    FUNCTION_TEST_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_TEST_RETURN(this->responseCode / 100 == 2);
-}
-
-/**********************************************************************************************************************************/
-const HttpHeader *
-httpClientResponseHeader(const HttpClient *this)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(HTTP_CLIENT, this);
-    FUNCTION_TEST_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_TEST_RETURN(this->responseHeader);
-}
-
-/**********************************************************************************************************************************/
-const String *
-httpClientResponseMessage(const HttpClient *this)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(HTTP_CLIENT, this);
-    FUNCTION_TEST_END();
-
-    ASSERT(this != NULL);
-
-    FUNCTION_TEST_RETURN(this->responseMessage);
 }

--- a/src/common/io/http/client.c
+++ b/src/common/io/http/client.c
@@ -59,6 +59,9 @@ Mark response object done
 ***********************************************************************************************************************************/
 OBJECT_DEFINE_FREE_RESOURCE_BEGIN(HTTP_CLIENT, LOG, logLevelTrace)
 {
+    // When the response is marked done it is going to call back into httpClientDone(). Set the TLS session NULL so it will not be
+    // freed again.
+    this->tlsSession = NULL;
     httpResponseDone(this->response);
 }
 OBJECT_DEFINE_FREE_RESOURCE_END(LOG);

--- a/src/common/io/http/client.c
+++ b/src/common/io/http/client.c
@@ -182,7 +182,7 @@ httpClientRequest(
                 // There are a few errors that might be permanently fatal but they are rare and it seems best not to try and pick
                 // and choose errors in this class to retry.
                 if (httpResponseCode(result) / 100 == HTTP_RESPONSE_CODE_RETRY_CLASS)
-                    THROW_FMT(ServiceError, "[%u] %s", httpResponseCode(result), strPtr(httpResponseMessage(result)));
+                    THROW_FMT(ServiceError, "[%u] %s", httpResponseCode(result), strPtr(httpResponseReason(result)));
 
                 // Move response to prior context
                 httpResponseMove(result, memContextPrior());

--- a/src/common/io/http/client.c
+++ b/src/common/io/http/client.c
@@ -123,13 +123,10 @@ httpClientRequest(
         {
             // Assume there will be no retry
             retry = false;
-            //
-            // // Free the read interface
-            // httpClientDone(this, false, false);
 
             TRY_BEGIN()
             {
-                // Set client busy and load request
+                // Set client busy get TLS session
                 this->busy = true;
 
                 if (this->tlsSession == NULL)
@@ -183,9 +180,6 @@ httpClientRequest(
                 // and choose errors in this class to retry.
                 if (httpResponseCode(result) / 100 == HTTP_RESPONSE_CODE_RETRY_CLASS)
                     THROW_FMT(ServiceError, "[%u] %s", httpResponseCode(result), strPtr(httpResponseReason(result)));
-
-                // Move response to prior context
-                httpResponseMove(result, memContextPrior());
             }
             CATCH_ANY()
             {
@@ -206,6 +200,9 @@ httpClientRequest(
             TRY_END();
         }
         while (retry);
+
+        // Move response to prior context
+        httpResponseMove(result, memContextPrior());
 
         httpClientStatLocal.request++;
     }

--- a/src/common/io/http/client.h
+++ b/src/common/io/http/client.h
@@ -89,7 +89,7 @@ void httpClientDone(HttpClient *this, bool close, bool closeRequired);
 // Perform a request
 HttpResponse *httpClientRequest(
     HttpClient *this, const String *verb, const String *uri, const HttpQuery *query, const HttpHeader *requestHeader,
-    const Buffer *body);
+    const Buffer *body, bool contentCache);
 
 // Format statistics to a string
 String *httpClientStatStr(void);

--- a/src/common/io/http/client.h
+++ b/src/common/io/http/client.h
@@ -21,6 +21,7 @@ typedef struct HttpClient HttpClient;
 
 #include "common/io/http/header.h"
 #include "common/io/http/query.h"
+#include "common/io/http/response.h"
 #include "common/io/read.h"
 #include "common/time.h"
 #include "common/type/stringList.h"
@@ -28,6 +29,9 @@ typedef struct HttpClient HttpClient;
 /***********************************************************************************************************************************
 HTTP Constants
 ***********************************************************************************************************************************/
+#define HTTP_VERSION                                                "HTTP/1.1"
+    STRING_DECLARE(HTTP_VERSION_STR);
+
 #define HTTP_VERB_DELETE                                            "DELETE"
     STRING_DECLARE(HTTP_VERB_DELETE_STR);
 #define HTTP_VERB_GET                                               "GET"
@@ -80,33 +84,15 @@ Functions
 bool httpClientBusy(const HttpClient *this);
 
 // Mark the client as done if read is complete
-void httpClientDone(HttpClient *this);
+void httpClientDone(HttpClient *this, bool close, bool closeRequired);
 
 // Perform a request
-Buffer *httpClientRequest(
+HttpResponse *httpClientRequest(
     HttpClient *this, const String *verb, const String *uri, const HttpQuery *query, const HttpHeader *requestHeader,
-    const Buffer *body, bool returnContent);
-
-// Is this response code OK, i.e. 2XX?
-bool httpClientResponseCodeOk(const HttpClient *this);
+    const Buffer *body);
 
 // Format statistics to a string
 String *httpClientStatStr(void);
-
-/***********************************************************************************************************************************
-Getters/Setters
-***********************************************************************************************************************************/
-// Read interface
-IoRead *httpClientIoRead(const HttpClient *this);
-
-// Get the response code
-unsigned int httpClientResponseCode(const HttpClient *this);
-
-// Response headers
-const HttpHeader *httpClientResponseHeader(const HttpClient *this);
-
-// Response message
-const String *httpClientResponseMessage(const HttpClient *this);
 
 /***********************************************************************************************************************************
 Destructor

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -84,6 +84,7 @@ httpResponseRead(THIS_VOID, Buffer *buffer, bool block)
     ASSERT(this != NULL);
     ASSERT(buffer != NULL);
     ASSERT(!bufFull(buffer));
+    ASSERT(this->contentEof || this->rawRead != NULL);
 
     // Read if EOF has not been reached
     size_t actualBytes = 0;

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -373,6 +373,19 @@ httpResponseContent(HttpResponse *this)
 }
 
 /**********************************************************************************************************************************/
+bool
+httpResponseBusy(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->httpClient != NULL);
+}
+
+/**********************************************************************************************************************************/
 void
 httpResponseDone(HttpResponse *this)
 {

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -1,0 +1,387 @@
+/***********************************************************************************************************************************
+Http Response
+***********************************************************************************************************************************/
+#include "build.auto.h"
+
+#include "common/debug.h"
+#include "common/io/http/client.h"
+#include "common/io/http/common.h"
+#include "common/io/io.h"
+#include "common/io/read.intern.h"
+#include "common/io/tls/client.h"
+#include "common/log.h"
+#include "common/type/object.h"
+#include "common/wait.h"
+
+/***********************************************************************************************************************************
+Http constants
+***********************************************************************************************************************************/
+#define HTTP_HEADER_CONNECTION                                      "connection"
+    STRING_STATIC(HTTP_HEADER_CONNECTION_STR,                       HTTP_HEADER_CONNECTION);
+#define HTTP_HEADER_TRANSFER_ENCODING                               "transfer-encoding"
+    STRING_STATIC(HTTP_HEADER_TRANSFER_ENCODING_STR,                HTTP_HEADER_TRANSFER_ENCODING);
+
+#define HTTP_VALUE_CONNECTION_CLOSE                                 "close"
+    STRING_STATIC(HTTP_VALUE_CONNECTION_CLOSE_STR,                  HTTP_VALUE_CONNECTION_CLOSE);
+#define HTTP_VALUE_TRANSFER_ENCODING_CHUNKED                        "chunked"
+    STRING_STATIC(HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR,         HTTP_VALUE_TRANSFER_ENCODING_CHUNKED);
+
+// 5xx errors that should always be retried
+#define HTTP_RESPONSE_CODE_RETRY_CLASS                              5
+
+/***********************************************************************************************************************************
+Object type
+***********************************************************************************************************************************/
+struct HttpResponse
+{
+    MemContext *memContext;                                         // Mem context
+
+    HttpClient *httpClient;                                         // HTTP client
+    IoRead *rawRead;                                                // Raw read interface passed from client
+    IoRead *contentRead;                                            // Read interface for response content
+
+    unsigned int responseCode;                                      // Response code (e.g. 200, 404)
+    String *responseMessage;                                        // Response message e.g. (OK, Not Found)
+    HttpHeader *responseHeader;                                     // Response headers
+
+    bool contentChunked;                                            // Is the response content chunked?
+    uint64_t contentSize;                                           // Content size (ignored for chunked)
+    uint64_t contentRemaining;                                      // Content remaining (per chunk if chunked)
+    bool closeOnContentEof;                                         // Will server close after content is sent?
+    bool contentEof;                                                // Has all content been read?
+};
+
+OBJECT_DEFINE_MOVE(HTTP_HEADER);
+OBJECT_DEFINE_FREE(HTTP_RESPONSE);
+
+/***********************************************************************************************************************************
+Read content
+***********************************************************************************************************************************/
+static size_t
+httpResponseRead(THIS_VOID, Buffer *buffer, bool block)
+{
+    THIS(HttpResponse);
+
+    FUNCTION_LOG_BEGIN(logLevelTrace);
+        FUNCTION_LOG_PARAM(HTTP_RESPONSE, this);
+        FUNCTION_LOG_PARAM(BUFFER, buffer);
+        FUNCTION_LOG_PARAM(BOOL, block);
+    FUNCTION_LOG_END();
+
+    ASSERT(this != NULL);
+    ASSERT(buffer != NULL);
+    ASSERT(!bufFull(buffer));
+
+    // Read if EOF has not been reached
+    size_t actualBytes = 0;
+
+    if (!this->contentEof)
+    {
+        // If close was requested and no content specified then the server may send content up until the eof
+        if (this->closeOnContentEof && !this->contentChunked && this->contentSize == 0)
+        {
+            ioRead(this->rawRead, buffer);
+            this->contentEof = ioReadEof(this->rawRead);
+        }
+        // Else read using specified encoding or size
+        else
+        {
+            do
+            {
+                // If chunked content and no content remaining
+                if (this->contentChunked && this->contentRemaining == 0)
+                {
+                    // Read length of next chunk
+                    MEM_CONTEXT_TEMP_BEGIN()
+                    {
+                        this->contentRemaining = cvtZToUInt64Base(
+                            strPtr(strTrim(ioReadLine(this->rawRead))), 16);
+                    }
+                    MEM_CONTEXT_TEMP_END();
+
+                    // If content remaining is still zero then eof
+                    if (this->contentRemaining == 0)
+                        this->contentEof = true;
+                }
+
+                // Read if there is content remaining
+                if (this->contentRemaining > 0)
+                {
+                    // If the buffer is larger than the content that needs to be read then limit the buffer size so the read won't
+                    // block or read too far.  Casting to size_t is safe on 32-bit because we know the max buffer size is defined as
+                    // less than 2^32 so content remaining can't be more than that.
+                    if (bufRemains(buffer) > this->contentRemaining)
+                        bufLimitSet(buffer, bufSize(buffer) - (bufRemains(buffer) - (size_t)this->contentRemaining));
+
+                    actualBytes = bufRemains(buffer);
+                    this->contentRemaining -= ioRead(this->rawRead, buffer);
+
+                    // Error if EOF but content read is not complete
+                    if (ioReadEof(this->rawRead))
+                        THROW(FileReadError, "unexpected EOF reading HTTP content");
+
+                    // Clear limit (this works even if the limit was not set and it is easier than checking)
+                    bufLimitClear(buffer);
+                }
+
+                // If no content remaining
+                if (this->contentRemaining == 0)
+                {
+                    // If chunked then consume the blank line that follows every chunk.  There might be more chunk data so loop back
+                    // around to check.
+                    if (this->contentChunked)
+                    {
+                        ioReadLine(this->rawRead);
+                    }
+                    // If total content size was provided then this is eof
+                    else
+                        this->contentEof = true;
+                }
+            }
+            while (!bufFull(buffer) && !this->contentEof);
+        }
+
+        // If the server notified that it would close the connection after sending content then close the client side
+        if (this->contentEof)
+            httpClientDone(this->httpClient, true, this->closeOnContentEof);
+    }
+
+    FUNCTION_LOG_RETURN(SIZE, (size_t)actualBytes);
+}
+
+/***********************************************************************************************************************************
+Has all content been read?
+***********************************************************************************************************************************/
+static bool
+httpResponseEof(THIS_VOID)
+{
+    THIS(HttpResponse);
+
+    FUNCTION_LOG_BEGIN(logLevelTrace);
+        FUNCTION_LOG_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_LOG_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_LOG_RETURN(BOOL, this->contentEof);
+}
+
+/**********************************************************************************************************************************/
+HttpResponse *
+httpResponseNew(HttpClient *client, IoRead *read, const String *verb, bool ignoreContent)
+{
+    FUNCTION_LOG_BEGIN(logLevelDebug)
+        FUNCTION_LOG_PARAM(HTTP_CLIENT, client);
+        FUNCTION_LOG_PARAM(IO_READ, read);
+        FUNCTION_LOG_PARAM(STRING, verb);
+    FUNCTION_LOG_END();
+
+    ASSERT(host != NULL);
+
+    HttpResponse *this = NULL;
+
+    MEM_CONTEXT_NEW_BEGIN("HttpResponse")
+    {
+        this = memNew(sizeof(HttpResponse));
+
+        *this = (HttpResponse)
+        {
+            .memContext = MEM_CONTEXT_NEW(),
+            .httpClient = client,
+            .rawRead = read,
+        };
+
+        // Read status
+        String *status = ioReadLine(this->rawRead);
+
+        // Check status ends with a CR and remove it to make error formatting easier and more accurate
+        if (!strEndsWith(status, CR_STR))
+            THROW_FMT(FormatError, "http response status '%s' should be CR-terminated", strPtr(status));
+
+        status = strSubN(status, 0, strSize(status) - 1);
+
+        // Check status is at least the minimum required length to avoid harder to interpret errors later on
+        if (strSize(status) < sizeof(HTTP_VERSION) + 4)
+            THROW_FMT(FormatError, "http response '%s' has invalid length", strPtr(strTrim(status)));
+
+        // Check status starts with the correct http version
+         if (!strBeginsWith(status, HTTP_VERSION_STR))
+            THROW_FMT(FormatError, "http version of response '%s' must be " HTTP_VERSION, strPtr(status));
+
+        // Read status code
+        status = strSub(status, sizeof(HTTP_VERSION));
+
+        int spacePos = strChr(status, ' ');
+
+        if (spacePos != 3)
+            THROW_FMT(FormatError, "response status '%s' must have a space after the status code", strPtr(status));
+
+        this->responseCode = cvtZToUInt(strPtr(strSubN(status, 0, (size_t)spacePos)));
+
+        // Read reason phrase. A missing reason phrase will be represented as an empty string.
+        MEM_CONTEXT_BEGIN(this->memContext)
+        {
+            this->responseMessage = strSub(status, (size_t)spacePos + 1);
+        }
+        MEM_CONTEXT_END();
+
+        // Read headers
+        MEM_CONTEXT_BEGIN(this->memContext)
+        {
+            this->responseHeader = httpHeaderNew(NULL);
+        }
+        MEM_CONTEXT_END();
+
+        do
+        {
+            // Read the next header
+            String *header = strTrim(ioReadLine(this->rawRead));
+
+            // If the header is empty then we have reached the end of the headers
+            if (strSize(header) == 0)
+                break;
+
+            // Split the header and store it
+            int colonPos = strChr(header, ':');
+
+            if (colonPos < 0)
+                THROW_FMT(FormatError, "header '%s' missing colon", strPtr(strTrim(header)));
+
+            String *headerKey = strLower(strTrim(strSubN(header, 0, (size_t)colonPos)));
+            String *headerValue = strTrim(strSub(header, (size_t)colonPos + 1));
+
+            httpHeaderAdd(this->responseHeader, headerKey, headerValue);
+
+            // Read transfer encoding (only chunked is supported)
+            if (strEq(headerKey, HTTP_HEADER_TRANSFER_ENCODING_STR))
+            {
+                // Error if transfer encoding is not chunked
+                if (!strEq(headerValue, HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR))
+                {
+                    THROW_FMT(
+                        FormatError, "only '%s' is supported for '%s' header", HTTP_VALUE_TRANSFER_ENCODING_CHUNKED,
+                        HTTP_HEADER_TRANSFER_ENCODING);
+                }
+
+                this->contentChunked = true;
+            }
+
+            // Read content size
+            if (strEq(headerKey, HTTP_HEADER_CONTENT_LENGTH_STR))
+            {
+                this->contentSize = cvtZToUInt64(strPtr(headerValue));
+                this->contentRemaining = this->contentSize;
+            }
+
+            // If the server notified of a closed connection then close the client connection after reading content.  This
+            // prevents doing a retry on the next request when using the closed connection.
+            if (strEq(headerKey, HTTP_HEADER_CONNECTION_STR) && strEq(headerValue, HTTP_VALUE_CONNECTION_CLOSE_STR))
+            {
+                this->closeOnContentEof = true;
+                httpResponseStatLocal.close++;
+            }
+        }
+        while (1);
+
+        // Error if transfer encoding and content length are both set
+        if (this->contentChunked && this->contentSize > 0)
+        {
+            THROW_FMT(
+                FormatError,  "'%s' and '%s' headers are both set", HTTP_HEADER_TRANSFER_ENCODING,
+                HTTP_HEADER_CONTENT_LENGTH);
+        }
+
+        // Was content returned in the response?  HEAD will report content but not actually return any.
+        bool contentExists =
+            (this->contentChunked || this->contentSize > 0 || this->closeOnContentEof) && !strEq(verb, HTTP_VERB_HEAD_STR);
+        this->contentEof = !contentExists;
+
+        // Create an io object, even if there is no content.  This makes the logic for readers easier -- they can just check eof
+        // rather than also checking if the io object exists.
+        MEM_CONTEXT_BEGIN(this->memContext)
+        {
+            this->contentRead = ioReadNewP(this, .eof = httpResponseEof, .read = httpResponseRead);
+            ioReadOpen(this->contentRead);
+        }
+        MEM_CONTEXT_END();
+
+        // If the server notified that it would close the connection and there is no content then close the client side
+        if (this->closeOnContentEof && !contentExists)
+            httpClientDone(this->httpClient, true);
+
+        // Retry when response code is 5xx.  These errors generally represent a server error for a request that looks valid.
+        // There are a few errors that might be permanently fatal but they are rare and it seems best not to try and pick
+        // and choose errors in this class to retry.
+        if (httpResponseResponseCode(this) / 100 == HTTP_RESPONSE_CODE_RETRY_CLASS)
+            THROW_FMT(ServiceError, "[%u] %s", httpResponseResponseCode(this), strPtr(httpResponseResponseMessage(this)));
+
+    }
+    MEM_CONTEXT_NEW_END();
+
+    FUNCTION_LOG_RETURN(HTTP_RESPONSE, this);
+}
+
+/**********************************************************************************************************************************/
+IoRead *
+httpResponseIoRead(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->contentRead);
+}
+
+/**********************************************************************************************************************************/
+unsigned int
+httpResponseCode(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->responseCode);
+}
+
+/**********************************************************************************************************************************/
+bool
+httpResponseCodeOk(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->responseCode / 100 == 2);
+}
+
+/**********************************************************************************************************************************/
+const HttpHeader *
+httpResponseHeader(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->responseHeader);
+}
+
+/**********************************************************************************************************************************/
+const String *
+httpResponseMessage(const HttpResponse *this)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_RESPONSE, this);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+
+    FUNCTION_TEST_RETURN(this->responseMessage);
+}

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -1,0 +1,68 @@
+/***********************************************************************************************************************************
+Http Response
+
+???
+***********************************************************************************************************************************/
+#ifndef COMMON_IO_HTTP_RESPONSE_H
+#define COMMON_IO_HTTP_RESPONSE_H
+
+/***********************************************************************************************************************************
+Object type
+***********************************************************************************************************************************/
+#define HTTP_RESPONSE_TYPE                                          HttpResponse
+#define HTTP_RESPONSE_PREFIX                                        httpResponse
+
+typedef struct HttpResponse HttpResponse;
+
+#include "common/io/http/header.h"
+#include "common/io/read.h"
+
+/***********************************************************************************************************************************
+HTTP Response Constants
+***********************************************************************************************************************************/
+#define HTTP_RESPONSE_CODE_FORBIDDEN                                403
+#define HTTP_RESPONSE_CODE_NOT_FOUND                                404
+
+/***********************************************************************************************************************************
+Constructors
+***********************************************************************************************************************************/
+HttpResponse *httpResponseNew(HttpClient *client, IoRead *read);
+
+/***********************************************************************************************************************************
+Functions
+***********************************************************************************************************************************/
+// Is this response code OK, i.e. 2XX?
+bool httpResponseCodeOk(const HttpResponse *this);
+
+// Move to a new parent mem context
+HttpHeader *httpResponseMove(HttpResponse *this, MemContext *parentNew);
+
+/***********************************************************************************************************************************
+Getters/Setters
+***********************************************************************************************************************************/
+// Read interface
+IoRead *httpResponseIoRead(const HttpResponse *this);
+
+// Get the response code
+unsigned int httpResponseCode(const HttpResponse *this);
+
+// Response headers
+const HttpHeader *httpResponseHeader(const HttpResponse *this);
+
+// Response message
+const String *httpResponseMessage(const HttpResponse *this);
+
+/***********************************************************************************************************************************
+Destructor
+***********************************************************************************************************************************/
+void httpResponseFree(HttpResponse *this);
+
+/***********************************************************************************************************************************
+Macros for function logging
+***********************************************************************************************************************************/
+#define FUNCTION_LOG_HTTP_RESPONSE_TYPE                                                                                            \
+    HttpResponse *
+#define FUNCTION_LOG_HTTP_RESPONSE_FORMAT(value, buffer, bufferSize)                                                               \
+    objToLog(value, "HttpResponse", buffer, bufferSize)
+
+#endif

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -1,7 +1,8 @@
 /***********************************************************************************************************************************
 Http Response
 
-???
+Response created after a successful request. Once the content is read the underlying connection may be recycled but the headers,
+cached content, etc. will still be available for the lifetime of the object.
 ***********************************************************************************************************************************/
 #ifndef COMMON_IO_HTTP_RESPONSE_H
 #define COMMON_IO_HTTP_RESPONSE_H

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -55,8 +55,8 @@ unsigned int httpResponseCode(const HttpResponse *this);
 // Response headers
 const HttpHeader *httpResponseHeader(const HttpResponse *this);
 
-// Response message
-const String *httpResponseMessage(const HttpResponse *this);
+// Response reason
+const String *httpResponseReason(const HttpResponse *this);
 
 /***********************************************************************************************************************************
 Destructor

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -26,7 +26,7 @@ HTTP Response Constants
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-HttpResponse *httpResponseNew(HttpClient *client, IoRead *read);
+HttpResponse *httpResponseNew(HttpClient *client, IoRead *read, const String *verb);
 
 /***********************************************************************************************************************************
 Functions
@@ -34,14 +34,20 @@ Functions
 // Is this response code OK, i.e. 2XX?
 bool httpResponseCodeOk(const HttpResponse *this);
 
+// Get response content. Content will be cached so it can be retrieved again without additional cost.
+const Buffer *httpResponseContent(HttpResponse *this);
+
+// No longer need to load new content. Cached content, headers, etc. will still be available.
+void httpResponseDone(HttpResponse *this);
+
 // Move to a new parent mem context
-HttpHeader *httpResponseMove(HttpResponse *this, MemContext *parentNew);
+HttpResponse *httpResponseMove(HttpResponse *this, MemContext *parentNew);
 
 /***********************************************************************************************************************************
 Getters/Setters
 ***********************************************************************************************************************************/
 // Read interface
-IoRead *httpResponseIoRead(const HttpResponse *this);
+IoRead *httpResponseIoRead(HttpResponse *this);
 
 // Get the response code
 unsigned int httpResponseCode(const HttpResponse *this);

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -47,6 +47,9 @@ HttpResponse *httpResponseMove(HttpResponse *this, MemContext *parentNew);
 /***********************************************************************************************************************************
 Getters/Setters
 ***********************************************************************************************************************************/
+// Is the response still being read?
+bool httpResponseBusy(const HttpResponse *this);
+
 // Read interface
 IoRead *httpResponseIoRead(HttpResponse *this);
 

--- a/src/common/io/http/response.h
+++ b/src/common/io/http/response.h
@@ -26,7 +26,7 @@ HTTP Response Constants
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-HttpResponse *httpResponseNew(HttpClient *client, IoRead *read, const String *verb);
+HttpResponse *httpResponseNew(HttpClient *client, IoRead *read, const String *verb, bool contentCache);
 
 /***********************************************************************************************************************************
 Functions
@@ -66,9 +66,11 @@ void httpResponseFree(HttpResponse *this);
 /***********************************************************************************************************************************
 Macros for function logging
 ***********************************************************************************************************************************/
+String *httpResponseToLog(const HttpResponse *this);
+
 #define FUNCTION_LOG_HTTP_RESPONSE_TYPE                                                                                            \
     HttpResponse *
 #define FUNCTION_LOG_HTTP_RESPONSE_FORMAT(value, buffer, bufferSize)                                                               \
-    objToLog(value, "HttpResponse", buffer, bufferSize)
+    FUNCTION_LOG_STRING_OBJECT_FORMAT(value, httpResponseToLog, buffer, bufferSize)
 
 #endif

--- a/src/storage/s3/read.c
+++ b/src/storage/s3/read.c
@@ -27,7 +27,7 @@ typedef struct StorageReadS3
     StorageReadInterface interface;                                 // Interface
     StorageS3 *storage;                                             // Storage that created this object
 
-    HttpClient *httpClient;                                         // Http client for requests
+    HttpResponse *httpResponse;                                     // Http response
 } StorageReadS3;
 
 /***********************************************************************************************************************************
@@ -37,15 +37,6 @@ Macros for function logging
     StorageReadS3 *
 #define FUNCTION_LOG_STORAGE_READ_S3_FORMAT(value, buffer, bufferSize)                                                             \
     objToLog(value, "StorageReadS3", buffer, bufferSize)
-
-/***********************************************************************************************************************************
-Mark http client as done so it can be reused
-***********************************************************************************************************************************/
-OBJECT_DEFINE_FREE_RESOURCE_BEGIN(STORAGE_READ_S3, LOG, logLevelTrace)
-{
-    httpClientDone(this->httpClient);
-}
-OBJECT_DEFINE_FREE_RESOURCE_END(LOG);
 
 /***********************************************************************************************************************************
 Open the file
@@ -60,16 +51,15 @@ storageReadS3Open(THIS_VOID)
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
-    ASSERT(this->httpClient == NULL);
+    ASSERT(this->httpResponse == NULL);
 
     bool result = false;
 
     // Request the file
-    this->httpClient = storageS3Request(this->storage, HTTP_VERB_GET_STR, this->interface.name, NULL, NULL, false, true).httpClient;
+    this->httpResponse = storageS3Request(this->storage, HTTP_VERB_GET_STR, this->interface.name, NULL, NULL, true, true);
 
-    if (httpClientResponseCodeOk(this->httpClient))
+    if (httpResponseCodeOk(this->httpResponse))
     {
-        memContextCallbackSet(this->memContext, storageReadS3FreeResource, this);
         result = true;
     }
     // Else error unless ignore missing
@@ -93,11 +83,11 @@ storageReadS3(THIS_VOID, Buffer *buffer, bool block)
         FUNCTION_LOG_PARAM(BOOL, block);
     FUNCTION_LOG_END();
 
-    ASSERT(this != NULL && this->httpClient != NULL);
-    ASSERT(httpClientIoRead(this->httpClient) != NULL);
+    ASSERT(this != NULL && this->httpResponse != NULL);
+    ASSERT(httpResponseIoRead(this->httpResponse) != NULL);
     ASSERT(buffer != NULL && !bufFull(buffer));
 
-    FUNCTION_LOG_RETURN(SIZE, ioRead(httpClientIoRead(this->httpClient), buffer));
+    FUNCTION_LOG_RETURN(SIZE, ioRead(httpResponseIoRead(this->httpResponse), buffer));
 }
 
 /***********************************************************************************************************************************
@@ -113,11 +103,8 @@ storageReadS3Close(THIS_VOID)
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
-    ASSERT(this->httpClient != NULL);
 
-    memContextCallbackClear(this->memContext);
-    storageReadS3FreeResource(this);
-    this->httpClient = NULL;
+    httpResponseDone(this->httpResponse);
 
     FUNCTION_LOG_RETURN_VOID();
 }
@@ -134,10 +121,10 @@ storageReadS3Eof(THIS_VOID)
         FUNCTION_TEST_PARAM(STORAGE_READ_S3, this);
     FUNCTION_TEST_END();
 
-    ASSERT(this != NULL && this->httpClient != NULL);
-    ASSERT(httpClientIoRead(this->httpClient) != NULL);
+    ASSERT(this != NULL && this->httpResponse != NULL);
+    ASSERT(httpResponseIoRead(this->httpResponse) != NULL);
 
-    FUNCTION_TEST_RETURN(ioReadEof(httpClientIoRead(this->httpClient)));
+    FUNCTION_TEST_RETURN(ioReadEof(httpResponseIoRead(this->httpResponse)));
 }
 
 /**********************************************************************************************************************************/

--- a/src/storage/s3/read.c
+++ b/src/storage/s3/read.c
@@ -56,7 +56,11 @@ storageReadS3Open(THIS_VOID)
     bool result = false;
 
     // Request the file
-    this->httpResponse = storageS3Request(this->storage, HTTP_VERB_GET_STR, this->interface.name, NULL, NULL, true, true);
+    MEM_CONTEXT_BEGIN(this->memContext)
+    {
+        this->httpResponse = storageS3Request(this->storage, HTTP_VERB_GET_STR, this->interface.name, NULL, NULL, true, true);
+    }
+    MEM_CONTEXT_END();
 
     if (httpResponseCodeOk(this->httpResponse))
     {

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -328,7 +328,7 @@ storageS3Request(
                 {
                     // General error message
                     String *error = strNewFmt(
-                        "S3 request failed with %u: %s", httpResponseCode(result), strPtr(httpResponseMessage(result)));
+                        "S3 request failed with %u: %s", httpResponseCode(result), strPtr(httpResponseReason(result)));
 
                     // Output uri/query
                     strCat(error, "\n*** URI/Query ***:");

--- a/src/storage/s3/storage.intern.h
+++ b/src/storage/s3/storage.intern.h
@@ -16,8 +16,9 @@ typedef struct StorageS3 StorageS3;
 Functions
 ***********************************************************************************************************************************/
 // Perform an S3 request
-HttpResponse storageS3Request(
-    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool allowMissing);
+HttpResponse *storageS3Request(
+    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool contentRequired,
+    bool allowMissing);
 
 /***********************************************************************************************************************************
 Macros for function logging

--- a/src/storage/s3/storage.intern.h
+++ b/src/storage/s3/storage.intern.h
@@ -13,23 +13,11 @@ typedef struct StorageS3 StorageS3;
 #include "storage/s3/storage.h"
 
 /***********************************************************************************************************************************
-Perform an S3 Request
+Functions
 ***********************************************************************************************************************************/
-#define FUNCTION_LOG_STORAGE_S3_REQUEST_RESULT_TYPE                                                                                \
-    StorageS3RequestResult
-#define FUNCTION_LOG_STORAGE_S3_REQUEST_RESULT_FORMAT(value, buffer, bufferSize)                                                   \
-    objToLog(&value, "StorageS3RequestResult", buffer, bufferSize)
-
-typedef struct StorageS3RequestResult
-{
-    HttpClient *httpClient;
-    HttpHeader *responseHeader;
-    Buffer *response;
-} StorageS3RequestResult;
-
-StorageS3RequestResult storageS3Request(
-    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool returnContent,
-    bool allowMissing);
+// Perform an S3 request
+HttpResponse storageS3Request(
+    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool allowMissing);
 
 /***********************************************************************************************************************************
 Macros for function logging

--- a/src/storage/s3/storage.intern.h
+++ b/src/storage/s3/storage.intern.h
@@ -17,7 +17,7 @@ Functions
 ***********************************************************************************************************************************/
 // Perform an S3 request
 HttpResponse *storageS3Request(
-    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool contentRequired,
+    StorageS3 *this, const String *verb, const String *uri, const HttpQuery *query, const Buffer *body, bool contentIo,
     bool allowMissing);
 
 /***********************************************************************************************************************************

--- a/src/storage/s3/write.c
+++ b/src/storage/s3/write.c
@@ -98,9 +98,10 @@ storageWriteS3Part(StorageWriteS3 *this)
             // Initiate mult-part upload
             XmlNode *xmlRoot = xmlDocumentRoot(
                 xmlDocumentNewBuf(
-                    storageS3Request(
-                        this->storage, HTTP_VERB_POST_STR, this->interface.name,
-                        httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOADS_STR, EMPTY_STR), NULL, true, false).response));
+                    httpResponseContent(
+                        storageS3Request(
+                            this->storage, HTTP_VERB_POST_STR, this->interface.name,
+                            httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOADS_STR, EMPTY_STR), NULL, true, false))));
 
             // Store the upload id
             MEM_CONTEXT_BEGIN(this->memContext)
@@ -119,8 +120,9 @@ storageWriteS3Part(StorageWriteS3 *this)
         strLstAdd(
             this->uploadPartList,
             httpHeaderGet(
-                storageS3Request(
-                    this->storage, HTTP_VERB_PUT_STR, this->interface.name, query, this->partBuffer, true, false).responseHeader,
+                httpResponseHeader(
+                    storageS3Request(
+                        this->storage, HTTP_VERB_PUT_STR, this->interface.name, query, this->partBuffer, false, false)),
                 HTTP_HEADER_ETAG_STR));
 
         ASSERT(strLstGet(this->uploadPartList, strLstSize(this->uploadPartList) - 1) != NULL);
@@ -208,13 +210,13 @@ storageWriteS3Close(THIS_VOID)
                 // Finalize the multi-part upload
                 storageS3Request(
                     this->storage, HTTP_VERB_POST_STR, this->interface.name,
-                    httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOAD_ID_STR, this->uploadId), xmlDocumentBuf(partList), true, false);
+                    httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOAD_ID_STR, this->uploadId), xmlDocumentBuf(partList), false, false);
             }
             // Else upload all the data in a single put
             else
             {
                 storageS3Request(
-                    this->storage, HTTP_VERB_PUT_STR, this->interface.name, NULL, this->partBuffer, true, false);
+                    this->storage, HTTP_VERB_PUT_STR, this->interface.name, NULL, this->partBuffer, false, false);
             }
 
             bufFree(this->partBuffer);

--- a/src/storage/s3/write.c
+++ b/src/storage/s3/write.c
@@ -101,7 +101,7 @@ storageWriteS3Part(StorageWriteS3 *this)
                     httpResponseContent(
                         storageS3Request(
                             this->storage, HTTP_VERB_POST_STR, this->interface.name,
-                            httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOADS_STR, EMPTY_STR), NULL, true, false))));
+                            httpQueryAdd(httpQueryNew(), S3_QUERY_UPLOADS_STR, EMPTY_STR), NULL, false, false))));
 
             // Store the upload id
             MEM_CONTEXT_BEGIN(this->memContext)

--- a/test/define.yaml
+++ b/test/define.yaml
@@ -254,14 +254,11 @@ unit:
 
         coverage:
           common/io/http/cache: full
-          # common/io/http/client: full
+          common/io/http/client: full
           common/io/http/common: full
           common/io/http/header: full
           common/io/http/query: full
           common/io/http/response: full
-
-        include:
-          - common/io/http/client
 
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: compress

--- a/test/define.yaml
+++ b/test/define.yaml
@@ -258,6 +258,7 @@ unit:
           common/io/http/common: full
           common/io/http/header: full
           common/io/http/query: full
+          common/io/http/response: full
 
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: compress

--- a/test/define.yaml
+++ b/test/define.yaml
@@ -254,11 +254,14 @@ unit:
 
         coverage:
           common/io/http/cache: full
-          common/io/http/client: full
+          # common/io/http/client: full
           common/io/http/common: full
           common/io/http/header: full
           common/io/http/query: full
           common/io/http/response: full
+
+        include:
+          - common/io/http/client
 
       # ----------------------------------------------------------------------------------------------------------------------------
       - name: compress

--- a/test/src/common/harnessTls.c
+++ b/test/src/common/harnessTls.c
@@ -311,6 +311,9 @@ void hrnTlsServerRunParam(IoRead *read, const String *certificate, const String 
 
             case hrnTlsCmdClose:
             {
+                if (serverSession == NULL)
+                    THROW(AssertError, "TLS session is already closed");
+
                 tlsSessionClose(serverSession, true);
                 tlsSessionFree(serverSession);
                 serverSession = NULL;

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -555,14 +555,14 @@ testRun(void)
         TEST_RESULT_PTR(httpClientCacheGet(cache), *(HttpClient **)lstGet(cache->clientList, 0), "    get same http client");
 
         // Make client 1 look like it is busy
-        client1->busy = true;
+        client1->response = (HttpResponse *)1;
 
         TEST_ASSIGN(client2, httpClientCacheGet(cache), "get http client");
         TEST_RESULT_PTR(client2, *(HttpClient **)lstGet(cache->clientList, 1), "    check http client");
         TEST_RESULT_BOOL(client1 != client2, true, "clients are not the same");
 
         // Set back to NULL so bad things don't happen during free
-        client1->busy = false;
+        client1->response = NULL;
 
         TEST_RESULT_VOID(httpClientCacheFree(cache), "free http client cache");
     }

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -139,7 +139,7 @@ testRun(void)
             "new client");
 
         TEST_ERROR_FMT(
-            httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), HostConnectError,
+            httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), HostConnectError,
             "unable to connect to 'localhost:%u': [111] Connection refused", hrnTlsServerPort());
 
         HARNESS_FORK_BEGIN()
@@ -179,7 +179,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FileReadError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FileReadError,
                     "unexpected eof while reading line");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -193,7 +193,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "http response status 'HTTP/1.0 200 OK' should be CR-terminated");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -207,7 +207,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "http response 'HTTP/1.0 200' has invalid length");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -221,7 +221,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "http version of response 'HTTP/1.0 200 OK' must be HTTP/1.1");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -235,7 +235,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "response status '200OK' must have a space after the status code");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -249,7 +249,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FileReadError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FileReadError,
                     "unexpected eof while reading line");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -263,7 +263,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "header 'header-value' missing colon");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -277,7 +277,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "only 'chunked' is supported for 'transfer-encoding' header");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -291,7 +291,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), FormatError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), FormatError,
                     "'transfer-encoding' and 'content-length' headers are both set");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -305,7 +305,7 @@ testRun(void)
                 hrnTlsServerClose();
 
                 TEST_ERROR(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), ServiceError,
+                    httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL), ServiceError,
                     "[503] Slow Down");
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -331,180 +331,184 @@ testRun(void)
 
                 client->timeout = 5000;
 
-                TEST_RESULT_VOID(
-                    httpClientRequest(client, strNew("GET"), strNew("/"), query, headerRequest, NULL, false), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
-                TEST_RESULT_UINT(httpClientEof(client), true, "io is eof");
+                HttpResponse *response = NULL;
+
+                TEST_ASSIGN(
+                    response, httpClientRequest(client, strNew("GET"), strNew("/"), query, headerRequest, NULL), "request");
+                TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
+                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_UINT(httpResponseEof(response), true, "io is eof");
                 TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{connection: 'ack', key1: '0', key2: 'value2'}",
+                    httpHeaderToLog(httpResponseHeader(response)),  "{connection: 'ack', key1: '0', key2: 'value2'}",
                     "check response headers");
 
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("head request with content-length but no content");
+                TEST_RESULT_VOID(httpResponseFree(response), "free response");
 
-                hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:380\r\n\r\n");
-
-                TEST_RESULT_VOID(
-                    httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
-                TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
-                TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '380'}", "check response headers");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("head request with transfer encoding but no content");
-
-                hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
-
-                TEST_RESULT_VOID(
-                    httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
-                TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
-                TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{transfer-encoding: 'chunked'}", "check response headers");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("head request with connection close but no content");
-
-                hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nConnection:close\r\n\r\n");
-
-                hrnTlsServerClose();
-
-                TEST_RESULT_VOID(
-                    httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
-                TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
-                TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{connection: 'close'}", "check response headers");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("error with content (with a few slow down errors)");
-
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 503 Slow Down\r\ncontent-length:3\r\nConnection:close\r\n\r\n123");
-
-                hrnTlsServerClose();
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 503 Slow Down\r\nTransfer-Encoding:chunked\r\nConnection:close\r\n\r\n0\r\n\r\n");
-
-                hrnTlsServerClose();
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 404 Not Found\r\ncontent-length:0\r\n\r\n");
-
-                TEST_RESULT_VOID(httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 404, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "Not Found", "check response message");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '0'}", "check response headers");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("error with content");
-
-                hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 403 \r\ncontent-length:7\r\n\r\nCONTENT");
-
-                Buffer *buffer = NULL;
-
-                TEST_ASSIGN(buffer, httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
-                TEST_RESULT_UINT(httpClientResponseCode(client), 403, "check response code");
-                TEST_RESULT_STR_Z(httpClientResponseMessage(client), "", "check empty response message");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '7'}", "check response headers");
-                TEST_RESULT_STR_Z(strNewBuf(buffer),  "CONTENT", "check response");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("request with content using content-length");
-
-                hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\ncontent-length:30\r\n\r\n012345678901234567890123456789");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nConnection:close\r\n\r\n01234567890123456789012345678901");
-
-                hrnTlsServerClose();
-
-                ioBufferSizeSet(30);
-
-                TEST_ASSIGN(
-                    buffer,
-                    httpClientRequest(
-                        client, strNew("GET"), strNew("/path/file 1.txt"), NULL,
-                        httpHeaderAdd(httpHeaderNew(NULL), strNew("content-length"), strNew("30")),
-                        BUFSTRDEF("012345678901234567890123456789"), true),
-                    "request");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{connection: 'close'}", "check response headers");
-                TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901", "check response");
-                TEST_RESULT_UINT(httpClientRead(client, bufNew(1), true), 0, "call internal read to check eof");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("request with eof before content complete with retry");
-
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n0123456789012345678901234567890");
-
-                hrnTlsServerClose();
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n01234567890123456789012345678901");
-
-                TEST_ASSIGN(
-                    buffer, httpClientRequest(client, strNew("GET"), strNew("/path/file 1.txt"), NULL, NULL, NULL, true),
-                    "request");
-                TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901", "check response");
-                TEST_RESULT_UINT(httpClientRead(client, bufNew(1), true), 0, "call internal read to check eof");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("request with eof before content complete");
-
-                hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n0123456789012345678901234567890");
-
-                hrnTlsServerClose();
-
-                buffer = bufNew(32);
-
-                TEST_RESULT_VOID(
-                    httpClientRequest(client, strNew("GET"), strNew("/path/file 1.txt"), NULL, NULL, NULL, false), "request");
-                TEST_RESULT_BOOL(httpClientBusy(client), true, "client is busy");
-                TEST_ERROR(ioRead(httpClientIoRead(client), buffer), FileReadError, "unexpected EOF reading HTTP content");
-
-                // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("request with chunked content");
-
-                hrnTlsServerAccept();
-
-                hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
-                hrnTlsServerReplyZ(
-                    "HTTP/1.1 200 OK\r\nTransfer-Encoding:chunked\r\n\r\n"
-                    "20\r\n01234567890123456789012345678901\r\n"
-                    "10\r\n0123456789012345\r\n"
-                    "0\r\n\r\n");
-
-                TEST_RESULT_VOID(httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
-                TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpClientResponseHeader(client)),  "{transfer-encoding: 'chunked'}", "check response headers");
-
-                buffer = bufNew(35);
-
-                TEST_RESULT_VOID(ioRead(httpClientIoRead(client), buffer),  "read response");
-                TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901012", "check response");
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("head request with content-length but no content");
+                //
+                // hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:380\r\n\r\n");
+                //
+                // TEST_RESULT_VOID(
+                //     httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
+                // TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
+                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
+                // TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
+                // TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '380'}", "check response headers");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("head request with transfer encoding but no content");
+                //
+                // hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+                //
+                // TEST_RESULT_VOID(
+                //     httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
+                // TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
+                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
+                // TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
+                // TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{transfer-encoding: 'chunked'}", "check response headers");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("head request with connection close but no content");
+                //
+                // hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nConnection:close\r\n\r\n");
+                //
+                // hrnTlsServerClose();
+                //
+                // TEST_RESULT_VOID(
+                //     httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
+                // TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
+                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
+                // TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
+                // TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{connection: 'close'}", "check response headers");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("error with content (with a few slow down errors)");
+                //
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 503 Slow Down\r\ncontent-length:3\r\nConnection:close\r\n\r\n123");
+                //
+                // hrnTlsServerClose();
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 503 Slow Down\r\nTransfer-Encoding:chunked\r\nConnection:close\r\n\r\n0\r\n\r\n");
+                //
+                // hrnTlsServerClose();
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 404 Not Found\r\ncontent-length:0\r\n\r\n");
+                //
+                // TEST_RESULT_VOID(httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
+                // TEST_RESULT_UINT(httpClientResponseCode(client), 404, "check response code");
+                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "Not Found", "check response message");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '0'}", "check response headers");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("error with content");
+                //
+                // hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 403 \r\ncontent-length:7\r\n\r\nCONTENT");
+                //
+                // Buffer *buffer = NULL;
+                //
+                // TEST_ASSIGN(buffer, httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
+                // TEST_RESULT_UINT(httpClientResponseCode(client), 403, "check response code");
+                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "", "check empty response message");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '7'}", "check response headers");
+                // TEST_RESULT_STR_Z(strNewBuf(buffer),  "CONTENT", "check response");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("request with content using content-length");
+                //
+                // hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\ncontent-length:30\r\n\r\n012345678901234567890123456789");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\nConnection:close\r\n\r\n01234567890123456789012345678901");
+                //
+                // hrnTlsServerClose();
+                //
+                // ioBufferSizeSet(30);
+                //
+                // TEST_ASSIGN(
+                //     buffer,
+                //     httpClientRequest(
+                //         client, strNew("GET"), strNew("/path/file 1.txt"), NULL,
+                //         httpHeaderAdd(httpHeaderNew(NULL), strNew("content-length"), strNew("30")),
+                //         BUFSTRDEF("012345678901234567890123456789"), true),
+                //     "request");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{connection: 'close'}", "check response headers");
+                // TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901", "check response");
+                // TEST_RESULT_UINT(httpClientRead(client, bufNew(1), true), 0, "call internal read to check eof");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("request with eof before content complete with retry");
+                //
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n0123456789012345678901234567890");
+                //
+                // hrnTlsServerClose();
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n01234567890123456789012345678901");
+                //
+                // TEST_ASSIGN(
+                //     buffer, httpClientRequest(client, strNew("GET"), strNew("/path/file 1.txt"), NULL, NULL, NULL, true),
+                //     "request");
+                // TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901", "check response");
+                // TEST_RESULT_UINT(httpClientRead(client, bufNew(1), true), 0, "call internal read to check eof");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("request with eof before content complete");
+                //
+                // hrnTlsServerExpectZ("GET /path/file%201.txt HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:32\r\n\r\n0123456789012345678901234567890");
+                //
+                // hrnTlsServerClose();
+                //
+                // buffer = bufNew(32);
+                //
+                // TEST_RESULT_VOID(
+                //     httpClientRequest(client, strNew("GET"), strNew("/path/file 1.txt"), NULL, NULL, NULL, false), "request");
+                // TEST_RESULT_BOOL(httpClientBusy(client), true, "client is busy");
+                // TEST_ERROR(ioRead(httpClientIoRead(client), buffer), FileReadError, "unexpected EOF reading HTTP content");
+                //
+                // // -----------------------------------------------------------------------------------------------------------------
+                // TEST_TITLE("request with chunked content");
+                //
+                // hrnTlsServerAccept();
+                //
+                // hrnTlsServerExpectZ("GET / HTTP/1.1\r\n\r\n");
+                // hrnTlsServerReplyZ(
+                //     "HTTP/1.1 200 OK\r\nTransfer-Encoding:chunked\r\n\r\n"
+                //     "20\r\n01234567890123456789012345678901\r\n"
+                //     "10\r\n0123456789012345\r\n"
+                //     "0\r\n\r\n");
+                //
+                // TEST_RESULT_VOID(httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
+                // TEST_RESULT_STR_Z(
+                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{transfer-encoding: 'chunked'}", "check response headers");
+                //
+                // buffer = bufNew(35);
+                //
+                // TEST_RESULT_VOID(ioRead(httpClientIoRead(client), buffer),  "read response");
+                // TEST_RESULT_STR_Z(strNewBuf(buffer),  "01234567890123456789012345678901012", "check response");
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("close connection");
@@ -540,14 +544,14 @@ testRun(void)
         TEST_RESULT_PTR(httpClientCacheGet(cache), *(HttpClient **)lstGet(cache->clientList, 0), "    get same http client");
 
         // Make client 1 look like it is busy
-        client1->ioRead = (IoRead *)1;
+        client1->busy = true;
 
         TEST_ASSIGN(client2, httpClientCacheGet(cache), "get http client");
         TEST_RESULT_PTR(client2, *(HttpClient **)lstGet(cache->clientList, 1), "    check http client");
         TEST_RESULT_BOOL(client1 != client2, true, "clients are not the same");
 
         // Set back to NULL so bad things don't happen during free
-        client1->ioRead = NULL;
+        client1->busy = false;
 
         TEST_RESULT_VOID(httpClientCacheFree(cache), "free http client cache");
     }

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -344,7 +344,7 @@ testRun(void)
 
                 TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
                 TEST_RESULT_BOOL(httpResponseCodeOk(response), true, "check response code ok");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "OK", "check response message");
                 TEST_RESULT_UINT(httpResponseEof(response), true, "io is eof");
                 TEST_RESULT_STR_Z(
                     httpHeaderToLog(httpResponseHeader(response)),  "{connection: 'ack', key1: '0', key2: 'value2'}",
@@ -363,7 +363,7 @@ testRun(void)
                     response, httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true),
                     "request");
                 TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "OK", "check response message");
                 TEST_RESULT_BOOL(httpResponseEof(response), true, "io is eof");
                 TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
                 TEST_RESULT_STR_Z(
@@ -379,7 +379,7 @@ testRun(void)
                     response, httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true),
                     "request");
                 TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "OK", "check response message");
                 TEST_RESULT_BOOL(httpResponseEof(response), true, "io is eof");
                 TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
                 TEST_RESULT_STR_Z(
@@ -397,7 +397,7 @@ testRun(void)
                     response, httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true),
                     "request");
                 TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "OK", "check response message");
                 TEST_RESULT_BOOL(httpResponseEof(response), true, "io is eof");
                 TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
                 TEST_RESULT_STR_Z(
@@ -426,7 +426,7 @@ testRun(void)
                 TEST_ASSIGN(response, httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
                 TEST_RESULT_UINT(httpResponseCode(response), 404, "check response code");
                 TEST_RESULT_BOOL(httpResponseCodeOk(response), false, "check response code error");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "Not Found", "check response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "Not Found", "check response message");
                 TEST_RESULT_STR_Z(
                     httpHeaderToLog(httpResponseHeader(response)),  "{content-length: '0'}", "check response headers");
 
@@ -438,7 +438,7 @@ testRun(void)
 
                 TEST_ASSIGN(response, httpClientRequest(client, strNew("GET"), strNew("/"), NULL, NULL, NULL, false), "request");
                 TEST_RESULT_UINT(httpResponseCode(response), 403, "check response code");
-                TEST_RESULT_STR_Z(httpResponseMessage(response), "", "check empty response message");
+                TEST_RESULT_STR_Z(httpResponseReason(response), "", "check empty response message");
                 TEST_RESULT_STR_Z(
                     httpHeaderToLog(httpResponseHeader(response)),  "{content-length: '7'}", "check response headers");
                 TEST_RESULT_STR_Z(strNewBuf(httpResponseContent(response)),  "CONTENT", "check response content");

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -344,21 +344,23 @@ testRun(void)
 
                 TEST_RESULT_VOID(httpResponseFree(response), "free response");
 
-                // // -----------------------------------------------------------------------------------------------------------------
-                // TEST_TITLE("head request with content-length but no content");
-                //
-                // hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
-                // hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:380\r\n\r\n");
-                //
-                // TEST_RESULT_VOID(
-                //     httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL, true), "request");
-                // TEST_RESULT_UINT(httpClientResponseCode(client), 200, "check response code");
-                // TEST_RESULT_STR_Z(httpClientResponseMessage(client), "OK", "check response message");
-                // TEST_RESULT_BOOL(httpClientEof(client), true, "io is eof");
-                // TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
-                // TEST_RESULT_STR_Z(
-                //     httpHeaderToLog(httpClientResponseHeader(client)),  "{content-length: '380'}", "check response headers");
-                //
+                // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("head request with content-length but no content");
+
+                hrnTlsServerExpectZ("HEAD / HTTP/1.1\r\n\r\n");
+                hrnTlsServerReplyZ("HTTP/1.1 200 OK\r\ncontent-length:380\r\n\r\n");
+
+                TEST_ASSIGN(
+                    response, httpClientRequest(client, strNew("HEAD"), strNew("/"), NULL, httpHeaderNew(NULL), NULL), "request");
+                TEST_RESULT_UINT(httpResponseCode(response), 200, "check response code");
+                TEST_RESULT_STR_Z(httpResponseMessage(response), "OK", "check response message");
+                TEST_RESULT_BOOL(httpResponseEof(response), true, "io is eof");
+                TEST_RESULT_BOOL(httpClientBusy(client), false, "client is not busy");
+                TEST_RESULT_STR_Z(
+                    httpHeaderToLog(httpResponseHeader(response)),  "{content-length: '380'}", "check response headers");
+
+                TEST_RESULT_VOID(httpResponseFree(response), "free response");
+
                 // // -----------------------------------------------------------------------------------------------------------------
                 // TEST_TITLE("head request with transfer encoding but no content");
                 //


### PR DESCRIPTION
Moving this code out of `HttpClient` allows for more flexibility and gets us closer to async request/response.

Another benefit is that there is no need to explicitly close a response that was partially read. The `HttpResponse` destructor takes care of this now.