### PR TITLE
Disable query parallelism in PostgreSQL sessions used for backup control.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -20,6 +20,10 @@
                     </release-item>
 
                     <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
                         <p>Disable query parallelism in <postgres/> sessions used for backup control.</p>
                     </release-item>
 


### PR DESCRIPTION
There is no need to have parallelism enabled in a backup control session. In particular, 9.6 marks pg_stop_backup() as parallel-safe but an error will be thrown if pg_stop_backup() is run in a worker.