### PR TITLE
Add hint about starting the stanza when WAL segment not found.

### DIFF
--- a/src/command/archive/common.c
+++ b/src/command/archive/common.c
@@ -442,7 +442,8 @@ walSegmentFind(const Storage *storage, const String *archiveId, const String *wa
             ArchiveTimeoutError,
             "WAL segment %s was not archived before the %" PRIu64 "ms timeout\n"
                 "HINT: check the archive_command to ensure that all options are correct (especially --stanza).\n"
-                "HINT: check the PostgreSQL server log for errors.",
+                "HINT: check the PostgreSQL server log for errors.\n",
+                "HINT: check that you have issued a `start` command if you previously issued a `stop` command.",
             strZ(walSegment), timeout);
     }
 


### PR DESCRIPTION
If a "pgbackrest stop" command has been issued is stopped on a database node, the "check" action
fails due to archiving timing out.  This provides a hint to document this situation and point the
user in the proper direction.