### PR TITLE
Fix expression when recursion enabled in storageInfoListP().

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -39,7 +39,7 @@
                             <release-item-reviewer id="cynthia.shang"/>
                         </release-item-contributor-list>
 
-                        <p>Fix filters when recursion enabled in <code>storageInfoListP()</code>.</p>
+                        <p>Fix expression when recursion enabled in <code>storageInfoListP()</code>.</p>
                     </release-item>
                 </release-development-list>
             </release-core-list>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -31,6 +31,16 @@
                         <p>Improve error when <br-option>pg1-path</br-option> option missing for <cmd>archive-get</cmd> command.</p>
                     </release-item>
                 </release-improvement-list>
+
+                <release-development-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix filters when recursion enabled in <code>storageInfoListP()</code>.</p>
+                    </release-item>
+                </release-development-list>
             </release-core-list>
 
             <release-doc-list>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -36,6 +36,7 @@
                     <release-item>
                         <release-item-contributor-list>
                             <release-item-reviewer id="stefan.fercot"/>
+                            <release-item-reviewer id="cynthia.shang"/>
                         </release-item-contributor-list>
 
                         <p>Fix filters when recursion enabled in <code>storageInfoListP()</code>.</p>

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -413,6 +413,21 @@ testRun(void)
             callbackData.content,
             "path {path, m=0700}\n",
             "    check content");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("filter in subpath during recursion");
+
+        callbackData.content = strNew("");
+
+        TEST_RESULT_VOID(
+            storageInfoListP(
+                storageTest, strNew("pg"), hrnStorageInfoListCallback, &callbackData, .sortOrder = sortOrderAsc, .recurse = true,
+                .expression = STRDEF("\\/file$")),
+            "filter");
+        TEST_RESULT_STR_Z(
+            callbackData.content,
+            "path/file {file, s=8}\n",
+            "    check content");
     }
 
     // *****************************************************************************************************************************

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -424,10 +424,7 @@ testRun(void)
                 storageTest, strNew("pg"), hrnStorageInfoListCallback, &callbackData, .sortOrder = sortOrderAsc, .recurse = true,
                 .expression = STRDEF("\\/file$")),
             "filter");
-        TEST_RESULT_STR_Z(
-            callbackData.content,
-            "path/file {file, s=8}\n",
-            "    check content");
+        TEST_RESULT_STR_Z(callbackData.content, "path/file {file, s=8}\n", "check content");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
Filters only worked at the first level of recursion because the filter was also being applied to paths so the path had to match the filter in order to recurse.

This is not considered a bug since it does not affect any existing code paths, but it is required for the general-purpose repo-ls command.