### PR TITLE
Error with hints when backup user cannot read pg_settings.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -19,6 +19,8 @@
                         <release-item-contributor-list>
                             <release-item-ideator id="mohamed.insaf.k"/>
                             <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                            <release-item-reviewer id="cynthia.shang"/>
                         </release-item-contributor-list>
 
                         <p>Error with hints when backup user cannot read <id>pg_settings</id>.</p>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -14,6 +14,17 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.30dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="mohamed.insaf.k"/>
+                            <release-item-contributor id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Error with hints when backup user cannot read <id>pg_settings</id>.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-improvement-list>
                     <release-item>
                         <release-item-contributor-list>
@@ -9042,6 +9053,11 @@
         <contributor id="milosz.suchy">
             <contributor-name-display>Milosz Suchy</contributor-name-display>
             <contributor-id type="github">Yuxael</contributor-id>
+        </contributor>
+
+        <contributor id="mohamed.insaf.k">
+            <contributor-name-display>Mohamed Insaf K</contributor-name-display>
+            <contributor-id type="github">insafk</contributor-id>
         </contributor>
 
         <contributor id="mohamad.el.rifai">

--- a/src/db/db.c
+++ b/src/db/db.c
@@ -219,16 +219,16 @@ dbOpen(Db *this)
                 " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"
                 " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text"));
 
-        // Check that none of the return values are null, which indicates the user does not have select on pg_settings
+        // Check that none of the return values are null, which indicates the user cannot select some rows in pg_settings
         for (unsigned int columnIdx = 0; columnIdx < varLstSize(row); columnIdx++)
         {
             if (varLstGet(row, columnIdx) == NULL)
             {
                 THROW(
                     DbQueryError,
-                    "unable to select rows from pg_settings\n"
-                        "HINT: does the user have select privileges on pg_settings?\n"
-                        "HINT: is the pg_read_all_settings role assigned for " PG_NAME " >= " PG_VERSION_10_STR);
+                    "unable to select some rows from pg_settings\n"
+                        "HINT: is the backup running as the postgres user?\n"
+                        "HINT: is the pg_read_all_settings role assigned for " PG_NAME " >= " PG_VERSION_10_STR "?");
             }
         }
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -411,40 +411,7 @@ testBackupPqScript(unsigned int pgVersion, time_t backupTimeStart, TestBackupPqS
             harnessPqScriptSet((HarnessPq [])
             {
                 // Connect to primary
-                // HRNPQ_MACRO_OPEN_GE_96(1, "dbname='postgres' port=5432", PG_VERSION_11, pg1Path, false, NULL, NULL),
-
-                // Connect to primary
-                HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
-                HRNPQ_MACRO_SET_SEARCH_PATH(1),
-                HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
-
-                {.session = 1, .function = HRNPQ_SENDQUERY, .param =
-                    "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
-                        " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"
-                        " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"
-                        " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text\"]",
-                    .resultInt = 1},
-                {.session = 1, .function = HRNPQ_CONSUMEINPUT},
-                {.session = 1, .function = HRNPQ_ISBUSY},
-                {.session = 1, .function = HRNPQ_GETRESULT},
-                {.session = 1, .function = HRNPQ_RESULTSTATUS, .resultInt = PGRES_TUPLES_OK},
-                {.session = 1, .function = HRNPQ_NTUPLES, .resultInt = 1},
-                {.session = 1, .function = HRNPQ_NFIELDS, .resultInt = 4},
-                {.session = 1, .function = HRNPQ_FTYPE, .param = "[0]", .resultInt = HRNPQ_TYPE_INT},
-                {.session = 1, .function = HRNPQ_FTYPE, .param = "[1]", .resultInt = HRNPQ_TYPE_TEXT},
-                {.session = 1, .function = HRNPQ_FTYPE, .param = "[2]", .resultInt = HRNPQ_TYPE_TEXT},
-                {.session = 1, .function = HRNPQ_FTYPE, .param = "[3]", .resultInt = HRNPQ_TYPE_TEXT},
-                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,0]", .resultZ = "90600"},
-                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,1]", .resultZ = ""},
-                {.session = 1, .function = HRNPQ_GETISNULL, .param = "[0,1]", .resultInt = 1},
-                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,2]", .resultZ = "on"},
-                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = "pgbackrest"},
-                {.session = 1, .function = HRNPQ_CLEAR},
-                {.session = 1, .function = HRNPQ_GETRESULT, .resultNull = true},
-
-                HRNPQ_MACRO_SET_APPLICATION_NAME(1),
-                HRNPQ_MACRO_SET_MAX_PARALLEL_WORKERS_PER_GATHER(1),
-                HRNPQ_MACRO_IS_STANDBY_QUERY(1, false),
+                HRNPQ_MACRO_OPEN_GE_96(1, "dbname='postgres' port=5432", PG_VERSION_11, pg1Path, false, NULL, NULL),
 
                 // Get start time
                 HRNPQ_MACRO_TIME_QUERY(1, (int64_t)backupTimeStart * 1000),

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -411,7 +411,40 @@ testBackupPqScript(unsigned int pgVersion, time_t backupTimeStart, TestBackupPqS
             harnessPqScriptSet((HarnessPq [])
             {
                 // Connect to primary
-                HRNPQ_MACRO_OPEN_GE_96(1, "dbname='postgres' port=5432", PG_VERSION_11, pg1Path, false, NULL, NULL),
+                // HRNPQ_MACRO_OPEN_GE_96(1, "dbname='postgres' port=5432", PG_VERSION_11, pg1Path, false, NULL, NULL),
+
+                // Connect to primary
+                HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
+                HRNPQ_MACRO_SET_SEARCH_PATH(1),
+                HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
+
+                {.session = 1, .function = HRNPQ_SENDQUERY, .param =
+                    "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
+                        " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"
+                        " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"
+                        " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text\"]",
+                    .resultInt = 1},
+                {.session = 1, .function = HRNPQ_CONSUMEINPUT},
+                {.session = 1, .function = HRNPQ_ISBUSY},
+                {.session = 1, .function = HRNPQ_GETRESULT},
+                {.session = 1, .function = HRNPQ_RESULTSTATUS, .resultInt = PGRES_TUPLES_OK},
+                {.session = 1, .function = HRNPQ_NTUPLES, .resultInt = 1},
+                {.session = 1, .function = HRNPQ_NFIELDS, .resultInt = 4},
+                {.session = 1, .function = HRNPQ_FTYPE, .param = "[0]", .resultInt = HRNPQ_TYPE_INT},
+                {.session = 1, .function = HRNPQ_FTYPE, .param = "[1]", .resultInt = HRNPQ_TYPE_TEXT},
+                {.session = 1, .function = HRNPQ_FTYPE, .param = "[2]", .resultInt = HRNPQ_TYPE_TEXT},
+                {.session = 1, .function = HRNPQ_FTYPE, .param = "[3]", .resultInt = HRNPQ_TYPE_TEXT},
+                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,0]", .resultZ = "90600"},
+                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,1]", .resultZ = ""},
+                {.session = 1, .function = HRNPQ_GETISNULL, .param = "[0,1]", .resultInt = 1},
+                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,2]", .resultZ = "on"},
+                {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = "pgbackrest"},
+                {.session = 1, .function = HRNPQ_CLEAR},
+                {.session = 1, .function = HRNPQ_GETRESULT, .resultNull = true},
+
+                HRNPQ_MACRO_SET_APPLICATION_NAME(1),
+                HRNPQ_MACRO_SET_MAX_PARALLEL_WORKERS_PER_GATHER(1),
+                HRNPQ_MACRO_IS_STANDBY_QUERY(1, false),
 
                 // Get start time
                 HRNPQ_MACRO_TIME_QUERY(1, (int64_t)backupTimeStart * 1000),

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -303,6 +303,53 @@ testRun(void)
         TEST_RESULT_VOID(dbFree(db.primary), "free primary");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("PostgreSQL 10 without pg_read_all_settings");
+
+        harnessPqScriptSet((HarnessPq [])
+        {
+            // Connect to primary
+            HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
+            HRNPQ_MACRO_SET_SEARCH_PATH(1),
+            HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
+
+            {.session = 1, .function = HRNPQ_SENDQUERY, .param =
+                "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
+                    " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"
+                    " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"
+                    " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text\"]",
+                .resultInt = 1},
+            {.session = 1, .function = HRNPQ_CONSUMEINPUT},
+            {.session = 1, .function = HRNPQ_ISBUSY},
+            {.session = 1, .function = HRNPQ_GETRESULT},
+            {.session = 1, .function = HRNPQ_RESULTSTATUS, .resultInt = PGRES_TUPLES_OK},
+            {.session = 1, .function = HRNPQ_NTUPLES, .resultInt = 1},
+            {.session = 1, .function = HRNPQ_NFIELDS, .resultInt = 4},
+            {.session = 1, .function = HRNPQ_FTYPE, .param = "[0]", .resultInt = HRNPQ_TYPE_INT},
+            {.session = 1, .function = HRNPQ_FTYPE, .param = "[1]", .resultInt = HRNPQ_TYPE_TEXT},
+            {.session = 1, .function = HRNPQ_FTYPE, .param = "[2]", .resultInt = HRNPQ_TYPE_TEXT},
+            {.session = 1, .function = HRNPQ_FTYPE, .param = "[3]", .resultInt = HRNPQ_TYPE_TEXT},
+            {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,0]", .resultZ = "0"},
+            {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,1]", .resultZ = "value"},
+            {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,2]", .resultZ = "value"},
+            {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = ""},
+            {.session = 1, .function = HRNPQ_GETISNULL, .param = "[0,3]", .resultInt = 1},
+            {.session = 1, .function = HRNPQ_CLEAR},
+            {.session = 1, .function = HRNPQ_GETRESULT, .resultNull = true},
+
+            // Close primary
+            HRNPQ_MACRO_CLOSE(1),
+
+            HRNPQ_MACRO_DONE()
+        });
+
+        TEST_ERROR(dbGet(true, true, false), DbConnectError, "unable to find primary cluster - cannot proceed");
+
+        TEST_RESULT_LOG(
+            "P00   WARN: unable to check pg-1: [DbQueryError] unable to select rows from pg_settings\n"
+            "            HINT: does the user have select privileges on pg_settings?\n"
+            "            HINT: is the pg_read_all_settings role assigned for PostgreSQL >= 10");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("PostgreSQL 9.5 start backup from standby");
 
         argList = strLstNew();

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -155,7 +155,7 @@ testRun(void)
             HRNPQ_MACRO_SET_SEARCH_PATH(1),
             HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
 
-            // Return NULL for data_directory in pg_settings
+            // Return NULL for a row in pg_settings
             {.session = 1, .function = HRNPQ_SENDQUERY, .param =
                 "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
                     " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -155,6 +155,7 @@ testRun(void)
             HRNPQ_MACRO_SET_SEARCH_PATH(1),
             HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
 
+            // Return NULL for data_directory in pg_settings
             {.session = 1, .function = HRNPQ_SENDQUERY, .param =
                 "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
                     " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"


### PR DESCRIPTION
This condition used to give a not-very-clear error which we have been intending to improve. But in the meantime the changes in fbff299 resulted in a segfault for this condition instead because the data_directory was assumed to be non-NULL.

Fix this by explicitly throwing an error with hints when any row in pg_settings cannot be selected.

