### PR TITLE
Proactively close file descriptors after forking async process.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -55,6 +55,15 @@
 
                         <p>Improve memory usage of unlogged relation detection in manifest build.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="stephen.frost"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Proactively close file descriptors after forking async process.</p>
+                    </release-item>
                 </release-improvement-list>
             </release-core-list>
 

--- a/src/command/archive/common.c
+++ b/src/command/archive/common.c
@@ -249,6 +249,12 @@ archiveAsyncExec(ArchiveMode archiveMode, const StringList *commandExec)
         // Detach from parent process
         forkDetach();
 
+        // Close any open file descriptors above the standard three (stdin, stdout, stderr). Don't check the return value since we
+        // don't know which file descriptors are actually open (might be none). It's possible that there are open files >= 1024 but
+        // there is no easy way to detect that and this should give us enough descriptors to do our work.
+        for (int fd = 3; fd < 1024; fd++)
+            close(fd);
+
         // Execute the binary.  This statement will not return if it is successful.
         THROW_ON_SYS_ERROR_FMT(
             execvp(strZ(strLstGet(commandExec, 0)), (char ** const)strLstPtr(commandExec)) == -1, ExecuteError,


### PR DESCRIPTION
PostgreSQL may be using most of the available file descriptors when it executes the the archive-get/archive-push commands (especially archive-get). This can lead to problems depending on how many file descriptors are needed for parallelism in the async process.

Proactively free file descriptors between 3 and 1023 to help ensure there are enough available for reasonable values of process-max, i.e. <= 300.