### PR TITLE
Add passing of storage to pgWalFromFile.

### DIFF
--- a/src/command/archive/push/file.c
+++ b/src/command/archive/push/file.c
@@ -48,7 +48,7 @@ archivePushFile(
         // If this is a segment compare archive version and systemId to the WAL header
         if (isSegment)
         {
-            PgWal walInfo = pgWalFromFile(walSource);
+            PgWal walInfo = pgWalFromFile(walSource, storageLocal());
 
             if (walInfo.version != pgVersion || walInfo.systemId != pgSystemId)
             {

--- a/src/postgres/interface.c
+++ b/src/postgres/interface.c
@@ -549,7 +549,7 @@ pgWalFromBuffer(const Buffer *walBuffer)
 }
 
 PgWal
-pgWalFromFile(const String *walFile)
+pgWalFromFile(const String *walFile, const Storage *storage)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(STRING, walFile);
@@ -562,7 +562,7 @@ pgWalFromFile(const String *walFile)
     MEM_CONTEXT_TEMP_BEGIN()
     {
         // Read WAL segment header
-        Buffer *walBuffer = storageGetP(storageNewReadP(storageLocal(), walFile), .exactSize = PG_WAL_HEADER_SIZE);
+        Buffer *walBuffer = storageGetP(storageNewReadP(storage, walFile), .exactSize = PG_WAL_HEADER_SIZE);
 
         result = pgWalFromBuffer(walBuffer);
     }

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -128,7 +128,7 @@ unsigned int pgVersionFromStr(const String *version);
 String *pgVersionToStr(unsigned int version);
 
 // Get info from WAL header
-PgWal pgWalFromFile(const String *walFile);
+PgWal pgWalFromFile(const String *walFile, const Storage *storage);
 PgWal pgWalFromBuffer(const Buffer *walBuffer);
 
 // Get the tablespace identifier used to distinguish versions in a tablespace directory, e.g. PG_9.0_201008051

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -229,7 +229,7 @@ testRun(void)
         storagePutP(storageNewWriteP(storageTest, walFile), result);
 
         PgWal info = {0};
-        TEST_ASSIGN(info, pgWalFromFile(walFile), "get wal info v11");
+        TEST_ASSIGN(info, pgWalFromFile(walFile, storageLocal()), "get wal info v11");
         TEST_RESULT_UINT(info.systemId, 0xECAFECAF, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_11, "   check version");
         TEST_RESULT_UINT(info.size, PG_WAL_SEGMENT_SIZE_DEFAULT * 2, "   check size");
@@ -246,7 +246,7 @@ testRun(void)
         pgWalTestToBuffer((PgWal){.version = PG_VERSION_83, .systemId = 0xEAEAEAEA, .size = PG_WAL_SEGMENT_SIZE_DEFAULT}, result);
         storagePutP(storageNewWriteP(storageTest, walFile), result);
 
-        TEST_ASSIGN(info, pgWalFromFile(walFile), "get wal info v8.3");
+        TEST_ASSIGN(info, pgWalFromFile(walFile, storageLocal()), "get wal info v8.3");
         TEST_RESULT_UINT(info.systemId, 0xEAEAEAEA, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_83, "   check version");
         TEST_RESULT_UINT(info.size, PG_WAL_SEGMENT_SIZE_DEFAULT, "   check size");


### PR DESCRIPTION
All flexibility for commands that do not use storageLocal() to be able to use pgWalFromFile().