### PR TITLE
Delay backup remote connection close until after archive check.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -67,6 +67,15 @@
 
                     <release-item>
                         <release-item-contributor-list>
+                            <release-item-contributor id="floris.van.nee"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Delay backup remote connection close until after archive check.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                             <release-item-reviewer id="cynthia.shang"/>
                             <release-item-reviewer id="stephen.frost"/>
                         </release-item-contributor-list>
@@ -8634,6 +8643,11 @@
         <contributor id="evan.benoit">
             <contributor-name-display>Evan Benoit</contributor-name-display>
             <contributor-id type="github">evanbenoit</contributor-id>
+        </contributor>
+
+        <contributor id="floris.van.nee">
+            <contributor-name-display>Floris van Nee</contributor-name-display>
+            <contributor-id type="github">fvannee</contributor-id>
         </contributor>
 
         <contributor id="vidhya.gurumoorthi">


### PR DESCRIPTION
Only close the connection to the remote after verifying that the WAL files are received.
This is necessary if the archive_command on pg servers is conditional. Then we need to
keep the backup lock until we know all WAL files have been sent.

Without this, the work-around as given in https://github.com/pgbackrest/pgbackrest/issues/900 sometimes fails, because the backup lock file is released before the last WAL segment is sent to the backup repo.

I know this isn't a full solution to proper conditional archiving, which would require a lot more changes. However, at least this makes the solution work. Would this be ok to merge?
