### PR TITLE
Allow ProtocolParallel to complete with no jobs.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -13,6 +13,17 @@
 
     <release-list>
         <release date="XXXX-XX-XX" version="2.30dev" title="UNDER DEVELOPMENT">
+            <release-core-list>
+                <release-development-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Allow <code>ProtocolParallel</code> to complete with no jobs.</p>
+                    </release-item>
+                </release-development-list>
+            </release-core-list>
         </release>
 
         <release date="2020-08-31" version="2.29" title="Auto S3 Credentials on AWS">

--- a/src/protocol/parallel.c
+++ b/src/protocol/parallel.c
@@ -253,20 +253,23 @@ protocolParallelResult(ProtocolParallel *this)
         }
     }
 
-    // If all jobs have been returned then we are done
-    if (lstSize(this->jobList) == 0)
-        this->state = protocolParallelJobStateDone;
-
     FUNCTION_LOG_RETURN(PROTOCOL_PARALLEL_JOB, result);
 }
 
 /**********************************************************************************************************************************/
 bool
-protocolParallelDone(const ProtocolParallel *this)
+protocolParallelDone(ProtocolParallel *this)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(PROTOCOL_PARALLEL, this);
     FUNCTION_LOG_END();
+
+    ASSERT(this != NULL);
+    ASSERT(this->state != protocolParallelJobStatePending);
+
+    // If there are no jobs left then we are done
+    if (this->state != protocolParallelJobStateDone && lstSize(this->jobList) == 0)
+        this->state = protocolParallelJobStateDone;
 
     FUNCTION_LOG_RETURN(BOOL, this->state == protocolParallelJobStateDone);
 }

--- a/src/protocol/parallel.h
+++ b/src/protocol/parallel.h
@@ -42,7 +42,7 @@ unsigned int protocolParallelProcess(ProtocolParallel *this);
 Getters/Setters
 ***********************************************************************************************************************************/
 // Are all jobs done?
-bool protocolParallelDone(const ProtocolParallel *this);
+bool protocolParallelDone(ProtocolParallel *this);
 
 // Completed job result
 ProtocolParallelJob *protocolParallelResult(ProtocolParallel *this);

--- a/test/src/module/protocol/protocolTest.c
+++ b/test/src/module/protocol/protocolTest.c
@@ -882,6 +882,7 @@ testRun(void)
                 TEST_RESULT_INT(protocolParallelProcess(parallel), 0, "process jobs");
 
                 TEST_RESULT_PTR(protocolParallelResult(parallel), NULL, "check no result");
+                TEST_RESULT_BOOL(protocolParallelDone(parallel), false, "check not done");
 
                 // Process jobs
                 TEST_RESULT_INT(protocolParallelProcess(parallel), 1, "process jobs");
@@ -891,13 +892,27 @@ testRun(void)
                 TEST_RESULT_INT(varIntForce(protocolParallelJobResult(job)), 1, "check result is 1");
 
                 TEST_RESULT_BOOL(protocolParallelDone(parallel), true, "check done");
+                TEST_RESULT_BOOL(protocolParallelDone(parallel), true, "check still done");
 
-                // Free client
+                TEST_RESULT_VOID(protocolParallelFree(parallel), "free parallel");
+
+                // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("process zero jobs");
+
+                data = (TestParallelJobCallback){.jobList = lstNewP(sizeof(ProtocolParallelJob *))};
+                TEST_ASSIGN(parallel, protocolParallelNew(2000, testParallelJobCallback, &data), "create parallel");
+                TEST_RESULT_VOID(protocolParallelClientAdd(parallel, client[0]), "add client");
+
+                TEST_RESULT_INT(protocolParallelProcess(parallel), 0, "process zero jobs");
+                TEST_RESULT_BOOL(protocolParallelDone(parallel), true, "check done");
+
+                TEST_RESULT_VOID(protocolParallelFree(parallel), "free parallel");
+
+                // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("free clients");
+
                 for (unsigned int clientIdx = 0; clientIdx < clientTotal; clientIdx++)
                     TEST_RESULT_VOID(protocolClientFree(client[clientIdx]), "free client %u", clientIdx);
-
-                // Free parallel
-                TEST_RESULT_VOID(protocolParallelFree(parallel), "free parallel");
             }
             HARNESS_FORK_PARENT_END();
         }


### PR DESCRIPTION
If the callback never returned any jobs then protocolParallelDone() would never be true. The reason is that the done state was being set in protocolParallelResult(), which never gets called if there are no results.

Calling protocolParallelResult() doesn't make much sense in this case so instead move the done logic to protocolParallelDone().

For current usage of ProtocolParallel we ensure there are jobs before processing so this is not a live issue, but the new behavior is required for future development.