### PR TITLE
Improve PostgreSQL version identification.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -27,6 +27,16 @@
                     <release-item>
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                            <release-item-reviewer id="stephen.frost"/>
+                        </release-item-contributor-list>
+
+                        <p>Improve <postgres/> version identification.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
                             <release-item-reviewer id="stefan.fercot"/>
                         </release-item-contributor-list>
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1982,8 +1982,8 @@ cmdBackup(void)
         // Complete manifest
         manifestBuildComplete(
             manifest, timestampStart, backupStartResult.lsn, backupStartResult.walSegmentName, backupStopResult.timestamp,
-            backupStopResult.lsn, backupStopResult.walSegmentName, infoPg.id, infoPg.systemId, backupStartResult.dbList,
-            cfgOptionBool(cfgOptOnline) && cfgOptionBool(cfgOptArchiveCheck),
+            backupStopResult.lsn, backupStopResult.walSegmentName, infoPg.id, infoPg.systemId, infoPg.catalogVersion,
+            backupStartResult.dbList, cfgOptionBool(cfgOptOnline) && cfgOptionBool(cfgOptArchiveCheck),
             !cfgOptionBool(cfgOptOnline) || (cfgOptionBool(cfgOptArchiveCheck) && cfgOptionBool(cfgOptArchiveCopy)),
             cfgOptionUInt(cfgOptBufferSize), cfgOptionUInt(cfgOptCompressLevel), cfgOptionUInt(cfgOptCompressLevelNetwork),
             cfgOptionBool(cfgOptRepoHardlink), cfgOptionUInt(cfgOptProcessMax), cfgOptionBool(cfgOptBackupStandby));

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1947,8 +1947,8 @@ cmdBackup(void)
 
         // Build the manifest
         Manifest *manifest = manifestNewBuild(
-            backupData->storagePrimary, infoPg.version, cfgOptionBool(cfgOptOnline), cfgOptionBool(cfgOptChecksumPage),
-            strLstNewVarLst(cfgOptionLst(cfgOptExclude)), backupStartResult.tablespaceList);
+            backupData->storagePrimary, infoPg.version, infoPg.catalogVersion, cfgOptionBool(cfgOptOnline),
+            cfgOptionBool(cfgOptChecksumPage), strLstNewVarLst(cfgOptionLst(cfgOptExclude)), backupStartResult.tablespaceList);
 
         // Validate the manifest using the copy start time
         manifestBuildValidate(
@@ -1982,8 +1982,8 @@ cmdBackup(void)
         // Complete manifest
         manifestBuildComplete(
             manifest, timestampStart, backupStartResult.lsn, backupStartResult.walSegmentName, backupStopResult.timestamp,
-            backupStopResult.lsn, backupStopResult.walSegmentName, infoPg.id, infoPg.systemId, infoPg.catalogVersion,
-            backupStartResult.dbList, cfgOptionBool(cfgOptOnline) && cfgOptionBool(cfgOptArchiveCheck),
+            backupStopResult.lsn, backupStopResult.walSegmentName, infoPg.id, infoPg.systemId, backupStartResult.dbList,
+            cfgOptionBool(cfgOptOnline) && cfgOptionBool(cfgOptArchiveCheck),
             !cfgOptionBool(cfgOptOnline) || (cfgOptionBool(cfgOptArchiveCheck) && cfgOptionBool(cfgOptArchiveCopy)),
             cfgOptionUInt(cfgOptBufferSize), cfgOptionUInt(cfgOptCompressLevel), cfgOptionUInt(cfgOptCompressLevelNetwork),
             cfgOptionBool(cfgOptRepoHardlink), cfgOptionUInt(cfgOptProcessMax), cfgOptionBool(cfgOptBackupStandby));

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -933,7 +933,8 @@ restoreCleanBuild(Manifest *manifest)
             // If this is a tablespace append the tablespace identifier
             if (cleanData->target->type == manifestTargetTypeLink && cleanData->target->tablespaceId != 0)
             {
-                const String *tablespaceId = pgTablespaceId(manifestData(manifest)->pgVersion);
+                const String *tablespaceId = pgTablespaceId(
+                    manifestData(manifest)->pgVersion, manifestData(manifest)->pgCatalogVersion);
 
                 // Only PostgreSQL >= 9.0 has tablespace indentifiers
                 if (tablespaceId != NULL)
@@ -1181,7 +1182,8 @@ restoreSelectiveExpression(Manifest *manifest)
 
             // Generate tablespace expression
             RegExp *tablespaceRegExp = NULL;
-            const String *tablespaceId = pgTablespaceId(manifestData(manifest)->pgVersion);
+            const String *tablespaceId = pgTablespaceId(
+                manifestData(manifest)->pgVersion, manifestData(manifest)->pgCatalogVersion);
 
             if (tablespaceId == NULL)
                 tablespaceRegExp = regExpNew(STRDEF("^" MANIFEST_TARGET_PGTBLSPC "/[0-9]+/[0-9]+/" PG_FILE_PGVERSION));

--- a/src/command/stanza/create.c
+++ b/src/command/stanza/create.c
@@ -80,7 +80,7 @@ cmdStanzaCreate(void)
             cipherPassSub = cipherPassGen(cipherType(cfgOptionStr(cfgOptRepoCipherType)));
 
             // Create and save backup info
-            infoBackup = infoBackupNew(pgControl.version, pgControl.systemId, cipherPassSub);
+            infoBackup = infoBackupNew(pgControl.version, pgControl.systemId, pgControl.catalogVersion, cipherPassSub);
 
             infoBackupSaveFile(
                 infoBackup, storageRepoWriteStanza, INFO_BACKUP_PATH_FILE_STR, cipherType(cfgOptionStr(cfgOptRepoCipherType)),

--- a/src/command/stanza/upgrade.c
+++ b/src/command/stanza/upgrade.c
@@ -65,7 +65,7 @@ cmdStanzaUpgrade(void)
         // Update backup
         if (pgControl.version != backupInfo.version || pgControl.systemId != backupInfo.systemId)
         {
-            infoBackupPgSet(infoBackup, pgControl.version, pgControl.systemId);
+            infoBackupPgSet(infoBackup, pgControl.version, pgControl.systemId, pgControl.catalogVersion);
             infoBackupUpgrade = true;
         }
 

--- a/src/info/infoArchive.c
+++ b/src/info/infoArchive.c
@@ -236,7 +236,7 @@ infoArchivePgSet(InfoArchive *this, unsigned int pgVersion, uint64_t pgSystemId)
 
     ASSERT(this != NULL);
 
-    this->infoPg = infoPgSet(this->infoPg, infoPgArchive, pgVersion, pgSystemId);
+    this->infoPg = infoPgSet(this->infoPg, infoPgArchive, pgVersion, pgSystemId, 0);
 
     FUNCTION_LOG_RETURN(INFO_ARCHIVE, this);
 }

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -97,7 +97,7 @@ infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, unsigned int pgCatalo
         FUNCTION_TEST_PARAM(STRING, cipherPassSub);
     FUNCTION_LOG_END();
 
-    ASSERT(pgVersion > 0 && pgSystemId > 0);
+    ASSERT(pgVersion > 0 && pgSystemId > 0 && pgCatalogVersion > 0);
 
     InfoBackup *this = NULL;
 

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -88,11 +88,12 @@ infoBackupNewInternal(void)
 
 /**********************************************************************************************************************************/
 InfoBackup *
-infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, const String *cipherPassSub)
+infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, unsigned int pgCatalogVersion, const String *cipherPassSub)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(UINT, pgVersion);
         FUNCTION_LOG_PARAM(UINT64, pgSystemId);
+        FUNCTION_LOG_PARAM(UINT, pgCatalogVersion);
         FUNCTION_TEST_PARAM(STRING, cipherPassSub);
     FUNCTION_LOG_END();
 
@@ -106,7 +107,7 @@ infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, const String *cipherP
 
         // Initialize the pg data
         this->infoPg = infoPgNew(infoPgBackup, cipherPassSub);
-        infoBackupPgSet(this, pgVersion, pgSystemId);
+        infoBackupPgSet(this, pgVersion, pgSystemId, pgCatalogVersion);
     }
     MEM_CONTEXT_NEW_END();
 
@@ -307,15 +308,16 @@ infoBackupPg(const InfoBackup *this)
 }
 
 InfoBackup *
-infoBackupPgSet(InfoBackup *this, unsigned int pgVersion, uint64_t pgSystemId)
+infoBackupPgSet(InfoBackup *this, unsigned int pgVersion, uint64_t pgSystemId, unsigned int pgCatalogVersion)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(INFO_BACKUP, this);
         FUNCTION_LOG_PARAM(UINT, pgVersion);
         FUNCTION_LOG_PARAM(UINT64, pgSystemId);
+        FUNCTION_LOG_PARAM(UINT, pgCatalogVersion);
     FUNCTION_LOG_END();
 
-    this->infoPg = infoPgSet(this->infoPg, infoPgBackup, pgVersion, pgSystemId);
+    this->infoPg = infoPgSet(this->infoPg, infoPgBackup, pgVersion, pgSystemId, pgCatalogVersion);
 
     FUNCTION_LOG_RETURN(INFO_BACKUP, this);
 }

--- a/src/info/infoBackup.h
+++ b/src/info/infoBackup.h
@@ -60,7 +60,7 @@ typedef struct InfoBackupData
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-InfoBackup *infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, const String *cipherPassSub);
+InfoBackup *infoBackupNew(unsigned int pgVersion, uint64_t pgSystemId, unsigned int pgCatalogVersion, const String *cipherPassSub);
 
 // Create new object and load contents from IoRead
 InfoBackup *infoBackupNewLoad(IoRead *read);
@@ -85,7 +85,7 @@ StringList *infoBackupDataLabelList(const InfoBackup *this, const String *expres
 
 // PostgreSQL info
 InfoPg *infoBackupPg(const InfoBackup *this);
-InfoBackup *infoBackupPgSet(InfoBackup *this, unsigned int pgVersion, uint64_t pgSystemId);
+InfoBackup *infoBackupPgSet(InfoBackup *this, unsigned int pgVersion, uint64_t pgSystemId, unsigned int pgCatalogVersion);
 
 // Return a structure of the backup data from a specific index
 InfoBackupData infoBackupData(const InfoBackup *this, unsigned int backupDataIdx);

--- a/src/info/infoPg.c
+++ b/src/info/infoPg.c
@@ -205,10 +205,8 @@ infoPgNewLoad(IoRead *read, InfoPgType type, InfoLoadNewCallback *callbackFuncti
     FUNCTION_LOG_RETURN(INFO_PG, this);
 }
 
-/***********************************************************************************************************************************
-Add Postgres data to the history list at position 0 to ensure the latest history is always first in the list
-***********************************************************************************************************************************/
-static void
+/**********************************************************************************************************************************/
+void
 infoPgAdd(InfoPg *this, const InfoPgData *infoPgData)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
@@ -332,7 +330,9 @@ infoPgSaveCallback(void *data, const String *sectionNext, InfoSave *infoSaveData
             {
                 kvPut(pgDataKv, INFO_KEY_DB_SYSTEM_ID_VAR, VARUINT64(pgData.systemId));
 
-                // These need to be saved because older pgBackRest versions expect them
+                // These need to be saved because older pgBackRest versions expect them. Archive info does not contain the catalog
+                // version so check that it is not zero to make sure we are not trying to save it in archive info.
+                ASSERT(pgData.catalogVersion != 0);
                 kvPut(pgDataKv, INFO_KEY_DB_CATALOG_VERSION_VAR, VARUINT(pgData.catalogVersion));
                 kvPut(pgDataKv, INFO_KEY_DB_CONTROL_VERSION_VAR, VARUINT(pgControlVersion(pgData.version)));
             }

--- a/src/info/infoPg.c
+++ b/src/info/infoPg.c
@@ -330,9 +330,7 @@ infoPgSaveCallback(void *data, const String *sectionNext, InfoSave *infoSaveData
             {
                 kvPut(pgDataKv, INFO_KEY_DB_SYSTEM_ID_VAR, VARUINT64(pgData.systemId));
 
-                // These need to be saved because older pgBackRest versions expect them. Archive info does not contain the catalog
-                // version so check that it is not zero to make sure we are not trying to save it in archive info.
-                ASSERT(pgData.catalogVersion != 0);
+                // These need to be saved because older pgBackRest versions expect them
                 kvPut(pgDataKv, INFO_KEY_DB_CATALOG_VERSION_VAR, VARUINT(pgData.catalogVersion));
                 kvPut(pgDataKv, INFO_KEY_DB_CONTROL_VERSION_VAR, VARUINT(pgControlVersion(pgData.version)));
             }
@@ -494,5 +492,7 @@ infoPgCurrentDataId(const InfoPg *this)
 String *
 infoPgDataToLog(const InfoPgData *this)
 {
-    return strNewFmt("{id: %u, version: %u, systemId: %" PRIu64 "}", this->id, this->version, this->systemId);
+    return strNewFmt(
+        "{id: %u, version: %u, systemId: %" PRIu64 ", catalogVersion: %u}", this->id, this->version, this->systemId,
+        this->catalogVersion);
 }

--- a/src/info/infoPg.c
+++ b/src/info/infoPg.c
@@ -203,8 +203,10 @@ infoPgNewLoad(IoRead *read, InfoPgType type, InfoLoadNewCallback *callbackFuncti
     FUNCTION_LOG_RETURN(INFO_PG, this);
 }
 
-/**********************************************************************************************************************************/
-void
+/***********************************************************************************************************************************
+Add Postgres data to the history list at position 0 to ensure the latest history is always first in the list
+***********************************************************************************************************************************/
+static void
 infoPgAdd(InfoPg *this, const InfoPgData *infoPgData)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);

--- a/src/info/infoPg.c
+++ b/src/info/infoPg.c
@@ -133,6 +133,8 @@ infoPgLoadCallback(void *data, const String *section, const String *key, const V
         {
             .id = cvtZToUInt(strZ(key)),
             .version = pgVersionFromStr(varStr(kvGet(pgDataKv, INFO_KEY_DB_VERSION_VAR))),
+            .catalogVersion =
+                loadData->infoPg->type == infoPgBackup ? varUIntForce(kvGet(pgDataKv, INFO_KEY_DB_CATALOG_VERSION_VAR)) : 0,
 
             // This is different in archive.info due to a typo that can't be fixed without a format version bump
             .systemId = varUInt64Force(
@@ -225,13 +227,15 @@ infoPgAdd(InfoPg *this, const InfoPgData *infoPgData)
 
 /**********************************************************************************************************************************/
 InfoPg *
-infoPgSet(InfoPg *this, InfoPgType type, const unsigned int pgVersion, const uint64_t pgSystemId)
+infoPgSet(
+    InfoPg *this, InfoPgType type, const unsigned int pgVersion, const uint64_t pgSystemId, const unsigned int pgCatalogVersion)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(INFO_PG, this);
         FUNCTION_LOG_PARAM(ENUM, type);
         FUNCTION_LOG_PARAM(UINT, pgVersion);
         FUNCTION_LOG_PARAM(UINT64, pgSystemId);
+        FUNCTION_LOG_PARAM(UINT, pgCatalogVersion);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
@@ -252,6 +256,9 @@ infoPgSet(InfoPg *this, InfoPgType type, const unsigned int pgVersion, const uin
 
             // This is different in archive.info due to a typo that can't be fixed without a format version bump
             .systemId = pgSystemId,
+
+            // Catalog version is only required for backup info to preserve the repo format
+            .catalogVersion = this->type == infoPgBackup ? pgCatalogVersion : 0,
         };
 
         // Add the pg data to the history list
@@ -296,8 +303,7 @@ infoPgSaveCallback(void *data, const String *sectionNext, InfoSave *infoSaveData
         if (saveData->infoPg->type == infoPgBackup)
         {
             infoSaveValue(
-                infoSaveData, INFO_SECTION_DB_STR, varStr(INFO_KEY_DB_CATALOG_VERSION_VAR),
-                jsonFromUInt(pgCatalogVersion(pgData.version)));
+                infoSaveData, INFO_SECTION_DB_STR, varStr(INFO_KEY_DB_CATALOG_VERSION_VAR), jsonFromUInt(pgData.catalogVersion));
             infoSaveValue(
                 infoSaveData, INFO_SECTION_DB_STR, varStr(INFO_KEY_DB_CONTROL_VERSION_VAR),
                 jsonFromUInt(pgControlVersion(pgData.version)));
@@ -327,7 +333,7 @@ infoPgSaveCallback(void *data, const String *sectionNext, InfoSave *infoSaveData
                 kvPut(pgDataKv, INFO_KEY_DB_SYSTEM_ID_VAR, VARUINT64(pgData.systemId));
 
                 // These need to be saved because older pgBackRest versions expect them
-                kvPut(pgDataKv, INFO_KEY_DB_CATALOG_VERSION_VAR, VARUINT(pgCatalogVersion(pgData.version)));
+                kvPut(pgDataKv, INFO_KEY_DB_CATALOG_VERSION_VAR, VARUINT(pgData.catalogVersion));
                 kvPut(pgDataKv, INFO_KEY_DB_CONTROL_VERSION_VAR, VARUINT(pgControlVersion(pgData.version)));
             }
             else

--- a/src/info/infoPg.h
+++ b/src/info/infoPg.h
@@ -32,6 +32,7 @@ typedef struct InfoPgData
 {
     unsigned int id;
     uint64_t systemId;
+    unsigned int catalogVersion;
     unsigned int version;
 } InfoPgData;
 
@@ -59,7 +60,8 @@ Functions
 void infoPgSave(InfoPg *this, IoWrite *write, InfoSaveCallback *callbackFunction, void *callbackData);
 
 // Set the InfoPg object data based on values passed
-InfoPg *infoPgSet(InfoPg *this, InfoPgType type, const unsigned int pgVersion, const uint64_t pgSystemId);
+InfoPg *infoPgSet(
+    InfoPg *this, InfoPgType type, const unsigned int pgVersion, const uint64_t pgSystemId, const unsigned int pgCatalogVersion);
 
 /***********************************************************************************************************************************
 Getters/Setters

--- a/src/info/infoPg.h
+++ b/src/info/infoPg.h
@@ -55,9 +55,6 @@ InfoPg *infoPgNewLoad(IoRead *read, InfoPgType type, InfoLoadNewCallback *callba
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/
-// Add Postgres data to the history list at position 0 to ensure the latest history is always first in the list
-void infoPgAdd(InfoPg *this, const InfoPgData *infoPgData);
-
 // Save to IO
 void infoPgSave(InfoPg *this, IoWrite *write, InfoSaveCallback *callbackFunction, void *callbackData);
 

--- a/src/info/infoPg.h
+++ b/src/info/infoPg.h
@@ -56,6 +56,9 @@ InfoPg *infoPgNewLoad(IoRead *read, InfoPgType type, InfoLoadNewCallback *callba
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/
+// Add Postgres data to the history list at position 0 to ensure the latest history is always first in the list
+void infoPgAdd(InfoPg *this, const InfoPgData *infoPgData);
+
 // Save to IO
 void infoPgSave(InfoPg *this, IoWrite *write, InfoSaveCallback *callbackFunction, void *callbackData);
 

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -855,12 +855,13 @@ manifestBuildCallback(void *data, const StorageInfo *info)
 
 Manifest *
 manifestNewBuild(
-    const Storage *storagePg, unsigned int pgVersion, bool online, bool checksumPage, const StringList *excludeList,
-    const VariantList *tablespaceList)
+    const Storage *storagePg, unsigned int pgVersion, unsigned int pgCatalogVersion, bool online, bool checksumPage,
+    const StringList *excludeList, const VariantList *tablespaceList)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(STORAGE, storagePg);
         FUNCTION_LOG_PARAM(UINT, pgVersion);
+        FUNCTION_LOG_PARAM(UINT, pgCatalogVersion);
         FUNCTION_LOG_PARAM(BOOL, online);
         FUNCTION_LOG_PARAM(BOOL, checksumPage);
         FUNCTION_LOG_PARAM(STRING_LIST, excludeList);
@@ -879,6 +880,7 @@ manifestNewBuild(
         this->info = infoNew(NULL);
         this->data.backrestVersion = strNew(PROJECT_VERSION);
         this->data.pgVersion = pgVersion;
+        this->data.pgCatalogVersion = pgCatalogVersion;
         this->data.backupOptionOnline = online;
         this->data.backupOptionChecksumPage = varNewBool(checksumPage);
 
@@ -889,7 +891,7 @@ manifestNewBuild(
             {
                 .manifest = this,
                 .storagePg = storagePg,
-                .tablespaceId = pgTablespaceId(pgVersion),
+                .tablespaceId = pgTablespaceId(pgVersion, pgCatalogVersion),
                 .online = online,
                 .checksumPage = checksumPage,
                 .tablespaceList = tablespaceList,
@@ -1234,9 +1236,9 @@ manifestBuildIncr(Manifest *this, const Manifest *manifestPrior, BackupType type
 void
 manifestBuildComplete(
     Manifest *this, time_t timestampStart, const String *lsnStart, const String *archiveStart, time_t timestampStop,
-    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, unsigned int pgCatalogVersion,
-    const VariantList *dbList, bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize,
-    unsigned int optionCompressLevel, unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax,
+    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, const VariantList *dbList,
+    bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize, unsigned int optionCompressLevel,
+    unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax,
     bool optionStandby)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
@@ -1249,7 +1251,6 @@ manifestBuildComplete(
         FUNCTION_LOG_PARAM(STRING, archiveStop);
         FUNCTION_LOG_PARAM(UINT, pgId);
         FUNCTION_LOG_PARAM(UINT64, pgSystemId);
-        FUNCTION_LOG_PARAM(UINT, pgCatalogVersion);
         FUNCTION_LOG_PARAM(VARIANT_LIST, dbList);
         FUNCTION_LOG_PARAM(BOOL, optionArchiveCheck);
         FUNCTION_LOG_PARAM(BOOL, optionArchiveCopy);
@@ -1272,7 +1273,6 @@ manifestBuildComplete(
         this->data.archiveStop = strDup(archiveStop);
         this->data.pgId = pgId;
         this->data.pgSystemId = pgSystemId;
-        this->data.pgCatalogVersion = pgCatalogVersion;
 
         // Save db list
         if (dbList != NULL)

--- a/src/info/manifest.h
+++ b/src/info/manifest.h
@@ -153,8 +153,8 @@ Constructors
 ***********************************************************************************************************************************/
 // Build a new manifest for a PostgreSQL data directory
 Manifest *manifestNewBuild(
-    const Storage *storagePg, unsigned int pgVersion, bool online, bool checksumPage, const StringList *excludeList,
-    const VariantList *tablespaceList);
+    const Storage *storagePg, unsigned int pgVersion, unsigned int pgCatalogVersion, bool online, bool checksumPage,
+    const StringList *excludeList, const VariantList *tablespaceList);
 
 // Load a manifest from IO
 Manifest *manifestNewLoad(IoRead *read);
@@ -171,10 +171,9 @@ void manifestBuildIncr(Manifest *this, const Manifest *prior, BackupType type, c
 // Set remaining values before the final save
 void manifestBuildComplete(
     Manifest *this, time_t timestampStart, const String *lsnStart, const String *archiveStart, time_t timestampStop,
-    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, unsigned int pgCatalogVersion,
-    const VariantList *dbList, bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize,
-    unsigned int optionCompressLevel, unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax,
-    bool optionStandby);
+    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, const VariantList *dbList,
+    bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize, unsigned int optionCompressLevel,
+    unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax, bool optionStandby);
 
 /***********************************************************************************************************************************
 Functions

--- a/src/info/manifest.h
+++ b/src/info/manifest.h
@@ -61,6 +61,7 @@ typedef struct ManifestData
     unsigned int pgId;                                              // PostgreSQL id in backup.info
     unsigned int pgVersion;                                         // PostgreSQL version
     uint64_t pgSystemId;                                            // PostgreSQL system identifier
+    unsigned int pgCatalogVersion;                                  // PostgreSQL catalog version
 
     bool backupOptionArchiveCheck;                                  // Will WAL segments be checked at the end of the backup?
     bool backupOptionArchiveCopy;                                   // Will WAL segments be copied to the backup?
@@ -170,9 +171,10 @@ void manifestBuildIncr(Manifest *this, const Manifest *prior, BackupType type, c
 // Set remaining values before the final save
 void manifestBuildComplete(
     Manifest *this, time_t timestampStart, const String *lsnStart, const String *archiveStart, time_t timestampStop,
-    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, const VariantList *dbList,
-    bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize, unsigned int optionCompressLevel,
-    unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax, bool optionStandby);
+    const String *lsnStop, const String *archiveStop, unsigned int pgId, uint64_t pgSystemId, unsigned int pgCatalogVersion,
+    const VariantList *dbList, bool optionArchiveCheck, bool optionArchiveCopy, size_t optionBufferSize,
+    unsigned int optionCompressLevel, unsigned int optionCompressLevelNetwork, bool optionHardLink, unsigned int optionProcessMax,
+    bool optionStandby);
 
 /***********************************************************************************************************************************
 Functions

--- a/src/postgres/interface.c
+++ b/src/postgres/interface.c
@@ -99,8 +99,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_13,
 
-        .catalogVersion = pgInterfaceCatalogVersion130,
-
         .controlIs = pgInterfaceControlIs130,
         .control = pgInterfaceControl130,
         .controlVersion = pgInterfaceControlVersion130,
@@ -115,8 +113,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_12,
-
-        .catalogVersion = pgInterfaceCatalogVersion120,
 
         .controlIs = pgInterfaceControlIs120,
         .control = pgInterfaceControl120,
@@ -133,8 +129,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_11,
 
-        .catalogVersion = pgInterfaceCatalogVersion110,
-
         .controlIs = pgInterfaceControlIs110,
         .control = pgInterfaceControl110,
         .controlVersion = pgInterfaceControlVersion110,
@@ -149,8 +143,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_10,
-
-        .catalogVersion = pgInterfaceCatalogVersion100,
 
         .controlIs = pgInterfaceControlIs100,
         .control = pgInterfaceControl100,
@@ -167,8 +159,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_96,
 
-        .catalogVersion = pgInterfaceCatalogVersion096,
-
         .controlIs = pgInterfaceControlIs096,
         .control = pgInterfaceControl096,
         .controlVersion = pgInterfaceControlVersion096,
@@ -183,8 +173,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_95,
-
-        .catalogVersion = pgInterfaceCatalogVersion095,
 
         .controlIs = pgInterfaceControlIs095,
         .control = pgInterfaceControl095,
@@ -201,8 +189,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_94,
 
-        .catalogVersion = pgInterfaceCatalogVersion094,
-
         .controlIs = pgInterfaceControlIs094,
         .control = pgInterfaceControl094,
         .controlVersion = pgInterfaceControlVersion094,
@@ -217,8 +203,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_93,
-
-        .catalogVersion = pgInterfaceCatalogVersion093,
 
         .controlIs = pgInterfaceControlIs093,
         .control = pgInterfaceControl093,
@@ -235,8 +219,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_92,
 
-        .catalogVersion = pgInterfaceCatalogVersion092,
-
         .controlIs = pgInterfaceControlIs092,
         .control = pgInterfaceControl092,
         .controlVersion = pgInterfaceControlVersion092,
@@ -251,8 +233,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_91,
-
-        .catalogVersion = pgInterfaceCatalogVersion091,
 
         .controlIs = pgInterfaceControlIs091,
         .control = pgInterfaceControl091,
@@ -269,8 +249,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_90,
 
-        .catalogVersion = pgInterfaceCatalogVersion090,
-
         .controlIs = pgInterfaceControlIs090,
         .control = pgInterfaceControl090,
         .controlVersion = pgInterfaceControlVersion090,
@@ -286,8 +264,6 @@ static const PgInterface pgInterface[] =
     {
         .version = PG_VERSION_84,
 
-        .catalogVersion = pgInterfaceCatalogVersion084,
-
         .controlIs = pgInterfaceControlIs084,
         .control = pgInterfaceControl084,
         .controlVersion = pgInterfaceControlVersion084,
@@ -302,8 +278,6 @@ static const PgInterface pgInterface[] =
     },
     {
         .version = PG_VERSION_83,
-
-        .catalogVersion = pgInterfaceCatalogVersion083,
 
         .controlIs = pgInterfaceControlIs083,
         .control = pgInterfaceControl083,
@@ -359,17 +333,6 @@ pgInterfaceVersion(unsigned int pgVersion)
         THROW_FMT(AssertError, "invalid " PG_NAME " version %u", pgVersion);
 
     FUNCTION_TEST_RETURN(result);
-}
-
-/**********************************************************************************************************************************/
-uint32_t
-pgCatalogVersion(unsigned int pgVersion)
-{
-    FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(UINT, pgVersion);
-    FUNCTION_TEST_END();
-
-    FUNCTION_TEST_RETURN(pgInterfaceVersion(pgVersion)->catalogVersion());
 }
 
 /***********************************************************************************************************************************
@@ -559,10 +522,11 @@ pgWalFromFile(const String *walFile, const Storage *storage)
 
 /**********************************************************************************************************************************/
 String *
-pgTablespaceId(unsigned int pgVersion)
+pgTablespaceId(unsigned int pgVersion, unsigned int pgCatalogVersion)
 {
     FUNCTION_TEST_BEGIN();
         FUNCTION_TEST_PARAM(UINT, pgVersion);
+        FUNCTION_TEST_PARAM(UINT, pgCatalogVersion);
     FUNCTION_TEST_END();
 
     String *result = NULL;
@@ -575,7 +539,7 @@ pgTablespaceId(unsigned int pgVersion)
 
             MEM_CONTEXT_PRIOR_BEGIN()
             {
-                result = strNewFmt("PG_%s_%u", strZ(pgVersionStr), pgCatalogVersion(pgVersion));
+                result = strNewFmt("PG_%s_%u", strZ(pgVersionStr), pgCatalogVersion);
             }
             MEM_CONTEXT_PRIOR_END();
         }

--- a/src/postgres/interface.c
+++ b/src/postgres/interface.c
@@ -66,9 +66,6 @@ typedef struct PgInterface
     // Version of PostgreSQL supported by this interface
     unsigned int version;
 
-    // Get the catalog version for this version of PostgreSQL
-    uint32_t (*catalogVersion)(void);
-
     // Does pg_control match this version of PostgreSQL?
     bool (*controlIs)(const unsigned char *);
 
@@ -85,6 +82,8 @@ typedef struct PgInterface
     PgWal (*wal)(const unsigned char *);
 
 #ifdef DEBUG
+    // Catalog version for testing
+    unsigned int catalogVersion;
 
     // Create pg_control for testing
     void (*controlTest)(PgControl, unsigned char *);
@@ -107,6 +106,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal130,
 
 #ifdef DEBUG
+        .catalogVersion = 202007201,
+
         .controlTest = pgInterfaceControlTest130,
         .walTest = pgInterfaceWalTest130,
 #endif
@@ -122,6 +123,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal120,
 
 #ifdef DEBUG
+        .catalogVersion = 201909212,
+
         .controlTest = pgInterfaceControlTest120,
         .walTest = pgInterfaceWalTest120,
 #endif
@@ -137,6 +140,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal110,
 
 #ifdef DEBUG
+        .catalogVersion = 201809051,
+
         .controlTest = pgInterfaceControlTest110,
         .walTest = pgInterfaceWalTest110,
 #endif
@@ -152,6 +157,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal100,
 
 #ifdef DEBUG
+        .catalogVersion = 201707211,
+
         .controlTest = pgInterfaceControlTest100,
         .walTest = pgInterfaceWalTest100,
 #endif
@@ -167,6 +174,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal096,
 
 #ifdef DEBUG
+        .catalogVersion = 201608131,
+
         .controlTest = pgInterfaceControlTest096,
         .walTest = pgInterfaceWalTest096,
 #endif
@@ -182,6 +191,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal095,
 
 #ifdef DEBUG
+        .catalogVersion = 201510051,
+
         .controlTest = pgInterfaceControlTest095,
         .walTest = pgInterfaceWalTest095,
 #endif
@@ -197,6 +208,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal094,
 
 #ifdef DEBUG
+        .catalogVersion = 201409291,
+
         .controlTest = pgInterfaceControlTest094,
         .walTest = pgInterfaceWalTest094,
 #endif
@@ -212,6 +225,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal093,
 
 #ifdef DEBUG
+        .catalogVersion = 201306121,
+
         .controlTest = pgInterfaceControlTest093,
         .walTest = pgInterfaceWalTest093,
 #endif
@@ -227,6 +242,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal092,
 
 #ifdef DEBUG
+        .catalogVersion = 201204301,
+
         .controlTest = pgInterfaceControlTest092,
         .walTest = pgInterfaceWalTest092,
 #endif
@@ -242,6 +259,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal091,
 
 #ifdef DEBUG
+        .catalogVersion = 201105231,
+
         .controlTest = pgInterfaceControlTest091,
         .walTest = pgInterfaceWalTest091,
 #endif
@@ -257,6 +276,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal090,
 
 #ifdef DEBUG
+        .catalogVersion = 201008051,
+
         .controlTest = pgInterfaceControlTest090,
         .walTest = pgInterfaceWalTest090,
 #endif
@@ -272,6 +293,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal084,
 
 #ifdef DEBUG
+        .catalogVersion = 200904091,
+
         .controlTest = pgInterfaceControlTest084,
         .walTest = pgInterfaceWalTest084,
 #endif
@@ -287,6 +310,8 @@ static const PgInterface pgInterface[] =
         .wal = pgInterfaceWal083,
 
 #ifdef DEBUG
+        .catalogVersion = 200711281,
+
         .controlTest = pgInterfaceControlTest083,
         .walTest = pgInterfaceWalTest083,
 #endif
@@ -732,6 +757,8 @@ pgControlTestToBuffer(PgControl pgControl)
     // Set defaults if values are not passed
     pgControl.pageSize = pgControl.pageSize == 0 ? PG_PAGE_SIZE_DEFAULT : pgControl.pageSize;
     pgControl.walSegmentSize = pgControl.walSegmentSize == 0 ? PG_WAL_SEGMENT_SIZE_DEFAULT : pgControl.walSegmentSize;
+    pgControl.catalogVersion = pgControl.catalogVersion == 0 ?
+        pgInterfaceVersion(pgControl.version)->catalogVersion : pgControl.catalogVersion;
 
     // Create the buffer and clear it
     Buffer *result = bufNew(PG_CONTROL_SIZE);

--- a/src/postgres/interface.c
+++ b/src/postgres/interface.c
@@ -747,6 +747,21 @@ pgXactPath(unsigned int pgVersion)
 /**********************************************************************************************************************************/
 #ifdef DEBUG
 
+unsigned int
+pgCatalogTestVersion(unsigned int pgVersion)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(UINT, pgVersion);
+    FUNCTION_TEST_END();
+
+    FUNCTION_TEST_RETURN(pgInterfaceVersion(pgVersion)->catalogVersion);
+}
+
+#endif
+
+/**********************************************************************************************************************************/
+#ifdef DEBUG
+
 Buffer *
 pgControlTestToBuffer(PgControl pgControl)
 {

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -146,7 +146,7 @@ PgWal pgWalFromFile(const String *walFile, const Storage *storage);
 PgWal pgWalFromBuffer(const Buffer *walBuffer);
 
 // Get the tablespace identifier used to distinguish versions in a tablespace directory, e.g. PG_9.0_201008051
-String *pgTablespaceId(unsigned int pgVersion);
+String *pgTablespaceId(unsigned int pgVersion, unsigned int pgCatalogVersion);
 
 // Convert a string to an lsn and vice versa
 uint64_t pgLsnFromStr(const String *lsn);

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -178,6 +178,9 @@ const String *pgXactPath(unsigned int pgVersion);
 Test Functions
 ***********************************************************************************************************************************/
 #ifdef DEBUG
+    // Get the catalog version for a PostgreSQL version for testing
+    unsigned int pgCatalogTestVersion(unsigned int pgVersion);
+
     // Create pg_control for testing
     Buffer *pgControlTestToBuffer(PgControl pgControl);
 

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -109,6 +109,7 @@ typedef struct PgControl
 {
     unsigned int version;
     uint64_t systemId;
+    unsigned int catalogVersion;
 
     unsigned int pageSize;
     unsigned int walSegmentSize;
@@ -129,9 +130,6 @@ typedef struct PgWal
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/
-// Get the catalog version for a PostgreSQL version
-uint32_t pgCatalogVersion(unsigned int pgVersion);
-
 // Get info from pg_control
 PgControl pgControlFromFile(const Storage *storage);
 PgControl pgControlFromBuffer(const Buffer *controlFile);

--- a/src/postgres/interface/version.h
+++ b/src/postgres/interface/version.h
@@ -9,91 +9,78 @@ PostgreSQL Version Interface
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/
-uint32_t pgInterfaceCatalogVersion083(void);
 bool pgInterfaceControlIs083(const unsigned char *controlFile);
 PgControl pgInterfaceControl083(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion083(void);
 bool pgInterfaceWalIs083(const unsigned char *walFile);
 PgWal pgInterfaceWal083(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion084(void);
 bool pgInterfaceControlIs084(const unsigned char *controlFile);
 PgControl pgInterfaceControl084(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion084(void);
 bool pgInterfaceWalIs084(const unsigned char *walFile);
 PgWal pgInterfaceWal084(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion090(void);
 bool pgInterfaceControlIs090(const unsigned char *controlFile);
 PgControl pgInterfaceControl090(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion090(void);
 bool pgInterfaceWalIs090(const unsigned char *walFile);
 PgWal pgInterfaceWal090(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion091(void);
 bool pgInterfaceControlIs091(const unsigned char *controlFile);
 PgControl pgInterfaceControl091(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion091(void);
 bool pgInterfaceWalIs091(const unsigned char *walFile);
 PgWal pgInterfaceWal091(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion092(void);
 bool pgInterfaceControlIs092(const unsigned char *controlFile);
 PgControl pgInterfaceControl092(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion092(void);
 bool pgInterfaceWalIs092(const unsigned char *walFile);
 PgWal pgInterfaceWal092(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion093(void);
 bool pgInterfaceControlIs093(const unsigned char *controlFile);
 PgControl pgInterfaceControl093(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion093(void);
 bool pgInterfaceWalIs093(const unsigned char *walFile);
 PgWal pgInterfaceWal093(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion094(void);
 bool pgInterfaceControlIs094(const unsigned char *controlFile);
 PgControl pgInterfaceControl094(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion094(void);
 bool pgInterfaceWalIs094(const unsigned char *walFile);
 PgWal pgInterfaceWal094(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion095(void);
 bool pgInterfaceControlIs095(const unsigned char *controlFile);
 PgControl pgInterfaceControl095(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion095(void);
 bool pgInterfaceWalIs095(const unsigned char *walFile);
 PgWal pgInterfaceWal095(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion096(void);
 bool pgInterfaceControlIs096(const unsigned char *controlFile);
 PgControl pgInterfaceControl096(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion096(void);
 bool pgInterfaceWalIs096(const unsigned char *walFile);
 PgWal pgInterfaceWal096(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion100(void);
 bool pgInterfaceControlIs100(const unsigned char *controlFile);
 PgControl pgInterfaceControl100(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion100(void);
 bool pgInterfaceWalIs100(const unsigned char *walFile);
 PgWal pgInterfaceWal100(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion110(void);
 bool pgInterfaceControlIs110(const unsigned char *controlFile);
 PgControl pgInterfaceControl110(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion110(void);
 bool pgInterfaceWalIs110(const unsigned char *walFile);
 PgWal pgInterfaceWal110(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion120(void);
 bool pgInterfaceControlIs120(const unsigned char *controlFile);
 PgControl pgInterfaceControl120(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion120(void);
 bool pgInterfaceWalIs120(const unsigned char *walFile);
 PgWal pgInterfaceWal120(const unsigned char *controlFile);
 
-uint32_t pgInterfaceCatalogVersion130(void);
 bool pgInterfaceControlIs130(const unsigned char *controlFile);
 PgControl pgInterfaceControl130(const unsigned char *controlFile);
 uint32_t pgInterfaceControlVersion130(void);

--- a/src/postgres/interface/version.intern.h
+++ b/src/postgres/interface/version.intern.h
@@ -40,6 +40,8 @@ Determine if the supplied pg_control is for this version of PostgreSQL
 
 #elif PG_VERSION >= PG_VERSION_83
 
+#ifdef PG_CONTROL_VERSION_DUPLICATE
+
 #define PG_INTERFACE_CONTROL_IS(version)                                                                                           \
     bool                                                                                                                           \
     pgInterfaceControlIs##version(const unsigned char *controlFile)                                                                \
@@ -50,6 +52,19 @@ Determine if the supplied pg_control is for this version of PostgreSQL
             ((ControlFileData *)controlFile)->pg_control_version == PG_CONTROL_VERSION &&                                          \
             ((ControlFileData *)controlFile)->catalog_version_no == CATALOG_VERSION_NO;                                            \
     }
+
+#else
+
+#define PG_INTERFACE_CONTROL_IS(version)                                                                                           \
+    bool                                                                                                                           \
+    pgInterfaceControlIs##version(const unsigned char *controlFile)                                                                \
+    {                                                                                                                              \
+        ASSERT(controlFile != NULL);                                                                                               \
+                                                                                                                                   \
+        return ((ControlFileData *)controlFile)->pg_control_version == PG_CONTROL_VERSION;                                         \
+    }
+
+#endif // PG_CONTROL_VERSION_DUPLICATE
 
 #endif
 

--- a/src/postgres/interface/version.intern.h
+++ b/src/postgres/interface/version.intern.h
@@ -165,7 +165,7 @@ Create a pg_control file for testing
         {                                                                                                                          \
             .system_identifier = pgControl.systemId,                                                                               \
             .pg_control_version = PG_CONTROL_VERSION,                                                                              \
-            .catalog_version_no = CATALOG_VERSION_NO,                                                                              \
+            .catalog_version_no = pgControl.catalogVersion,                                                                        \
             .blcksz = pgControl.pageSize,                                                                                          \
             .xlog_seg_size = pgControl.walSegmentSize,                                                                             \
         };                                                                                                                         \

--- a/src/postgres/interface/version.intern.h
+++ b/src/postgres/interface/version.intern.h
@@ -85,6 +85,7 @@ Read the version specific pg_control into a general data structure
         return (PgControl)                                                                                                         \
         {                                                                                                                          \
             .systemId = ((ControlFileData *)controlFile)->system_identifier,                                                       \
+            .catalogVersion = ((ControlFileData *)controlFile)->catalog_version_no,                                                \
             .pageSize = ((ControlFileData *)controlFile)->blcksz,                                                                  \
             .walSegmentSize = ((ControlFileData *)controlFile)->xlog_seg_size,                                                     \
             .pageChecksum = ((ControlFileData *)controlFile)->data_checksum_version != 0,                                          \
@@ -103,6 +104,7 @@ Read the version specific pg_control into a general data structure
         return (PgControl)                                                                                                         \
         {                                                                                                                          \
             .systemId = ((ControlFileData *)controlFile)->system_identifier,                                                       \
+            .catalogVersion = ((ControlFileData *)controlFile)->catalog_version_no,                                                \
             .pageSize = ((ControlFileData *)controlFile)->blcksz,                                                                  \
             .walSegmentSize = ((ControlFileData *)controlFile)->xlog_seg_size,                                                     \
         };                                                                                                                         \

--- a/src/postgres/interface/version.intern.h
+++ b/src/postgres/interface/version.intern.h
@@ -18,29 +18,13 @@ Each version of PostgreSQL will need a vXXX.c file to contain the version-specif
 #include "postgres/interface/version.vendor.h"
 
 /***********************************************************************************************************************************
-Get the catalog version
-***********************************************************************************************************************************/
-#if PG_VERSION > PG_VERSION_MAX
-
-#elif PG_VERSION >= PG_VERSION_83
-
-#define PG_INTERFACE_CATALOG_VERSION(version)                                                                                      \
-    uint32_t                                                                                                                       \
-    pgInterfaceCatalogVersion##version(void)                                                                                       \
-    {                                                                                                                              \
-        return CATALOG_VERSION_NO;                                                                                                 \
-    }
-
-#endif
-
-/***********************************************************************************************************************************
 Determine if the supplied pg_control is for this version of PostgreSQL
 ***********************************************************************************************************************************/
 #if PG_VERSION > PG_VERSION_MAX
 
 #elif PG_VERSION >= PG_VERSION_83
 
-#ifdef PG_CONTROL_VERSION_DUPLICATE
+#ifdef CATALOG_VERSION_NO
 
 #define PG_INTERFACE_CONTROL_IS(version)                                                                                           \
     bool                                                                                                                           \
@@ -64,7 +48,7 @@ Determine if the supplied pg_control is for this version of PostgreSQL
         return ((ControlFileData *)controlFile)->pg_control_version == PG_CONTROL_VERSION;                                         \
     }
 
-#endif // PG_CONTROL_VERSION_DUPLICATE
+#endif // CATALOG_VERSION_NO
 
 #endif
 
@@ -145,7 +129,7 @@ Create a pg_control file for testing
         {                                                                                                                          \
             .system_identifier = pgControl.systemId,                                                                               \
             .pg_control_version = PG_CONTROL_VERSION,                                                                              \
-            .catalog_version_no = CATALOG_VERSION_NO,                                                                              \
+            .catalog_version_no = pgControl.catalogVersion,                                                                        \
             .blcksz = pgControl.pageSize,                                                                                          \
             .xlog_seg_size = pgControl.walSegmentSize,                                                                             \
             .data_checksum_version = pgControl.pageChecksum,                                                                       \
@@ -237,7 +221,6 @@ Create a WAL file file for testing
 Call all macros with a single macro to make the vXXX.c files as simple as possible
 ***********************************************************************************************************************************/
 #define PG_INTERFACE_BASE(version)                                                                                                 \
-    PG_INTERFACE_CATALOG_VERSION(version)                                                                                          \
     PG_INTERFACE_CONTROL_IS(version)                                                                                               \
     PG_INTERFACE_CONTROL(version)                                                                                                  \
     PG_INTERFACE_CONTROL_VERSION(version)                                                                                          \

--- a/src/postgres/interface/version.vendor.h
+++ b/src/postgres/interface/version.vendor.h
@@ -373,6 +373,10 @@ typedef struct FullTransactionId
 
 /***********************************************************************************************************************************
 Types from src/include/catalog/pg_control.h
+
+When more than one PostgreSQL version shares a control version then #define PG_CONTROL_VERSION_DUPLICATE so the catalog version will
+also be used to identify the PostgreSQL version. Newer versions of PostgreSQL have reliably bumped the control version but that has
+not always been the case.
 ***********************************************************************************************************************************/
 
 // PG_CONTROL_VERSION define
@@ -409,6 +413,9 @@ Types from src/include/catalog/pg_control.h
 /* Version identifier for this pg_control format */
 #define PG_CONTROL_VERSION	942
 
+/* 9.4 and 9.5 have the same control version */
+#define PG_CONTROL_VERSION_DUPLICATE
+
 #elif PG_VERSION >= PG_VERSION_93
 
 /* Version identifier for this pg_control format */
@@ -423,6 +430,9 @@ Types from src/include/catalog/pg_control.h
 
 /* Version identifier for this pg_control format */
 #define PG_CONTROL_VERSION	903
+
+/* 9.1 and 9.2 have the same control version */
+#define PG_CONTROL_VERSION_DUPLICATE
 
 #elif PG_VERSION >= PG_VERSION_84
 

--- a/src/postgres/interface/version.vendor.h
+++ b/src/postgres/interface/version.vendor.h
@@ -180,10 +180,14 @@ Types from src/include/catalog/catversion.h
 //
 // Add CATALOG_VERSION_NO when more than one PostgreSQL version shares a control version so the PostgreSQL version can be reliably
 // identified. Newer versions of PostgreSQL have bumped the control version but that has not always been the case.
+//
+// Undef CATALOG_VERSION_NO in PostgreSQL versions where it is not required to improve readability.
 // ---------------------------------------------------------------------------------------------------------------------------------
 #if PG_VERSION > PG_VERSION_MAX
 
 #elif PG_VERSION >= PG_VERSION_96
+
+#undef CATALOG_VERSION_NO
 
 #elif PG_VERSION >= PG_VERSION_95
 
@@ -213,6 +217,8 @@ Types from src/include/catalog/catversion.h
 
 #elif PG_VERSION >= PG_VERSION_92
 
+#undef CATALOG_VERSION_NO
+
 #elif PG_VERSION >= PG_VERSION_91
 
 /*
@@ -240,6 +246,8 @@ Types from src/include/catalog/catversion.h
 #define CATALOG_VERSION_NO	201008051
 
 #elif PG_VERSION >= PG_VERSION_83
+
+#undef CATALOG_VERSION_NO
 
 #endif
 

--- a/src/postgres/interface/version.vendor.h
+++ b/src/postgres/interface/version.vendor.h
@@ -177,71 +177,13 @@ Types from src/include/catalog/catversion.h
 ***********************************************************************************************************************************/
 
 // CATALOG_VERSION_NO define
+//
+// Add CATALOG_VERSION_NO when more than one PostgreSQL version shares a control version so the version can be reliably identified.
+// Newer versions of PostgreSQL have reliably bumped the control version but that has not always been the case.
 // ---------------------------------------------------------------------------------------------------------------------------------
 #if PG_VERSION > PG_VERSION_MAX
 
-#elif PG_VERSION >= PG_VERSION_13
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	202007201
-
-#elif PG_VERSION >= PG_VERSION_12
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201909212
-
-#elif PG_VERSION >= PG_VERSION_11
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201809051
-
-#elif PG_VERSION >= PG_VERSION_10
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201707211
-
 #elif PG_VERSION >= PG_VERSION_96
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201608131
 
 #elif PG_VERSION >= PG_VERSION_95
 
@@ -269,31 +211,7 @@ Types from src/include/catalog/catversion.h
 /*							yyyymmddN */
 #define CATALOG_VERSION_NO	201409291
 
-#elif PG_VERSION >= PG_VERSION_93
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201306121
-
 #elif PG_VERSION >= PG_VERSION_92
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	201204301
 
 #elif PG_VERSION >= PG_VERSION_91
 
@@ -321,31 +239,7 @@ Types from src/include/catalog/catversion.h
 /*							yyyymmddN */
 #define CATALOG_VERSION_NO	201008051
 
-#elif PG_VERSION >= PG_VERSION_84
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	200904091
-
 #elif PG_VERSION >= PG_VERSION_83
-
-/*
- * We could use anything we wanted for version numbers, but I recommend
- * following the "YYYYMMDDN" style often used for DNS zone serial numbers.
- * YYYYMMDD are the date of the change, and N is the number of the change
- * on that day.  (Hopefully we'll never commit ten independent sets of
- * catalog changes on the same day...)
- */
-
-/*							yyyymmddN */
-#define CATALOG_VERSION_NO	200711281
 
 #endif
 
@@ -373,10 +267,6 @@ typedef struct FullTransactionId
 
 /***********************************************************************************************************************************
 Types from src/include/catalog/pg_control.h
-
-When more than one PostgreSQL version shares a control version then #define PG_CONTROL_VERSION_DUPLICATE so the catalog version will
-also be used to identify the PostgreSQL version. Newer versions of PostgreSQL have reliably bumped the control version but that has
-not always been the case.
 ***********************************************************************************************************************************/
 
 // PG_CONTROL_VERSION define
@@ -413,9 +303,6 @@ not always been the case.
 /* Version identifier for this pg_control format */
 #define PG_CONTROL_VERSION	942
 
-/* 9.4 and 9.5 have the same control version */
-#define PG_CONTROL_VERSION_DUPLICATE
-
 #elif PG_VERSION >= PG_VERSION_93
 
 /* Version identifier for this pg_control format */
@@ -430,9 +317,6 @@ not always been the case.
 
 /* Version identifier for this pg_control format */
 #define PG_CONTROL_VERSION	903
-
-/* 9.1 and 9.2 have the same control version */
-#define PG_CONTROL_VERSION_DUPLICATE
 
 #elif PG_VERSION >= PG_VERSION_84
 

--- a/src/postgres/interface/version.vendor.h
+++ b/src/postgres/interface/version.vendor.h
@@ -178,8 +178,8 @@ Types from src/include/catalog/catversion.h
 
 // CATALOG_VERSION_NO define
 //
-// Add CATALOG_VERSION_NO when more than one PostgreSQL version shares a control version so the version can be reliably identified.
-// Newer versions of PostgreSQL have reliably bumped the control version but that has not always been the case.
+// Add CATALOG_VERSION_NO when more than one PostgreSQL version shares a control version so the PostgreSQL version can be reliably
+// identified. Newer versions of PostgreSQL have bumped the control version but that has not always been the case.
 // ---------------------------------------------------------------------------------------------------------------------------------
 #if PG_VERSION > PG_VERSION_MAX
 

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -120,7 +120,8 @@ testRun(void)
         // -------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 0xFACEFACEFACEFACE}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 0xFACEFACEFACEFACE, .catalogVersion = 201608131}));
 
         // Create incorrect archive info
         storagePutP(
@@ -213,7 +214,8 @@ testRun(void)
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACEFACEFACE}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACEFACEFACE, .catalogVersion = 201809051}));
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("repo/archive/test/archive.info")),
@@ -498,7 +500,8 @@ testRun(void)
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_94, .systemId = 0xAAAABBBBCCCCDDDD}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_94, .systemId = 0xAAAABBBBCCCCDDDD, .catalogVersion = 201409291}));
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("repo/archive/test/archive.info")),

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -120,8 +120,7 @@ testRun(void)
         // -------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 0xFACEFACEFACEFACE, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 0xFACEFACEFACEFACE}));
 
         // Create incorrect archive info
         storagePutP(
@@ -214,8 +213,7 @@ testRun(void)
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACEFACEFACE, .catalogVersion = 201809051}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACEFACEFACE}));
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("repo/archive/test/archive.info")),
@@ -500,8 +498,7 @@ testRun(void)
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("pg/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_94, .systemId = 0xAAAABBBBCCCCDDDD, .catalogVersion = 201409291}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_94, .systemId = 0xAAAABBBBCCCCDDDD}));
 
         storagePutP(
             storageNewWriteP(storageTest, strNew("repo/archive/test/archive.info")),

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1016,7 +1016,7 @@ testRun(void)
         harnessCfgLoad(cfgCmdBackup, argList);
 
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_91, 1000000000000000910, NULL)), ConfigError,
+            backupInit(infoBackupNew(PG_VERSION_91, 1000000000000000910, 201105231, NULL)), ConfigError,
              "option 'backup-standby' not valid for PostgreSQL < 9.2");
 
         // -------------------------------------------------------------------------------------------------------------------------
@@ -1025,7 +1025,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 1000000000000000920}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 1000000000000000920, .catalogVersion = 201204301}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1036,7 +1037,7 @@ testRun(void)
         strLstAddZ(argList, "--no-" CFGOPT_ONLINE);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_92, 1000000000000000920, NULL)), "backup init");
+        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_92, 1000000000000000920, 201204301, NULL)), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptBackupStandby), false, "    check backup-standby");
 
         TEST_RESULT_LOG(
@@ -1048,7 +1049,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_10, .systemId = 1000000000000001000}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_10, .systemId = 1000000000000001000, .catalogVersion = 201707211}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1059,11 +1061,11 @@ testRun(void)
         harnessCfgLoad(cfgCmdBackup, argList);
 
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_11, 1000000000000001100, NULL)), BackupMismatchError,
+            backupInit(infoBackupNew(PG_VERSION_11, 1000000000000001100, 201809051, NULL)), BackupMismatchError,
             "PostgreSQL version 10, system-id 1000000000000001000 do not match stanza version 11, system-id 1000000000000001100\n"
             "HINT: is this the correct stanza?");
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_10, 1000000000000001100, NULL)), BackupMismatchError,
+            backupInit(infoBackupNew(PG_VERSION_10, 1000000000000001100, 201707211, NULL)), BackupMismatchError,
             "PostgreSQL version 10, system-id 1000000000000001000 do not match stanza version 10, system-id 1000000000000001100\n"
             "HINT: is this the correct stanza?");
 
@@ -1073,7 +1075,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_83, .systemId = 1000000000000000830}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_83, .systemId = 1000000000000000830, .catalogVersion = 200711281}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1084,7 +1087,7 @@ testRun(void)
         strLstAddZ(argList, "--" CFGOPT_START_FAST);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_83, 1000000000000000830, NULL)), "backup init");
+        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_83, 1000000000000000830, 200711281, NULL)), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptStartFast), false, "    check start-fast");
 
         TEST_RESULT_LOG("P00   WARN: start-fast option is only available in PostgreSQL >= 8.4");
@@ -1095,7 +1098,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840, .catalogVersion = 200904091}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1106,7 +1110,7 @@ testRun(void)
         strLstAddZ(argList, "--" CFGOPT_STOP_AUTO);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_84, 1000000000000000840, NULL)), "backup init");
+        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_84, 1000000000000000840, 200904091, NULL)), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptStopAuto), false, "    check stop-auto");
 
         TEST_RESULT_LOG("P00   WARN: stop-auto option is only available in PostgreSQL >= 9.3");
@@ -1117,7 +1121,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1135,7 +1140,8 @@ testRun(void)
             HRNPQ_MACRO_DONE()
         });
 
-        TEST_RESULT_VOID(dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, NULL))->dbPrimary), "backup init");
+        TEST_RESULT_VOID(
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
 
         TEST_RESULT_LOG(
@@ -1147,7 +1153,9 @@ testRun(void)
         // Create pg_control with page checksums
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .pageChecksum = true}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121,
+                .pageChecksum = true}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1165,13 +1173,14 @@ testRun(void)
             HRNPQ_MACRO_DONE()
         });
 
-        TEST_RESULT_VOID(dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, NULL))->dbPrimary), "backup init");
+        TEST_RESULT_VOID(
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
 
         // Create pg_control without page checksums
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -1181,7 +1190,8 @@ testRun(void)
             HRNPQ_MACRO_DONE()
         });
 
-        TEST_RESULT_VOID(dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, NULL))->dbPrimary), "backup init");
+        TEST_RESULT_VOID(
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
     }
 
@@ -1204,7 +1214,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -1218,7 +1228,7 @@ testRun(void)
             HRNPQ_MACRO_DONE()
         });
 
-        BackupData *backupData = backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, NULL));
+        BackupData *backupData = backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL));
 
         TEST_ERROR(backupTime(backupData, true), AssertError, "invalid sleep for online backup time with wait remainder");
         dbFree(backupData->dbPrimary);
@@ -1425,7 +1435,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840, .catalogVersion = 200904091}));
 
         // Create stanza
         StringList *argList = strLstNew();
@@ -1600,7 +1611,8 @@ testRun(void)
                 storageNewWriteP(
                     storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path)),
                     .timeModified = backupTimeStart),
-                pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .systemId = 1000000000000000950}));
+                pgControlTestToBuffer(
+                    (PgControl){.version = PG_VERSION_95, .systemId = 1000000000000000950, .catalogVersion = 201510051}));
 
             // Create stanza
             StringList *argList = strLstNew();
@@ -2056,7 +2068,8 @@ testRun(void)
                 storageNewWriteP(
                     storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path)),
                     .timeModified = backupTimeStart),
-                pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 1000000000000000960}));
+                pgControlTestToBuffer(
+                    (PgControl){.version = PG_VERSION_96, .systemId = 1000000000000000960, .catalogVersion = 201608131}));
 
             // Update version
             storagePutP(
@@ -2199,8 +2212,8 @@ testRun(void)
                     .timeModified = backupTimeStart),
                 pgControlTestToBuffer(
                     (PgControl){
-                        .version = PG_VERSION_11, .systemId = 1000000000000001100, .pageChecksum = true,
-                        .walSegmentSize = 1024 * 1024}));
+                        .version = PG_VERSION_11, .systemId = 1000000000000001100, .catalogVersion = 201809051,
+                        .pageChecksum = true, .walSegmentSize = 1024 * 1024}));
 
             // Update version
             storagePutP(

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1025,8 +1025,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 1000000000000000920, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 1000000000000000920}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1049,8 +1048,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_10, .systemId = 1000000000000001000, .catalogVersion = 201707211}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_10, .systemId = 1000000000000001000}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1075,8 +1073,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_83, .systemId = 1000000000000000830, .catalogVersion = 200711281}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_83, .systemId = 1000000000000000830}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1098,8 +1095,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840, .catalogVersion = 200904091}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1121,8 +1117,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1153,9 +1148,7 @@ testRun(void)
         // Create pg_control with page checksums
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121,
-                .pageChecksum = true}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .pageChecksum = true}));
 
         argList = strLstNew();
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test1");
@@ -1180,7 +1173,7 @@ testRun(void)
         // Create pg_control without page checksums
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -1214,7 +1207,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93, .catalogVersion = 201306121}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_93, .systemId = PG_VERSION_93}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -1435,8 +1428,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840, .catalogVersion = 200904091}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_84, .systemId = 1000000000000000840}));
 
         // Create stanza
         StringList *argList = strLstNew();
@@ -1611,8 +1603,7 @@ testRun(void)
                 storageNewWriteP(
                     storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path)),
                     .timeModified = backupTimeStart),
-                pgControlTestToBuffer(
-                    (PgControl){.version = PG_VERSION_95, .systemId = 1000000000000000950, .catalogVersion = 201510051}));
+                pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .systemId = 1000000000000000950}));
 
             // Create stanza
             StringList *argList = strLstNew();
@@ -2068,8 +2059,7 @@ testRun(void)
                 storageNewWriteP(
                     storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1Path)),
                     .timeModified = backupTimeStart),
-                pgControlTestToBuffer(
-                    (PgControl){.version = PG_VERSION_96, .systemId = 1000000000000000960, .catalogVersion = 201608131}));
+                pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 1000000000000000960}));
 
             // Update version
             storagePutP(
@@ -2212,8 +2202,8 @@ testRun(void)
                     .timeModified = backupTimeStart),
                 pgControlTestToBuffer(
                     (PgControl){
-                        .version = PG_VERSION_11, .systemId = 1000000000000001100, .catalogVersion = 201809051,
-                        .pageChecksum = true, .walSegmentSize = 1024 * 1024}));
+                        .version = PG_VERSION_11, .systemId = 1000000000000001100, .pageChecksum = true,
+                        .walSegmentSize = 1024 * 1024}));
 
             // Update version
             storagePutP(

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1016,7 +1016,7 @@ testRun(void)
         harnessCfgLoad(cfgCmdBackup, argList);
 
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_91, 1000000000000000910, 201105231, NULL)), ConfigError,
+            backupInit(infoBackupNew(PG_VERSION_91, 1000000000000000910, pgCatalogTestVersion(PG_VERSION_91), NULL)), ConfigError,
              "option 'backup-standby' not valid for PostgreSQL < 9.2");
 
         // -------------------------------------------------------------------------------------------------------------------------
@@ -1036,7 +1036,9 @@ testRun(void)
         strLstAddZ(argList, "--no-" CFGOPT_ONLINE);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_92, 1000000000000000920, 201204301, NULL)), "backup init");
+        TEST_RESULT_VOID(
+            backupInit(infoBackupNew(PG_VERSION_92, 1000000000000000920, pgCatalogTestVersion(PG_VERSION_92), NULL)),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptBackupStandby), false, "    check backup-standby");
 
         TEST_RESULT_LOG(
@@ -1059,11 +1061,13 @@ testRun(void)
         harnessCfgLoad(cfgCmdBackup, argList);
 
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_11, 1000000000000001100, 201809051, NULL)), BackupMismatchError,
+            backupInit(infoBackupNew(PG_VERSION_11, 1000000000000001100, pgCatalogTestVersion(PG_VERSION_11), NULL)),
+            BackupMismatchError,
             "PostgreSQL version 10, system-id 1000000000000001000 do not match stanza version 11, system-id 1000000000000001100\n"
             "HINT: is this the correct stanza?");
         TEST_ERROR(
-            backupInit(infoBackupNew(PG_VERSION_10, 1000000000000001100, 201707211, NULL)), BackupMismatchError,
+            backupInit(infoBackupNew(PG_VERSION_10, 1000000000000001100, pgCatalogTestVersion(PG_VERSION_10), NULL)),
+            BackupMismatchError,
             "PostgreSQL version 10, system-id 1000000000000001000 do not match stanza version 10, system-id 1000000000000001100\n"
             "HINT: is this the correct stanza?");
 
@@ -1084,7 +1088,9 @@ testRun(void)
         strLstAddZ(argList, "--" CFGOPT_START_FAST);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_83, 1000000000000000830, 200711281, NULL)), "backup init");
+        TEST_RESULT_VOID(
+            backupInit(infoBackupNew(PG_VERSION_83, 1000000000000000830, pgCatalogTestVersion(PG_VERSION_83), NULL)),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptStartFast), false, "    check start-fast");
 
         TEST_RESULT_LOG("P00   WARN: start-fast option is only available in PostgreSQL >= 8.4");
@@ -1106,7 +1112,9 @@ testRun(void)
         strLstAddZ(argList, "--" CFGOPT_STOP_AUTO);
         harnessCfgLoad(cfgCmdBackup, argList);
 
-        TEST_RESULT_VOID(backupInit(infoBackupNew(PG_VERSION_84, 1000000000000000840, 200904091, NULL)), "backup init");
+        TEST_RESULT_VOID(
+            backupInit(infoBackupNew(PG_VERSION_84, 1000000000000000840, pgCatalogTestVersion(PG_VERSION_84), NULL)),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptStopAuto), false, "    check stop-auto");
 
         TEST_RESULT_LOG("P00   WARN: stop-auto option is only available in PostgreSQL >= 9.3");
@@ -1136,7 +1144,8 @@ testRun(void)
         });
 
         TEST_RESULT_VOID(
-            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, pgCatalogTestVersion(PG_VERSION_93), NULL))->dbPrimary),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
 
         TEST_RESULT_LOG(
@@ -1167,7 +1176,8 @@ testRun(void)
         });
 
         TEST_RESULT_VOID(
-            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, pgCatalogTestVersion(PG_VERSION_93), NULL))->dbPrimary),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
 
         // Create pg_control without page checksums
@@ -1184,7 +1194,8 @@ testRun(void)
         });
 
         TEST_RESULT_VOID(
-            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL))->dbPrimary), "backup init");
+            dbFree(backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, pgCatalogTestVersion(PG_VERSION_93), NULL))->dbPrimary),
+            "backup init");
         TEST_RESULT_BOOL(cfgOptionBool(cfgOptChecksumPage), false, "    check checksum-page");
     }
 
@@ -1221,7 +1232,8 @@ testRun(void)
             HRNPQ_MACRO_DONE()
         });
 
-        BackupData *backupData = backupInit(infoBackupNew(PG_VERSION_93, PG_VERSION_93, 201306121, NULL));
+        BackupData *backupData = backupInit(
+            infoBackupNew(PG_VERSION_93, PG_VERSION_93, pgCatalogTestVersion(PG_VERSION_93), NULL));
 
         TEST_ERROR(backupTime(backupData, true), AssertError, "invalid sleep for online backup time with wait remainder");
         dbFree(backupData->dbPrimary);
@@ -1637,7 +1649,8 @@ testRun(void)
             storagePathCreateP(storagePgWrite(), pgWalPath(PG_VERSION_95), .noParentCreate = true);
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(
+                storagePg(), PG_VERSION_95, pgCatalogTestVersion(PG_VERSION_95), true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeFull;
@@ -1724,7 +1737,8 @@ testRun(void)
             harnessCfgLoad(cfgCmdBackup, argList);
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(
+                storagePg(), PG_VERSION_95, pgCatalogTestVersion(PG_VERSION_95), true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeFull;
@@ -1917,7 +1931,8 @@ testRun(void)
             manifestSave(manifestPrior, storageWriteIo(storageNewWriteP(storageRepoWrite(), manifestPriorFile)));
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(
+                storagePg(), PG_VERSION_95, pgCatalogTestVersion(PG_VERSION_95), true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeDiff;
@@ -2290,7 +2305,8 @@ testRun(void)
 
             storagePutP(
                 storageNewWriteP(
-                    storageTest, strNewFmt("pg1-tblspc/32768/%s/1/5", strZ(pgTablespaceId(PG_VERSION_11, 201809051))),
+                    storageTest,
+                    strNewFmt("pg1-tblspc/32768/%s/1/5", strZ(pgTablespaceId(PG_VERSION_11, pgCatalogTestVersion(PG_VERSION_11)))),
                     .timeModified = backupTimeStart),
                 NULL);
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1646,7 +1646,7 @@ testRun(void)
             storagePathCreateP(storagePgWrite(), pgWalPath(PG_VERSION_95), .noParentCreate = true);
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeFull;
@@ -1733,7 +1733,7 @@ testRun(void)
             harnessCfgLoad(cfgCmdBackup, argList);
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeFull;
@@ -1926,7 +1926,7 @@ testRun(void)
             manifestSave(manifestPrior, storageWriteIo(storageNewWriteP(storageRepoWrite(), manifestPriorFile)));
 
             // Create a backup manifest that looks like a halted backup manifest
-            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, true, false, NULL, NULL);
+            Manifest *manifestResume = manifestNewBuild(storagePg(), PG_VERSION_95, 201510051, true, false, NULL, NULL);
             ManifestData *manifestResumeData = (ManifestData *)manifestData(manifestResume);
 
             manifestResumeData->backupType = backupTypeDiff;
@@ -2300,7 +2300,7 @@ testRun(void)
 
             storagePutP(
                 storageNewWriteP(
-                    storageTest, strNewFmt("pg1-tblspc/32768/%s/1/5", strZ(pgTablespaceId(PG_VERSION_11))),
+                    storageTest, strNewFmt("pg1-tblspc/32768/%s/1/5", strZ(pgTablespaceId(PG_VERSION_11, 201809051))),
                     .timeModified = backupTimeStart),
                 NULL);
 

--- a/test/src/module/command/checkTest.c
+++ b/test/src/module/command/checkTest.c
@@ -146,7 +146,8 @@ testRun(void)
         // Create pg_control for standby
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679, .catalogVersion = 201204301}));
 
         argList = strLstNew();
         strLstAdd(argList, stanzaOpt);
@@ -205,7 +206,8 @@ testRun(void)
         // Create pg_control for primary
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg8))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679, .catalogVersion = 201204301}));
 
         // Create info files
         storagePutP(
@@ -444,14 +446,14 @@ testRun(void)
         InfoArchive *archiveInfo = infoArchiveNew(PG_VERSION_96, 6569239123849665679, NULL);
         InfoPgData archivePg = infoPgData(infoArchivePg(archiveInfo), infoPgDataCurrentId(infoArchivePg(archiveInfo)));
 
-        InfoBackup *backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665679, NULL);
+        InfoBackup *backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665679, 201608131, NULL);
         InfoPgData backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_RESULT_VOID(checkStanzaInfo(&archivePg, &backupPg), "stanza info files match");
 
         // Create a corrupted backup file - system id
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665999, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665999, 201608131, NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -462,7 +464,7 @@ testRun(void)
 
         // Create a corrupted backup file - system id and version
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665999, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665999, 201510051, NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -473,7 +475,7 @@ testRun(void)
 
         // Create a corrupted backup file - version
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665679, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665679, 201510051, NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -484,7 +486,7 @@ testRun(void)
 
         // Create a corrupted backup file - db id
         // -------------------------------------------------------------------------------------------------------------------------
-        infoBackupPgSet(backupInfo, PG_VERSION_96, 6569239123849665679);
+        infoBackupPgSet(backupInfo, PG_VERSION_96, 6569239123849665679, 201608131);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -507,7 +509,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         // Create info files
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - encryption");

--- a/test/src/module/command/checkTest.c
+++ b/test/src/module/command/checkTest.c
@@ -444,14 +444,14 @@ testRun(void)
         InfoArchive *archiveInfo = infoArchiveNew(PG_VERSION_96, 6569239123849665679, NULL);
         InfoPgData archivePg = infoPgData(infoArchivePg(archiveInfo), infoPgDataCurrentId(infoArchivePg(archiveInfo)));
 
-        InfoBackup *backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665679, 201608131, NULL);
+        InfoBackup *backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665679, pgCatalogTestVersion(PG_VERSION_96), NULL);
         InfoPgData backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_RESULT_VOID(checkStanzaInfo(&archivePg, &backupPg), "stanza info files match");
 
         // Create a corrupted backup file - system id
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665999, 201608131, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_96, 6569239123849665999, pgCatalogTestVersion(PG_VERSION_96), NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -462,7 +462,7 @@ testRun(void)
 
         // Create a corrupted backup file - system id and version
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665999, 201510051, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665999, pgCatalogTestVersion(PG_VERSION_95), NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -473,7 +473,7 @@ testRun(void)
 
         // Create a corrupted backup file - version
         // -------------------------------------------------------------------------------------------------------------------------
-        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665679, 201510051, NULL);
+        backupInfo = infoBackupNew(PG_VERSION_95, 6569239123849665679, pgCatalogTestVersion(PG_VERSION_95), NULL);
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(
@@ -484,7 +484,7 @@ testRun(void)
 
         // Create a corrupted backup file - db id
         // -------------------------------------------------------------------------------------------------------------------------
-        infoBackupPgSet(backupInfo, PG_VERSION_96, 6569239123849665679, 201608131);
+        infoBackupPgSet(backupInfo, PG_VERSION_96, 6569239123849665679, pgCatalogTestVersion(PG_VERSION_96));
         backupPg = infoPgData(infoBackupPg(backupInfo), infoPgDataCurrentId(infoBackupPg(backupInfo)));
 
         TEST_ERROR_FMT(

--- a/test/src/module/command/checkTest.c
+++ b/test/src/module/command/checkTest.c
@@ -146,8 +146,7 @@ testRun(void)
         // Create pg_control for standby
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679}));
 
         argList = strLstNew();
         strLstAdd(argList, stanzaOpt);
@@ -206,8 +205,7 @@ testRun(void)
         // Create pg_control for primary
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg8))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665679}));
 
         // Create info files
         storagePutP(
@@ -509,8 +507,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         // Create info files
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - encryption");

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1279,7 +1279,7 @@ testRun(void)
         TEST_TITLE("one database selected with tablespace id");
 
         manifest->data.pgVersion = PG_VERSION_94;
-        manifest->data.pgCatalogVersion = 201409291;
+        manifest->data.pgCatalogVersion = pgCatalogTestVersion(PG_VERSION_94);
 
         MEM_CONTEXT_BEGIN(manifest->memContext)
         {
@@ -2016,7 +2016,7 @@ testRun(void)
             manifest->info = infoNew(NULL);
             manifest->data.backupLabel = strNew(TEST_LABEL);
             manifest->data.pgVersion = PG_VERSION_10;
-            manifest->data.pgCatalogVersion = 201707211;
+            manifest->data.pgCatalogVersion = pgCatalogTestVersion(PG_VERSION_10);
             manifest->data.backupType = backupTypeFull;
             manifest->data.backupTimestampCopyStart = 1482182861; // So file timestamps should be less than this
 

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1279,6 +1279,7 @@ testRun(void)
         TEST_TITLE("one database selected with tablespace id");
 
         manifest->data.pgVersion = PG_VERSION_94;
+        manifest->data.pgCatalogVersion = 201409291;
 
         MEM_CONTEXT_BEGIN(manifest->memContext)
         {
@@ -2015,6 +2016,7 @@ testRun(void)
             manifest->info = infoNew(NULL);
             manifest->data.backupLabel = strNew(TEST_LABEL);
             manifest->data.pgVersion = PG_VERSION_10;
+            manifest->data.pgCatalogVersion = 201707211;
             manifest->data.backupType = backupTypeFull;
             manifest->data.backupTimestampCopyStart = 1482182861; // So file timestamps should be less than this
 

--- a/test/src/module/command/stanzaTest.c
+++ b/test/src/module/command/stanzaTest.c
@@ -63,7 +63,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - no files exist");
 
@@ -387,7 +388,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -413,7 +415,8 @@ testRun(void)
         // Create pg_control with different version
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_91, .systemId = 6569239123849665699}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_91, .systemId = 6569239123849665699, .catalogVersion = 201105231}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -432,7 +435,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -461,12 +465,14 @@ testRun(void)
         // Create pg_control for primary
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
 
         // Create pg_control for standby
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, testPath())),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_94, .systemId = 6569239123849665700}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_94, .systemId = 6569239123849665700, .catalogVersion = 201409291}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -479,6 +485,7 @@ testRun(void)
         TEST_ASSIGN(pgControl, pgValidate(), "validate primary on pg2");
         TEST_RESULT_UINT(pgControl.version, PG_VERSION_92, "    version set");
         TEST_RESULT_UINT(pgControl.systemId, 6569239123849665699, "    systemId set");
+        TEST_RESULT_UINT(pgControl.catalogVersion, 201204301, "    catalogVersion set");
     }
 
     // *****************************************************************************************************************************
@@ -492,7 +499,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - encryption");
 
@@ -545,7 +553,8 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create");
 
@@ -837,7 +846,8 @@ testRun(void)
         // Create pg_control for stanza-create
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanzaOther))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "create a stanza that will not be deleted");
 
@@ -865,7 +875,8 @@ testRun(void)
         // Create pg_control for stanza-create
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
+            pgControlTestToBuffer(
+                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "create a stanza to be deleted");
         TEST_RESULT_BOOL(

--- a/test/src/module/command/stanzaTest.c
+++ b/test/src/module/command/stanzaTest.c
@@ -63,8 +63,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - no files exist");
 
@@ -388,8 +387,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -415,8 +413,7 @@ testRun(void)
         // Create pg_control with different version
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_91, .systemId = 6569239123849665699, .catalogVersion = 201105231}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_91, .systemId = 6569239123849665699}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -435,8 +432,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -465,14 +461,12 @@ testRun(void)
         // Create pg_control for primary
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(pg1))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699, .catalogVersion = 201204301}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_92, .systemId = 6569239123849665699}));
 
         // Create pg_control for standby
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, testPath())),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_94, .systemId = 6569239123849665700, .catalogVersion = 201409291}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_94, .systemId = 6569239123849665700}));
 
         harnessPqScriptSet((HarnessPq [])
         {
@@ -499,8 +493,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create - encryption");
 
@@ -553,8 +546,7 @@ testRun(void)
         // Create pg_control
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "stanza create");
 
@@ -846,8 +838,7 @@ testRun(void)
         // Create pg_control for stanza-create
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanzaOther))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "create a stanza that will not be deleted");
 
@@ -875,8 +866,7 @@ testRun(void)
         // Create pg_control for stanza-create
         storagePutP(
             storageNewWriteP(storageTest, strNewFmt("%s/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL, strZ(stanza))),
-            pgControlTestToBuffer(
-                (PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679, .catalogVersion = 201608131}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_96, .systemId = 6569239123849665679}));
 
         TEST_RESULT_VOID(cmdStanzaCreate(), "create a stanza to be deleted");
         TEST_RESULT_BOOL(

--- a/test/src/module/command/stanzaTest.c
+++ b/test/src/module/command/stanzaTest.c
@@ -267,14 +267,14 @@ testRun(void)
         contentBackup = strNew
         (
             "[db]\n"
-            "db-catalog-version=201608131\n"
-            "db-control-version=960\n"
+            "db-catalog-version=201510051\n"
+            "db-control-version=942\n"
             "db-id=1\n"
             "db-system-id=6569239123849665679\n"
             "db-version=\"9.5\"\n"
             "\n"
             "[db:history]\n"
-            "1={\"db-catalog-version\":201608131,\"db-control-version\":960,\"db-system-id\":6569239123849665679,"
+            "1={\"db-catalog-version\":201510051,\"db-control-version\":942,\"db-system-id\":6569239123849665679,"
                 "\"db-version\":\"9.5\"}\n"
         );
         TEST_RESULT_VOID(
@@ -604,7 +604,7 @@ testRun(void)
             "db-version=\"9.6\"\n"
             "\n"
             "[db:history]\n"
-            "1={\"db-catalog-version\":201608131,\"db-control-version\":960,\"db-system-id\":6569239123849665999,"
+            "1={\"db-catalog-version\":201510051,\"db-control-version\":942,\"db-system-id\":6569239123849665999,"
                 "\"db-version\":\"9.5\"}\n"
             "2={\"db-catalog-version\":201608131,\"db-control-version\":960,\"db-system-id\":6569239123849665679,"
                 "\"db-version\":\"9.6\"}\n"
@@ -666,7 +666,7 @@ testRun(void)
             "db-version=\"9.5\"\n"
             "\n"
             "[db:history]\n"
-            "1={\"db-catalog-version\":201608131,\"db-control-version\":942,\"db-system-id\":6569239123849665679,"
+            "1={\"db-catalog-version\":201510051,\"db-control-version\":942,\"db-system-id\":6569239123849665679,"
                 "\"db-version\":\"9.5\"}\n"
         );
         TEST_RESULT_VOID(

--- a/test/src/module/info/infoBackupTest.c
+++ b/test/src/module/info/infoBackupTest.c
@@ -59,7 +59,7 @@ testRun(void)
         Buffer *contentCompare = bufNew(0);
 
         TEST_ASSIGN(
-            infoBackup, infoBackupNew(PG_VERSION_94, 6569239123849665679, NULL),
+            infoBackup, infoBackupNew(PG_VERSION_94, 6569239123849665679, 201409291, NULL),
             "infoBackupNew() - no cipher sub");
         TEST_RESULT_VOID(infoBackupSave(infoBackup, ioBufferWriteNew(contentCompare)), "    save backup info from new");
         TEST_RESULT_STR(strNewBuf(contentCompare), strNewBuf(contentSave), "   check save");
@@ -74,7 +74,8 @@ testRun(void)
         TEST_ASSIGN(
             infoBackup,
             infoBackupNew(
-                PG_VERSION_10, 6569239123849665999, strNew("zWa/6Xtp-IVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO")),
+                PG_VERSION_10, 6569239123849665999, 201707211,
+                strNew("zWa/6Xtp-IVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO")),
             "infoBackupNew() - cipher sub");
 
         contentSave = bufNew(0);
@@ -91,11 +92,12 @@ testRun(void)
         // Add pg info
         // -------------------------------------------------------------------------------------------------------------------------
         InfoPgData infoPgData = {0};
-        TEST_RESULT_VOID(infoBackupPgSet(infoBackup, PG_VERSION_94, 6569239123849665679), "add another infoPg");
+        TEST_RESULT_VOID(infoBackupPgSet(infoBackup, PG_VERSION_94, 6569239123849665679, 201409291), "add another infoPg");
         TEST_RESULT_INT(infoPgDataTotal(infoBackup->infoPg), 2, "    history incremented");
         TEST_ASSIGN(infoPgData, infoPgDataCurrent(infoBackup->infoPg), "    get current infoPgData");
         TEST_RESULT_INT(infoPgData.version, PG_VERSION_94, "    version set");
         TEST_RESULT_UINT(infoPgData.systemId, 6569239123849665679, "    systemId set");
+        TEST_RESULT_UINT(infoPgData.catalogVersion, 201409291, "    catalogVersion set");
 
         // Free
         //--------------------------------------------------------------------------------------------------------------------------
@@ -695,7 +697,7 @@ testRun(void)
             "20190818-084777F, 20190923-164324F", "confirm backups on disk");
 
         // With the infoBackup from above, upgrade the DB so there a 2 histories then save to disk
-        TEST_ASSIGN(infoBackup, infoBackupPgSet(infoBackup, PG_VERSION_11, 6739907367085689196), "upgrade db");
+        TEST_ASSIGN(infoBackup, infoBackupPgSet(infoBackup, PG_VERSION_11, 6739907367085689196, 201809051), "upgrade db");
         TEST_RESULT_VOID(
             infoBackupSaveFile(infoBackup, storageRepoWrite(), INFO_BACKUP_PATH_FILE_STR, cipherTypeNone, NULL),
             "save backup info");
@@ -823,7 +825,7 @@ testRun(void)
             "HINT: has a stanza-create been performed?",
             testPath(), testPath(), testPath(), testPath());
 
-        InfoBackup *infoBackup = infoBackupNew(PG_VERSION_10, 6569239123849665999, NULL);
+        InfoBackup *infoBackup = infoBackupNew(PG_VERSION_10, 6569239123849665999, 201707211, NULL);
         TEST_RESULT_VOID(
             infoBackupSaveFile(infoBackup, storageTest, STRDEF(INFO_BACKUP_FILE), cipherTypeNone, NULL), "save backup info");
 

--- a/test/src/module/info/infoBackupTest.c
+++ b/test/src/module/info/infoBackupTest.c
@@ -59,7 +59,7 @@ testRun(void)
         Buffer *contentCompare = bufNew(0);
 
         TEST_ASSIGN(
-            infoBackup, infoBackupNew(PG_VERSION_94, 6569239123849665679, 201409291, NULL),
+            infoBackup, infoBackupNew(PG_VERSION_94, 6569239123849665679, pgCatalogTestVersion(PG_VERSION_94), NULL),
             "infoBackupNew() - no cipher sub");
         TEST_RESULT_VOID(infoBackupSave(infoBackup, ioBufferWriteNew(contentCompare)), "    save backup info from new");
         TEST_RESULT_STR(strNewBuf(contentCompare), strNewBuf(contentSave), "   check save");
@@ -74,7 +74,7 @@ testRun(void)
         TEST_ASSIGN(
             infoBackup,
             infoBackupNew(
-                PG_VERSION_10, 6569239123849665999, 201707211,
+                PG_VERSION_10, 6569239123849665999, pgCatalogTestVersion(PG_VERSION_10),
                 strNew("zWa/6Xtp-IVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO")),
             "infoBackupNew() - cipher sub");
 
@@ -92,7 +92,9 @@ testRun(void)
         // Add pg info
         // -------------------------------------------------------------------------------------------------------------------------
         InfoPgData infoPgData = {0};
-        TEST_RESULT_VOID(infoBackupPgSet(infoBackup, PG_VERSION_94, 6569239123849665679, 201409291), "add another infoPg");
+        TEST_RESULT_VOID(
+            infoBackupPgSet(infoBackup, PG_VERSION_94, 6569239123849665679, pgCatalogTestVersion(PG_VERSION_94)),
+            "add another infoPg");
         TEST_RESULT_INT(infoPgDataTotal(infoBackup->infoPg), 2, "    history incremented");
         TEST_ASSIGN(infoPgData, infoPgDataCurrent(infoBackup->infoPg), "    get current infoPgData");
         TEST_RESULT_INT(infoPgData.version, PG_VERSION_94, "    version set");
@@ -697,7 +699,9 @@ testRun(void)
             "20190818-084777F, 20190923-164324F", "confirm backups on disk");
 
         // With the infoBackup from above, upgrade the DB so there a 2 histories then save to disk
-        TEST_ASSIGN(infoBackup, infoBackupPgSet(infoBackup, PG_VERSION_11, 6739907367085689196, 201809051), "upgrade db");
+        TEST_ASSIGN(
+            infoBackup, infoBackupPgSet(infoBackup, PG_VERSION_11, 6739907367085689196, pgCatalogTestVersion(PG_VERSION_11)),
+            "upgrade db");
         TEST_RESULT_VOID(
             infoBackupSaveFile(infoBackup, storageRepoWrite(), INFO_BACKUP_PATH_FILE_STR, cipherTypeNone, NULL),
             "save backup info");
@@ -825,7 +829,7 @@ testRun(void)
             "HINT: has a stanza-create been performed?",
             testPath(), testPath(), testPath(), testPath());
 
-        InfoBackup *infoBackup = infoBackupNew(PG_VERSION_10, 6569239123849665999, 201707211, NULL);
+        InfoBackup *infoBackup = infoBackupNew(PG_VERSION_10, 6569239123849665999, pgCatalogTestVersion(PG_VERSION_10), NULL);
         TEST_RESULT_VOID(
             infoBackupSaveFile(infoBackup, storageTest, STRDEF(INFO_BACKUP_FILE), cipherTypeNone, NULL), "save backup info");
 

--- a/test/src/module/info/infoPgTest.c
+++ b/test/src/module/info/infoPgTest.c
@@ -47,7 +47,10 @@ testRun(void)
 
         //--------------------------------------------------------------------------------------------------------------------------
         TEST_ASSIGN(
-            infoPg, infoPgSet(infoPgNew(infoPgArchive, NULL), infoPgArchive, PG_VERSION_94, 6569239123849665679, 201409291),
+            infoPg,
+            infoPgSet(
+                infoPgNew(infoPgArchive, NULL), infoPgArchive, PG_VERSION_94, 6569239123849665679,
+                pgCatalogTestVersion(PG_VERSION_94)),
             "infoPgSet - infoPgArchive");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 1, "  1 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
@@ -58,7 +61,7 @@ testRun(void)
         TEST_RESULT_UINT(pgData.catalogVersion, 0, "  catalog version not set for archive");
 
         TEST_ASSIGN(
-            infoPg, infoPgSet(infoPg, infoPgArchive, PG_VERSION_95, 6569239123849665999, 201409291),
+            infoPg, infoPgSet(infoPg, infoPgArchive, PG_VERSION_95, 6569239123849665999, pgCatalogTestVersion(PG_VERSION_95)),
             "infoPgSet - infoPgArchive second db");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 2, "  2 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
@@ -72,7 +75,9 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         TEST_ASSIGN(
             infoPg,
-            infoPgSet(infoPgNew(infoPgBackup, strNew("123xyz")), infoPgBackup, PG_VERSION_94, 6569239123849665679, 201409290),
+            infoPgSet(
+                infoPgNew(infoPgBackup, strNew("123xyz")), infoPgBackup, PG_VERSION_94, 6569239123849665679,
+                pgCatalogTestVersion(PG_VERSION_94)),
             "infoPgSet - infoPgBackup");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 1, "  1 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
@@ -80,7 +85,7 @@ testRun(void)
         TEST_RESULT_INT(pgData.id, 1, "  id set");
         TEST_RESULT_UINT(pgData.systemId, 6569239123849665679, "  system-id set");
         TEST_RESULT_UINT(pgData.version, PG_VERSION_94, "  version set");
-        TEST_RESULT_UINT(pgData.catalogVersion, 201409290, "  catalog version updated");
+        TEST_RESULT_UINT(pgData.catalogVersion, 201409291, "  catalog version updated");
         TEST_RESULT_STR_Z(infoCipherPass(infoPgInfo(infoPg)), "123xyz", "  cipherPass set");
     }
 

--- a/test/src/module/info/infoPgTest.c
+++ b/test/src/module/info/infoPgTest.c
@@ -199,8 +199,11 @@ testRun(void)
         pgDataTest.id = (unsigned int)4294967295;
         pgDataTest.version = (unsigned int)4294967295;
         pgDataTest.systemId = 18446744073709551615U;
+        pgDataTest.catalogVersion = 200101011;
+
         TEST_RESULT_STR_Z(
-            infoPgDataToLog(&pgDataTest), "{id: 4294967295, version: 4294967295, systemId: 18446744073709551615}",
+            infoPgDataToLog(&pgDataTest),
+            "{id: 4294967295, version: 4294967295, systemId: 18446744073709551615, catalogVersion: 200101011}",
             "    check max format");
     }
 }

--- a/test/src/module/info/infoPgTest.c
+++ b/test/src/module/info/infoPgTest.c
@@ -47,7 +47,7 @@ testRun(void)
 
         //--------------------------------------------------------------------------------------------------------------------------
         TEST_ASSIGN(
-            infoPg, infoPgSet(infoPgNew(infoPgArchive, NULL), infoPgArchive, PG_VERSION_94, 6569239123849665679),
+            infoPg, infoPgSet(infoPgNew(infoPgArchive, NULL), infoPgArchive, PG_VERSION_94, 6569239123849665679, 201409291),
             "infoPgSet - infoPgArchive");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 1, "  1 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
@@ -55,20 +55,24 @@ testRun(void)
         TEST_RESULT_INT(pgData.id, 1, "  id set");
         TEST_RESULT_UINT(pgData.systemId, 6569239123849665679, "  system-id set");
         TEST_RESULT_UINT(pgData.version, PG_VERSION_94, "  version set");
+        TEST_RESULT_UINT(pgData.catalogVersion, 0, "  catalog version not set for archive");
 
         TEST_ASSIGN(
-            infoPg, infoPgSet(infoPg, infoPgArchive, PG_VERSION_95, 6569239123849665999), "infoPgSet - infoPgArchive second db");
+            infoPg, infoPgSet(infoPg, infoPgArchive, PG_VERSION_95, 6569239123849665999, 201409291),
+            "infoPgSet - infoPgArchive second db");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 2, "  2 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
         pgData = infoPgData(infoPg, infoPgDataCurrentId(infoPg));
         TEST_RESULT_INT(pgData.id, 2, "  current id updated");
         TEST_RESULT_UINT(pgData.systemId, 6569239123849665999, "  system-id updated");
         TEST_RESULT_UINT(pgData.version, PG_VERSION_95, "  version updated");
+        TEST_RESULT_UINT(pgData.catalogVersion, 0, "  catalog version not set for archive");
         TEST_RESULT_STR(infoCipherPass(infoPgInfo(infoPg)), NULL, "  cipherPass not set");
 
         //--------------------------------------------------------------------------------------------------------------------------
         TEST_ASSIGN(
-            infoPg, infoPgSet(infoPgNew(infoPgBackup, strNew("123xyz")), infoPgBackup, PG_VERSION_94, 6569239123849665679),
+            infoPg,
+            infoPgSet(infoPgNew(infoPgBackup, strNew("123xyz")), infoPgBackup, PG_VERSION_94, 6569239123849665679, 201409290),
             "infoPgSet - infoPgBackup");
         TEST_RESULT_INT(infoPgDataTotal(infoPg), 1, "  1 history");
         TEST_RESULT_INT(infoPgDataCurrentId(infoPg), 0, "  0 historyCurrent");
@@ -76,6 +80,7 @@ testRun(void)
         TEST_RESULT_INT(pgData.id, 1, "  id set");
         TEST_RESULT_UINT(pgData.systemId, 6569239123849665679, "  system-id set");
         TEST_RESULT_UINT(pgData.version, PG_VERSION_94, "  version set");
+        TEST_RESULT_UINT(pgData.catalogVersion, 201409290, "  catalog version updated");
         TEST_RESULT_STR_Z(infoCipherPass(infoPgInfo(infoPg)), "123xyz", "  cipherPass set");
     }
 

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -279,7 +279,9 @@ testRun(void)
 
         Manifest *manifest = NULL;
         TEST_ASSIGN(
-            manifest, manifestNewBuild(storagePg, PG_VERSION_83, 200711281, false, false, exclusionList, NULL), "build manifest");
+            manifest,
+            manifestNewBuild(storagePg, PG_VERSION_83, pgCatalogTestVersion(PG_VERSION_83), false, false, exclusionList, NULL),
+            "build manifest");
 
         Buffer *contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -402,7 +404,9 @@ testRun(void)
             BUFSTRDEF("TEMP_RELATION"));
 
         // Test manifest - mode stored for shared cluster tablespace dir, pg_xlog contents ignored because online
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_84, 200904091, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_84, pgCatalogTestVersion(PG_VERSION_84), true, false, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -515,7 +519,9 @@ testRun(void)
         varLstAdd(tablespaceList, varNewVarLst(tablespace));
 
         // Test tablespace error
-        TEST_ERROR(manifestNewBuild(storagePg, PG_VERSION_90, 201008051, false, false, NULL, tablespaceList), AssertError,
+        TEST_ERROR(
+            manifestNewBuild(storagePg, PG_VERSION_90, pgCatalogTestVersion(PG_VERSION_90), false, false, NULL, tablespaceList),
+            AssertError,
             "tablespace with oid 1 not found in tablespace map\n"
             "HINT: was a tablespace created or dropped during the backup?");
 
@@ -527,7 +533,9 @@ testRun(void)
 
         // Test manifest - temp tables and pg_notify files ignored
         TEST_ASSIGN(
-            manifest, manifestNewBuild(storagePg, PG_VERSION_90, 201008051, false, false, NULL, tablespaceList), "build manifest");
+            manifest,
+            manifestNewBuild(storagePg, PG_VERSION_90, pgCatalogTestVersion(PG_VERSION_90), false, false, NULL, tablespaceList),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -618,7 +626,9 @@ testRun(void)
             BUFSTRDEF("WALDATA"));
 
         // Test manifest - temp tables, unlogged tables, pg_serial and pg_xlog files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_91, 201105231, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_91, pgCatalogTestVersion(PG_VERSION_91), true, false, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -701,7 +711,9 @@ testRun(void)
             NULL);
 
         // Test manifest - pg_snapshots files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_92, 201204301, false, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_92, pgCatalogTestVersion(PG_VERSION_92), false, false, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -841,7 +853,9 @@ testRun(void)
             BUFSTRDEF("TESTDATA"));
 
         // Test manifest - pg_dynshmem, pg_replslot and postgresql.auto.conf.tmp files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, true, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, true, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -935,7 +949,8 @@ testRun(void)
 
         // Tablespace link errors when correct verion not found
         TEST_ERROR_FMT(
-            manifestNewBuild(storagePg, PG_VERSION_12, 201909212, false, false, NULL, NULL), FileOpenError,
+            manifestNewBuild(storagePg, PG_VERSION_12, pgCatalogTestVersion(PG_VERSION_12), false, false, NULL, NULL),
+            FileOpenError,
             "unable to get info for missing path/file '%s/pg/pg_tblspc/1/PG_12_201909212': [2] No such file or directory",
             testPath());
 
@@ -962,7 +977,9 @@ testRun(void)
         // Test manifest - 'pg_data/pg_tblspc' will appear in manifest but 'pg_tblspc' will not (no links). Recovery signal files
         // and backup_label ignored. Old recovery files and pg_xlog are now just another file/directory and will not be ignored.
         // pg_wal contents will be ignored online. pg_clog pgVersion > 10 master:true, pg_xact pgVersion > 10 master:false
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_12, 201909212, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_12, pgCatalogTestVersion(PG_VERSION_12), true, false, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -1032,7 +1049,9 @@ testRun(void)
         TEST_TITLE("run 13, offline");
 
         // pg_wal not ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_13, 202007201, false, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_13, pgCatalogTestVersion(PG_VERSION_13), false, false, NULL, NULL),
+            "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -1104,8 +1123,8 @@ testRun(void)
             FileOpenError, "unable to create symlink");
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkDestinationError,
-            hrnReplaceKey("link 'link' destination '{[path]}/pg/base' is in PGDATA"));
+            manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, false, NULL, NULL),
+            LinkDestinationError, hrnReplaceKey("link 'link' destination '{[path]}/pg/base' is in PGDATA"));
 
         THROW_ON_SYS_ERROR(
             unlink(strZ(strNewFmt("%s/pg/link", testPath()))) == -1, FileRemoveError, "unable to remove symlink");
@@ -1116,8 +1135,8 @@ testRun(void)
         storagePathCreateP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somedir"), .mode = 0700, .noParentCreate = true);
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkExpectedError,
-            "'pg_data/pg_tblspc/somedir' is not a symlink - pg_tblspc should contain only symlinks");
+            manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, false, NULL, NULL),
+            LinkExpectedError, "'pg_data/pg_tblspc/somedir' is not a symlink - pg_tblspc should contain only symlinks");
 
         storagePathRemoveP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somedir"));
 
@@ -1127,8 +1146,8 @@ testRun(void)
         storagePutP(storageNewWriteP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somefile")), NULL);
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkExpectedError,
-            "'pg_data/pg_tblspc/somefile' is not a symlink - pg_tblspc should contain only symlinks");
+            manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, false, NULL, NULL),
+            LinkExpectedError, "'pg_data/pg_tblspc/somefile' is not a symlink - pg_tblspc should contain only symlinks");
 
         storageRemoveP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somefile"));
 
@@ -1140,7 +1159,7 @@ testRun(void)
             "unable to create symlink");
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, true, NULL, NULL), FileOpenError,
+            manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, true, NULL, NULL), FileOpenError,
             hrnReplaceKey("unable to get info for missing path/file '{[path]}/pg/link-to-link': [2] No such file or directory"));
 
         THROW_ON_SYS_ERROR(
@@ -1158,8 +1177,8 @@ testRun(void)
             FileOpenError, "unable to create symlink");
 
         TEST_ERROR_FMT(
-            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkDestinationError,
-            "link '%s/pg/linktolink' cannot reference another link '%s/linktest'", testPath(), testPath());
+            manifestNewBuild(storagePg, PG_VERSION_94, pgCatalogTestVersion(PG_VERSION_94), false, false, NULL, NULL),
+            LinkDestinationError, "link '%s/pg/linktolink' cannot reference another link '%s/linktest'", testPath(), testPath());
 
         #undef TEST_MANIFEST_HEADER
         #undef TEST_MANIFEST_DB_83
@@ -1269,7 +1288,7 @@ testRun(void)
         Manifest *manifest = manifestNewInternal();
         manifest->info = infoNew(NULL);
         manifest->data.pgVersion = PG_VERSION_96;
-        manifest->data.pgCatalogVersion = 201608131;
+        manifest->data.pgCatalogVersion = pgCatalogTestVersion(PG_VERSION_96);
         manifest->data.backupOptionDelta = BOOL_FALSE_VAR;
 
         manifestTargetAdd(manifest, &(ManifestTarget){.name = MANIFEST_TARGET_PGDATA_STR, .path = STRDEF("/pg")});

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -47,7 +47,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_83                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=200711281\n"                                                                                       \
             "db-control-version=833\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -56,7 +56,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_84                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=200904091\n"                                                                                       \
             "db-control-version=843\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -65,7 +65,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_90                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201008051\n"                                                                                       \
             "db-control-version=903\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -74,7 +74,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_91                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201105231\n"                                                                                       \
             "db-control-version=903\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -83,7 +83,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_92                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201204301\n"                                                                                       \
             "db-control-version=922\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -92,7 +92,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_94                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201409291\n"                                                                                       \
             "db-control-version=942\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -101,7 +101,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_12                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201909212\n"                                                                                       \
             "db-control-version=1201\n"                                                                                            \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -110,7 +110,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_13                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=202007201\n"                                                                                       \
             "db-control-version=1300\n"                                                                                            \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -278,7 +278,8 @@ testRun(void)
         strLstAddZ(exclusionList, "bogus/");
 
         Manifest *manifest = NULL;
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_83, false, false, exclusionList, NULL), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_83, 200711281, false, false, exclusionList, NULL), "build manifest");
 
         Buffer *contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -401,7 +402,7 @@ testRun(void)
             BUFSTRDEF("TEMP_RELATION"));
 
         // Test manifest - mode stored for shared cluster tablespace dir, pg_xlog contents ignored because online
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_84, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_84, 200904091, true, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -514,7 +515,7 @@ testRun(void)
         varLstAdd(tablespaceList, varNewVarLst(tablespace));
 
         // Test tablespace error
-        TEST_ERROR(manifestNewBuild(storagePg, PG_VERSION_90, false, false, NULL, tablespaceList), AssertError,
+        TEST_ERROR(manifestNewBuild(storagePg, PG_VERSION_90, 201008051, false, false, NULL, tablespaceList), AssertError,
             "tablespace with oid 1 not found in tablespace map\n"
             "HINT: was a tablespace created or dropped during the backup?");
 
@@ -525,7 +526,8 @@ testRun(void)
         varLstAdd(tablespaceList, varNewVarLst(tablespace));
 
         // Test manifest - temp tables and pg_notify files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_90, false, false, NULL, tablespaceList), "build manifest");
+        TEST_ASSIGN(
+            manifest, manifestNewBuild(storagePg, PG_VERSION_90, 201008051, false, false, NULL, tablespaceList), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -616,7 +618,7 @@ testRun(void)
             BUFSTRDEF("WALDATA"));
 
         // Test manifest - temp tables, unlogged tables, pg_serial and pg_xlog files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_91, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_91, 201105231, true, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -699,7 +701,7 @@ testRun(void)
             NULL);
 
         // Test manifest - pg_snapshots files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_92, false, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_92, 201204301, false, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -839,7 +841,7 @@ testRun(void)
             BUFSTRDEF("TESTDATA"));
 
         // Test manifest - pg_dynshmem, pg_replslot and postgresql.auto.conf.tmp files ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_94, false, true, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, true, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -933,7 +935,7 @@ testRun(void)
 
         // Tablespace link errors when correct verion not found
         TEST_ERROR_FMT(
-            manifestNewBuild(storagePg, PG_VERSION_12, false, false, NULL, NULL), FileOpenError,
+            manifestNewBuild(storagePg, PG_VERSION_12, 201909212, false, false, NULL, NULL), FileOpenError,
             "unable to get info for missing path/file '%s/pg/pg_tblspc/1/PG_12_201909212': [2] No such file or directory",
             testPath());
 
@@ -960,7 +962,7 @@ testRun(void)
         // Test manifest - 'pg_data/pg_tblspc' will appear in manifest but 'pg_tblspc' will not (no links). Recovery signal files
         // and backup_label ignored. Old recovery files and pg_xlog are now just another file/directory and will not be ignored.
         // pg_wal contents will be ignored online. pg_clog pgVersion > 10 master:true, pg_xact pgVersion > 10 master:false
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_12, true, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_12, 201909212, true, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -1030,7 +1032,7 @@ testRun(void)
         TEST_TITLE("run 13, offline");
 
         // pg_wal not ignored
-        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_13, false, false, NULL, NULL), "build manifest");
+        TEST_ASSIGN(manifest, manifestNewBuild(storagePg, PG_VERSION_13, 202007201, false, false, NULL, NULL), "build manifest");
 
         contentSave = bufNew(0);
         TEST_RESULT_VOID(manifestSave(manifest, ioBufferWriteNew(contentSave)), "save manifest");
@@ -1102,7 +1104,7 @@ testRun(void)
             FileOpenError, "unable to create symlink");
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, false, false, NULL, NULL), LinkDestinationError,
+            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkDestinationError,
             hrnReplaceKey("link 'link' destination '{[path]}/pg/base' is in PGDATA"));
 
         THROW_ON_SYS_ERROR(
@@ -1114,7 +1116,7 @@ testRun(void)
         storagePathCreateP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somedir"), .mode = 0700, .noParentCreate = true);
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, false, false, NULL, NULL), LinkExpectedError,
+            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkExpectedError,
             "'pg_data/pg_tblspc/somedir' is not a symlink - pg_tblspc should contain only symlinks");
 
         storagePathRemoveP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somedir"));
@@ -1125,7 +1127,7 @@ testRun(void)
         storagePutP(storageNewWriteP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somefile")), NULL);
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, false, false, NULL, NULL), LinkExpectedError,
+            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkExpectedError,
             "'pg_data/pg_tblspc/somefile' is not a symlink - pg_tblspc should contain only symlinks");
 
         storageRemoveP(storagePgWrite, strNew(MANIFEST_TARGET_PGTBLSPC "/somefile"));
@@ -1138,7 +1140,7 @@ testRun(void)
             "unable to create symlink");
 
         TEST_ERROR(
-            manifestNewBuild(storagePg, PG_VERSION_94, false, true, NULL, NULL), FileOpenError,
+            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, true, NULL, NULL), FileOpenError,
             hrnReplaceKey("unable to get info for missing path/file '{[path]}/pg/link-to-link': [2] No such file or directory"));
 
         THROW_ON_SYS_ERROR(
@@ -1156,7 +1158,7 @@ testRun(void)
             FileOpenError, "unable to create symlink");
 
         TEST_ERROR_FMT(
-            manifestNewBuild(storagePg, PG_VERSION_94, false, false, NULL, NULL), LinkDestinationError,
+            manifestNewBuild(storagePg, PG_VERSION_94, 201409291, false, false, NULL, NULL), LinkDestinationError,
             "link '%s/pg/linktolink' cannot reference another link '%s/linktest'", testPath(), testPath());
 
         #undef TEST_MANIFEST_HEADER
@@ -1230,7 +1232,7 @@ testRun(void)
             "backup-type=\"incr\"\n"                                                                                               \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=0\n"                                                                                               \
+            "db-catalog-version=201608131\n"                                                                                       \
             "db-control-version=960\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -1267,6 +1269,7 @@ testRun(void)
         Manifest *manifest = manifestNewInternal();
         manifest->info = infoNew(NULL);
         manifest->data.pgVersion = PG_VERSION_96;
+        manifest->data.pgCatalogVersion = 201608131;
         manifest->data.backupOptionDelta = BOOL_FALSE_VAR;
 
         manifestTargetAdd(manifest, &(ManifestTarget){.name = MANIFEST_TARGET_PGDATA_STR, .path = STRDEF("/pg")});
@@ -1833,7 +1836,7 @@ testRun(void)
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_RESULT_VOID(
-            manifestBuildComplete(manifest, 0, NULL, NULL, 0, NULL, NULL, 0, 0, 0, NULL, false, false, 0, 0, 0, false, 0, false),
+            manifestBuildComplete(manifest, 0, NULL, NULL, 0, NULL, NULL, 0, 0, NULL, false, false, 0, 0, 0, false, 0, false),
             "manifest complete without db");
 
         // Create db list
@@ -1860,7 +1863,7 @@ testRun(void)
         TEST_RESULT_VOID(
             manifestBuildComplete(
                 manifest, 1565282140, STRDEF("285/89000028"), STRDEF("000000030000028500000089"), 1565282142,
-                STRDEF("285/89001F88"), STRDEF("000000030000028500000089"), 1, 1000000000000000094, 201409291, dbList,
+                STRDEF("285/89001F88"), STRDEF("000000030000028500000089"), 1, 1000000000000000094, dbList,
                 true, true, 16384, 3, 6, true, 32, false),
             "manifest complete with db");
 

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -47,7 +47,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_83                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=200711281\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=833\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -56,7 +56,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_84                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=200904091\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=843\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -65,7 +65,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_90                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201008051\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=903\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -74,7 +74,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_91                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201105231\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=903\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -83,7 +83,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_92                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201204301\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=922\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -92,7 +92,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_94                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201409291\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=942\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -101,7 +101,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_12                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201909212\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=1201\n"                                                                                            \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -110,7 +110,7 @@ testRun(void)
         #define TEST_MANIFEST_DB_13                                                                                                \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=202007201\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=1300\n"                                                                                            \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -1230,7 +1230,7 @@ testRun(void)
             "backup-type=\"incr\"\n"                                                                                               \
             "\n"                                                                                                                   \
             "[backup:db]\n"                                                                                                        \
-            "db-catalog-version=201608131\n"                                                                                       \
+            "db-catalog-version=0\n"                                                                                               \
             "db-control-version=960\n"                                                                                             \
             "db-id=0\n"                                                                                                            \
             "db-system-id=0\n"                                                                                                     \
@@ -1833,7 +1833,7 @@ testRun(void)
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_RESULT_VOID(
-            manifestBuildComplete(manifest, 0, NULL, NULL, 0, NULL, NULL, 0, 0, NULL, false, false, 0, 0, 0, false, 0, false),
+            manifestBuildComplete(manifest, 0, NULL, NULL, 0, NULL, NULL, 0, 0, 0, NULL, false, false, 0, 0, 0, false, 0, false),
             "manifest complete without db");
 
         // Create db list
@@ -1860,7 +1860,7 @@ testRun(void)
         TEST_RESULT_VOID(
             manifestBuildComplete(
                 manifest, 1565282140, STRDEF("285/89000028"), STRDEF("000000030000028500000089"), 1565282142,
-                STRDEF("285/89001F88"), STRDEF("000000030000028500000089"), 1, 1000000000000000094, dbList,
+                STRDEF("285/89001F88"), STRDEF("000000030000028500000089"), 1, 1000000000000000094, 201409291, dbList,
                 true, true, 16384, 3, 6, true, 32, false),
             "manifest complete with db");
 

--- a/test/src/module/performance/typeTest.c
+++ b/test/src/module/performance/typeTest.c
@@ -238,7 +238,7 @@ testRun(void)
         MEM_CONTEXT_BEGIN(testContext)
         {
             TEST_ASSIGN(
-                manifest, manifestNewBuild(storagePg, PG_VERSION_91, 201105231, false, false, NULL, NULL),
+                manifest, manifestNewBuild(storagePg, PG_VERSION_91, 999999999, false, false, NULL, NULL),
                 "build with %" PRIu64 " files", driver.fileTotal);
         }
         MEM_CONTEXT_END();

--- a/test/src/module/performance/typeTest.c
+++ b/test/src/module/performance/typeTest.c
@@ -238,8 +238,8 @@ testRun(void)
         MEM_CONTEXT_BEGIN(testContext)
         {
             TEST_ASSIGN(
-                manifest, manifestNewBuild(storagePg, PG_VERSION_91, false, false, NULL, NULL), "build with %" PRIu64 " files",
-                driver.fileTotal);
+                manifest, manifestNewBuild(storagePg, PG_VERSION_91, 201105231, false, false, NULL, NULL),
+                "build with %" PRIu64 " files", driver.fileTotal);
         }
         MEM_CONTEXT_END();
 

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -68,9 +68,7 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer(
-                (PgControl){
-                    .version = PG_VERSION_11, .systemId = 0xFACEFACE, .catalogVersion = 201809051, .walSegmentSize = 1024 * 1024}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACE, .walSegmentSize = 1024 * 1024}));
 
         PgControl info = {0};
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v11");
@@ -89,7 +87,7 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .pageSize = 32 * 1024, .catalogVersion = 201510051}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .pageSize = 32 * 1024}));
 
         TEST_ERROR(pgControlFromFile(storageTest), FormatError, "page size is 32768 but must be 8192");
 

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -68,12 +68,15 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_11, .systemId = 0xFACEFACE, .walSegmentSize = 1024 * 1024}));
+            pgControlTestToBuffer(
+                (PgControl){
+                    .version = PG_VERSION_11, .systemId = 0xFACEFACE, .catalogVersion = 201809051, .walSegmentSize = 1024 * 1024}));
 
         PgControl info = {0};
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v11");
         TEST_RESULT_UINT(info.systemId, 0xFACEFACE, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_11, "   check version");
+        TEST_RESULT_UINT(info.catalogVersion, 201809051, "   check version");
 
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
@@ -93,11 +96,12 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_83, .systemId = 0xEFEFEFEFEF}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_83, .systemId = 0xEFEFEFEFEF, .catalogVersion = 200711281}));
 
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v83");
         TEST_RESULT_UINT(info.systemId, 0xEFEFEFEFEF, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_83, "   check version");
+        TEST_RESULT_UINT(info.catalogVersion, 200711281, "   check version");
     }
 
     // *****************************************************************************************************************************

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -94,7 +94,9 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_83, .systemId = 0xEFEFEFEFEF, .catalogVersion = 200711281}));
+            pgControlTestToBuffer(
+                (PgControl){
+                    .version = PG_VERSION_83, .systemId = 0xEFEFEFEFEF, .catalogVersion = pgCatalogTestVersion(PG_VERSION_83)}));
 
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v83");
         TEST_RESULT_UINT(info.systemId, 0xEFEFEFEFEF, "   check system id");

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -30,15 +30,11 @@ testRun(void)
     }
 
     // *****************************************************************************************************************************
-    if (testBegin("pgControlVersion() and pgCatalogVersion()"))
+    if (testBegin("pgControlVersion()"))
     {
         TEST_ERROR(pgControlVersion(70300), AssertError, "invalid PostgreSQL version 70300");
         TEST_RESULT_UINT(pgControlVersion(PG_VERSION_83), 833, "8.3 control version");
         TEST_RESULT_UINT(pgControlVersion(PG_VERSION_11), 1100, "11 control version");
-
-        TEST_ERROR(pgCatalogVersion(70900), AssertError, "invalid PostgreSQL version 70900");
-        TEST_RESULT_UINT(pgCatalogVersion(PG_VERSION_83), 200711281, "8.3 catalog version");
-        TEST_RESULT_UINT(pgCatalogVersion(PG_VERSION_11), 201809051, "11 catalog version");
     }
 
     // *****************************************************************************************************************************
@@ -90,7 +86,7 @@ testRun(void)
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
             storageNewWriteP(storageTest, controlFile),
-            pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .pageSize = 32 * 1024}));
+            pgControlTestToBuffer((PgControl){.version = PG_VERSION_95, .pageSize = 32 * 1024, .catalogVersion = 201510051}));
 
         TEST_ERROR(pgControlFromFile(storageTest), FormatError, "page size is 32768 but must be 8192");
 
@@ -169,10 +165,9 @@ testRun(void)
         TEST_RESULT_STR_Z(pgLsnName(PG_VERSION_96), "location", "check location name");
         TEST_RESULT_STR_Z(pgLsnName(PG_VERSION_10), "lsn", "check lsn name");
 
-        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_84), NULL, "check 8.4 tablespace id");
-        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_90), "PG_9.0_201008051", "check 9.0 tablespace id");
-        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_94), "PG_9.4_201409291", "check 9.4 tablespace id");
-        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_11), "PG_11_201809051", "check 11 tablespace id");
+        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_84, 200904091), NULL, "check 8.4 tablespace id");
+        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_90, 201008051), "PG_9.0_201008051", "check 9.0 tablespace id");
+        TEST_RESULT_STR_Z(pgTablespaceId(PG_VERSION_94, 999999999), "PG_9.4_999999999", "check 9.4 tablespace id");
 
         TEST_RESULT_STR_Z(pgWalName(PG_VERSION_96), "xlog", "check xlog name");
         TEST_RESULT_STR_Z(pgWalName(PG_VERSION_10), "wal", "check wal name");

--- a/test/src/module/postgres/interfaceTest.c
+++ b/test/src/module/postgres/interfaceTest.c
@@ -76,7 +76,7 @@ testRun(void)
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v11");
         TEST_RESULT_UINT(info.systemId, 0xFACEFACE, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_11, "   check version");
-        TEST_RESULT_UINT(info.catalogVersion, 201809051, "   check version");
+        TEST_RESULT_UINT(info.catalogVersion, 201809051, "   check catalog version");
 
         //--------------------------------------------------------------------------------------------------------------------------
         storagePutP(
@@ -101,7 +101,7 @@ testRun(void)
         TEST_ASSIGN(info, pgControlFromFile(storageTest), "get control info v83");
         TEST_RESULT_UINT(info.systemId, 0xEFEFEFEFEF, "   check system id");
         TEST_RESULT_UINT(info.version, PG_VERSION_83, "   check version");
-        TEST_RESULT_UINT(info.catalogVersion, 200711281, "   check version");
+        TEST_RESULT_UINT(info.catalogVersion, 200711281, "   check catalog version");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
Previously, catalog versions were fixed for all versions which made maintaining the catalog versions during PostgreSQL beta and release candidate cycles very painful. A version of pgBackRest which was functionally compatible was rendered useless by a catalog version bump in PostgreSQL.

Instead use only the control version to identify a PostgreSQL version when possible. Some older versions require a catalog version to positively identify a version, so included them when required.

Since the catalog number is required to work with tablespaces it will need to be stored. There's already a copy of it in backup.info so use that (even though we have been ignoring it in the C versions).