### PR TITLE
Update yum repository path for CentOS/RHEL user guide.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -76,6 +76,19 @@
                     </release-item>
                 </release-development-list>
             </release-core-list>
+
+            <release-doc-list>
+                <release-improvement-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-contributor id="heath.lord"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Update yum repository path for <proper>CentOS/RHEL</proper> user guide.</p>
+                    </release-item>
+                </release-improvement-list>
+            </release-doc-list>
         </release>
 
         <release date="2020-08-31" version="2.29" title="Auto S3 Credentials on AWS">

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -367,7 +367,7 @@
 
         # Install PostgreSQL
         RUN rpm --import http://yum.postgresql.org/RPM-GPG-KEY-PGDG-10 &amp;&amp; \
-            rpm -ivh https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm &amp;&amp; \
+            rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm &amp;&amp; \
             yum install -y postgresql{[pg-version-nodot]}-server postgresql{[pg-version-upgrade-nodot]}-server
 
         # Create an ssh key for root so all hosts can ssh to each other as root
@@ -411,7 +411,7 @@
 
         # Install PostgreSQL
         RUN rpm --import http://yum.postgresql.org/RPM-GPG-KEY-PGDG-10 &amp;&amp; \
-            rpm -ivh https://download.postgresql.org/pub/repos/yum/11/redhat/rhel-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm  &amp;&amp; \
+            rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm &amp;&amp; \
             yum install -y postgresql{[pg-version-nodot]}-server postgresql{[pg-version-upgrade-nodot]}-server
 
         # Create an ssh key for root so all hosts can ssh to each other as root


### PR DESCRIPTION
  This change allows the running of the ./doc.pl script when testing a pgbackrest build based on PostgreSQL 13.  Without this change the version of the pgdg-redhat-repo that is installed does not container the pgdg-13 repo at all.  I have built and run this on centos-7 and with it I am able to fully run the ./doc.pl script to complete the regression. 