### PR TITLE
Asynchronous list/remove for S3/Azure storage.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -51,6 +51,7 @@
                     <release-item>
                         <release-item-contributor-list>
                             <release-item-reviewer id="cynthia.shang"/>
+                            <release-item-reviewer id="stephen.frost"/>
                         </release-item-contributor-list>
 
                         <p>Asynchronous <id>list</id>/<id>remove</id> for <proper>S3</proper>/<proper>Azure</proper> storage.</p>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -50,6 +50,14 @@
 
                     <release-item>
                         <release-item-contributor-list>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Asynchronous <id>list</id>/<id>remove</id> for <proper>S3</proper>/<proper>Azure</proper> storage.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                             <release-item-ideator id="MannerMan"/>
                             <release-item-ideator id="brad.nicholson"/>
                             <release-item-reviewer id="cynthia.shang"/>

--- a/src/storage/azure/storage.c
+++ b/src/storage/azure/storage.c
@@ -387,18 +387,19 @@ storageAzureListInternal(
             // free memory at regular intervals
             MEM_CONTEXT_TEMP_BEGIN()
             {
-                // Get sync response on first request or async response on continuation
                 HttpResponse *response = NULL;
 
-                if (request == NULL)
-                    response = storageAzureRequestP(this, HTTP_VERB_GET_STR, .query = query);
-                else
+                // If there is an outstanding async request then wait for the response
+                if (request != NULL)
                 {
                     response = storageAzureResponseP(request);
 
                     httpRequestFree(request);
                     request = NULL;
                 }
+                // Else get the response immediately from a sync request
+                else
+                    response = storageAzureRequestP(this, HTTP_VERB_GET_STR, .query = query);
 
                 XmlNode *xmlRoot = xmlDocumentRoot(xmlDocumentNewBuf(httpResponseContent(response)));
 

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -412,18 +412,19 @@ storageS3ListInternal(
             // free memory at regular intervals
             MEM_CONTEXT_TEMP_BEGIN()
             {
-                // Get sync response on first request or async response on continuation
                 HttpResponse *response = NULL;
 
-                if (request == NULL)
-                    response = storageS3RequestP(this, HTTP_VERB_GET_STR, FSLASH_STR, query);
-                else
+                // If there is an outstanding async request then wait for the response
+                if (request != NULL)
                 {
                     response = storageS3ResponseP(request);
 
                     httpRequestFree(request);
                     request = NULL;
                 }
+                // Else get the response immediately from a sync request
+                else
+                    response = storageS3RequestP(this, HTTP_VERB_GET_STR, FSLASH_STR, query);
 
                 XmlNode *xmlRoot = xmlDocumentRoot(xmlDocumentNewBuf(httpResponseContent(response)));
 

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -433,13 +433,12 @@ storageS3ListInternal(
 
                 if (continuationToken != NULL)
                 {
-                    HttpQuery *queryContinuation = httpQueryDupP(query);
-                    httpQueryAdd(queryContinuation, S3_QUERY_CONTINUATION_TOKEN_STR, continuationToken);
+                    httpQueryPut(query, S3_QUERY_CONTINUATION_TOKEN_STR, continuationToken);
 
                     // Store request in the outer temp context
                     MEM_CONTEXT_PRIOR_BEGIN()
                     {
-                        request = storageS3RequestAsyncP(this, HTTP_VERB_GET_STR, FSLASH_STR, queryContinuation);
+                        request = storageS3RequestAsyncP(this, HTTP_VERB_GET_STR, FSLASH_STR, query);
                     }
                     MEM_CONTEXT_PRIOR_END();
                 }

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -664,7 +664,7 @@ typedef struct StorageS3PathRemoveData
 {
     MemContext *memContext;                                         // Mem context to create xml document in
     unsigned int size;                                              // Size of delete request
-    HttpRequest *request;                                           // Delete request
+    HttpRequest *request;                                           // Async delete request
     XmlDocument *xml;                                               // Delete xml
 } StorageS3PathRemoveData;
 
@@ -797,7 +797,7 @@ storageS3PathRemove(THIS_VOID, const String *path, bool recurse, StorageInterfac
         if (data.xml != NULL)
             data.request = storageS3PathRemoveInternal(this, data.request, data.xml);
 
-        // And once more to check async request response
+        // Check response on last async request
         storageS3PathRemoveInternal(this, data.request, NULL);
     }
     MEM_CONTEXT_TEMP_END();


### PR DESCRIPTION
Improve the performance of list/delete operations by using async requests.

It's questionable whether this will have any impact on Azure deletes since they are sent one at a time with little work done in between, but it doesn't hurt to try.