### PR TITLE
Update the PITR FAQ to clarify the default behavior.

### DIFF
--- a/doc/xml/faq.xml
+++ b/doc/xml/faq.xml
@@ -95,9 +95,9 @@ process-max=1
     <section id="time-based-pitr">
         <title>Time-based Point-in-Time Recovery does not appear to work, why?</title>
 
-        <p>The most common mistake when using time-based Point-in-Time Recovery is forgetting to choose a backup set that is before the target time. <backrest/> defaults to the latest backup and if it is after the target time, then <setting>--target=</setting> is not considered valid by <postgres/> and is therefore ignored, resulting in WAL recovery to the latest time available.</p>
+        <p>The most common mistake when using time-based Point-in-Time Recovery is forgetting to choose a backup set that is before the target time. <backrest/> will attempt to discover a backup to play forward from the time specified by the <setting>--target=</setting> if the <setting>--set</setting> option is not specified. If a backup set cannot be found, then restore will default to the latest backup. However, if the latest backup is after the target time, then <setting>--target=</setting> is not considered valid by <postgres/> and is therefore ignored, resulting in WAL recovery to the latest time available.</p>
 
-        <p>To choose the correct backup set, run the <cmd>info</cmd> command and find the backup with a timestamp stop that is before the target time. When running the restore, specify the option <setting>--set=BACKUP_LABEL</setting> where <id>BACKUP_LABEL</id> is the backup that was found with a <b>stop</b> timestamp before the target time.</p>
+        <p>To use the <setting>--set</setting> option, choose a backup set by running the <cmd>info</cmd> command and finding the backup with a timestamp stop that is before the target time. Then when running the restore, specify the option <setting>--set=BACKUP_LABEL</setting> where <id>BACKUP_LABEL</id> is the chosen backup set.</p>
 
         <p>See the <link url="user-guide.html#pitr">Point-in-Time Recovery</link> section of the <proper>User Guide</proper> for more information.</p>
     </section>

--- a/doc/xml/faq.xml
+++ b/doc/xml/faq.xml
@@ -32,11 +32,7 @@
     <section id="manual-expire">
         <title>How do I manually purge a backup set?</title>
 
-        <p>Backup sets in the middle cannot be expired, but it is possible to expire the oldest backup sets by running the <cmd>expire</cmd> command with retention. For example, the following command will keep only the last two full backups, purging any prior full backups including their associated incremental/differential backups and archive:</p>
-
-        <code-block>pgbackrest --stanza=xxx --repo1-retention-full=2 expire</code-block>
-
-        <p>Using the <br-setting>{[dash]}-repo1-retention-full</br-setting> option on the command-  line simply overrides the setting in the configuration file for that one execution of the command. See the <link url='https://pgbackrest.org/user-guide.html#retention'>Retention</link> section in the User Guide for more information on retention.</p>
+        <p>A full backup set can be expired using the <br-setting>{[dash]}-set</br-setting> option as explained in <link url="https://pgbackrest.org/command.html#command-expire">Command Reference: Expire</link>.</p>
     </section>
 
     <section id="optimize-config">

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -70,7 +70,7 @@
                             <release-item-contributor id="cynthia.shang"/>
                         </release-item-contributor-list>
 
-                        <p>Update the PITR FAQ to clarify the default behavior.</p>
+                        <p>Update the FAQ page to clarify how a backup set can be expired.</p>
                     </release-item>
 
                     <release-item>
@@ -78,7 +78,7 @@
                             <release-item-contributor id="cynthia.shang"/>
                         </release-item-contributor-list>
 
-                        <p>Update the FAQ page to clarify how restore is handled given a target time for PITR.</p>
+                        <p>Update the PITR FAQ to clarify the default behavior.</p>
                     </release-item>
                 </release-improvement-list>
             </release-doc-list>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -72,6 +72,14 @@
 
                         <p>Update the FAQ page to clarify how a backup set can be expired.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Update the FAQ page to clarify how restore is handled given a target time for PITR.</p>
+                    </release-item>
                 </release-improvement-list>
             </release-doc-list>
         </release>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -70,7 +70,7 @@
                             <release-item-contributor id="cynthia.shang"/>
                         </release-item-contributor-list>
 
-                        <p>Update the FAQ page to clarify how a backup set can be expired.</p>
+                        <p>Update the PITR FAQ to clarify the default behavior.</p>
                     </release-item>
 
                     <release-item>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -43,6 +43,16 @@
                         <p>Fix incorrect example for <br-option>repo-retention-full-type</br-option> option.</p>
                     </release-item>
                 </release-bug-list>
+
+                <release-improvement-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Update the FAQ page to clarify how a backup set can be expired.</p>
+                    </release-item>
+                </release-improvement-list>
             </release-doc-list>
         </release>
 


### PR DESCRIPTION
The FAQ still reflected the old default behavior which used the latest backup for recovery when the --set option was not used. The FAQ has been updated to indicate the default behavior is to attempt to discover the backup given the target time.