### PR TITLE
Ignore backup_manifest for PG13.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -18,6 +18,15 @@
                     <release-item>
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Ignore <file>backup_manifest</file> in <postgres/> 13.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
                             <release-item-reviewer id="stefan.fercot"/>
                         </release-item-contributor-list>
 

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -608,6 +608,9 @@ manifestBuildCallback(void *data, const StorageInfo *info)
                     (strEqZ(info->name, PG_FILE_BACKUPLABEL) && pgVersion >= PG_VERSION_96) ||
                     // Skip old backup labels
                     strEqZ(info->name, PG_FILE_BACKUPLABELOLD) ||
+                    // Skip backup_manifest/tmp in versions where it is created
+                    ((strEqZ(info->name, PG_FILE_BACKUPMANIFEST) || strEqZ(info->name, PG_FILE_BACKUPMANIFEST_TMP)) &&
+                        pgVersion >= PG_VERSION_13) ||
                     // Skip running process options
                     strEqZ(info->name, PG_FILE_POSTMASTEROPTS) ||
                     // Skip process id file to avoid confusing postgres after restore

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -16,6 +16,8 @@ Defines for various Postgres paths and files
 ***********************************************************************************************************************************/
 #define PG_FILE_BACKUPLABEL                                         "backup_label"
 #define PG_FILE_BACKUPLABELOLD                                      "backup_label.old"
+#define PG_FILE_BACKUPMANIFEST                                      "backup_manifest"
+#define PG_FILE_BACKUPMANIFEST_TMP                                  "backup_manifest.tmp"
 #define PG_FILE_PGCONTROL                                           "pg_control"
 #define PG_FILE_PGFILENODEMAP                                       "pg_filenode.map"
 #define PG_FILE_PGINTERNALINIT                                      "pg_internal.init"

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -107,6 +107,15 @@ testRun(void)
             "db-system-id=0\n"                                                                                                     \
             "db-version=\"12\"\n"
 
+        #define TEST_MANIFEST_DB_13                                                                                                \
+            "\n"                                                                                                                   \
+            "[backup:db]\n"                                                                                                        \
+            "db-catalog-version=202007201\n"                                                                                       \
+            "db-control-version=1300\n"                                                                                            \
+            "db-id=0\n"                                                                                                            \
+            "db-system-id=0\n"                                                                                                     \
+            "db-version=\"13\"\n"
+
         #define TEST_MANIFEST_OPTION_ALL                                                                                           \
             "\n"                                                                                                                   \
             "[backup:option]\n"                                                                                                    \
@@ -940,6 +949,14 @@ testRun(void)
         // create pg_xlog/wal as a link
         storagePathCreateP(storageTest, STRDEF("wal"), .mode = 0700);
 
+        // Create backup_manifest and backup_manifest.tmp that will show up for PG12 but will be ignored in PG13
+        storagePutP(
+            storageNewWriteP(storagePgWrite, STRDEF(PG_FILE_BACKUPMANIFEST), .modeFile = 0600, .timeModified = 1565282198),
+            BUFSTRDEF("MANIFEST"));
+        storagePutP(
+            storageNewWriteP(storagePgWrite, STRDEF(PG_FILE_BACKUPMANIFEST_TMP), .modeFile = 0600, .timeModified = 1565282199),
+            BUFSTRDEF("MANIFEST"));
+
         // Test manifest - 'pg_data/pg_tblspc' will appear in manifest but 'pg_tblspc' will not (no links). Recovery signal files
         // and backup_label ignored. Old recovery files and pg_xlog are now just another file/directory and will not be ignored.
         // pg_wal contents will be ignored online. pg_clog pgVersion > 10 master:true, pg_xact pgVersion > 10 master:false
@@ -964,6 +981,8 @@ testRun(void)
                 "\n"
                 "[target:file]\n"
                 "pg_data/PG_VERSION={\"size\":3,\"timestamp\":1565282100}\n"
+                "pg_data/backup_manifest={\"mode\":\"0600\",\"size\":8,\"timestamp\":1565282198}\n"
+                "pg_data/backup_manifest.tmp={\"mode\":\"0600\",\"size\":8,\"timestamp\":1565282199}\n"
                 "pg_data/base/1/555_init={\"master\":false,\"size\":0,\"timestamp\":1565282114}\n"
                 "pg_data/base/1/555_init.1={\"master\":false,\"size\":0,\"timestamp\":1565282114}\n"
                 "pg_data/base/1/555_vm.1_vm={\"master\":false,\"size\":0,\"timestamp\":1565282114}\n"
@@ -1008,10 +1027,10 @@ testRun(void)
             "check manifest");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("rerun 12, offline");
+        TEST_TITLE("run 13, offline");
 
         // pg_wal not ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_12, false, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_13, false, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -1019,7 +1038,7 @@ testRun(void)
             strNewBuf(contentSave),
             strNewBuf(harnessInfoChecksumZ(hrnReplaceKey(
                 TEST_MANIFEST_HEADER
-                TEST_MANIFEST_DB_12
+                TEST_MANIFEST_DB_13
                 TEST_MANIFEST_OPTION_ALL
                 "\n"
                 "[backup:target]\n"


### PR DESCRIPTION
This file is created by pg_basebackup so might be in the data directory if the cluster was restored from a pg_basebackup backup. Also exclude backup_manifest.tmp since it is possible to find that in the backup directory.