### PR TITLE
Move info command text to the reference and link to user guide.

### DIFF
--- a/doc/lib/pgBackRestDoc/Common/DocRender.pm
+++ b/doc/lib/pgBackRestDoc/Common/DocRender.pm
@@ -741,11 +741,22 @@ sub processTag
                 # Else point locally
                 else
                 {
-                    if ($strType eq 'html' || $strType eq 'markdown')
+                    my $strSection = $oTag->paramGet('section', false);
+
+                    if ($strType eq 'html')
                     {
                         $strUrl =
-                            $oTag->paramGet('page', false) . '.' .
-                            ($strType eq 'html' ? $strType : '.md');
+                            ($strPage ne $self->{strRenderOutKey} ? "${strPage}.html" : '') .
+                            (defined($strSection) ? '#' . substr($strSection, 1) : '');
+                    }
+                    elsif ($strType eq 'markdown')
+                    {
+                        if (defined($strSection))
+                        {
+                            confess &log(ERROR, "page and section links not supported for type ${strType}, value '" . $oTag->valueGet() . "'");
+                        }
+
+                        $strUrl = "${strPage}.md";
                     }
                     else
                     {

--- a/doc/lib/pgBackRestDoc/Common/DocRender.pm
+++ b/doc/lib/pgBackRestDoc/Common/DocRender.pm
@@ -729,6 +729,13 @@ sub processTag
         if (!defined($strUrl))
         {
             my $strPage = $self->variableReplace($oTag->paramGet('page', false));
+            my $strSection = $oTag->paramGet('section', false);
+
+            # If a page/section link points to the current page then remove the page portion
+            if (defined($strPage) && defined($strSection) && $strPage eq $self->{strRenderOutKey})
+            {
+                undef($strPage);
+            }
 
             # If this is a page URL
             if (defined($strPage))
@@ -741,19 +748,17 @@ sub processTag
                 # Else point locally
                 else
                 {
-                    my $strSection = $oTag->paramGet('section', false);
-
                     if ($strType eq 'html')
                     {
-                        $strUrl =
-                            ($strPage ne $self->{strRenderOutKey} ? "${strPage}.html" : '') .
-                            (defined($strSection) ? '#' . substr($strSection, 1) : '');
+                        $strUrl = "${strPage}.html". (defined($strSection) ? '#' . substr($strSection, 1) : '');
                     }
                     elsif ($strType eq 'markdown')
                     {
                         if (defined($strSection))
                         {
-                            confess &log(ERROR, "page and section links not supported for type ${strType}, value '" . $oTag->valueGet() . "'");
+                            confess &log(
+                                ERROR,
+                                "page and section links not supported for type ${strType}, value '" . $oTag->valueGet() . "'");
                         }
 
                         $strUrl = "${strPage}.md";

--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -1557,7 +1557,7 @@
 
                 <text>The <cmd>info</cmd> command operates on a single stanza or all stanzas.  Text output is the default and gives a human-readable summary of backups for the stanza(s) requested.  This format is subject to change with any release.
 
-                For machine-readable output use <setting>--output=json</setting>.  The JSON output contains far more information than the text output and is kept stable unless a bug is found.
+                For machine-readable output use <br-option>--output=json</br-option>.  The JSON output contains far more information than the text output and is kept stable unless a bug is found.
 
                 Each stanza has a separate section and it is possible to limit output to a single stanza with the <br-option>--stanza</br-option> option.  The stanza '<id>status</id>' gives a brief indication of the stanza's health.  If this is '<id>ok</id>' then <backrest/> is functioning normally.  The '<id>wal archive min/max</id>' shows the minimum and maximum WAL currently stored in the archive.  Note that there may be gaps due to archive retention policies or other reasons.
 

--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -1557,7 +1557,21 @@
 
                 <text>The <cmd>info</cmd> command operates on a single stanza or all stanzas.  Text output is the default and gives a human-readable summary of backups for the stanza(s) requested.  This format is subject to change with any release.
 
-                For machine-readable output use <setting>--output=json</setting>.  The JSON output contains far more information than the text output and is kept stable unless a bug is found.</text>
+                For machine-readable output use <setting>--output=json</setting>.  The JSON output contains far more information than the text output and is kept stable unless a bug is found.
+
+                Each stanza has a separate section and it is possible to limit output to a single stanza with the <br-option>--stanza</br-option> option.  The stanza '<id>status</id>' gives a brief indication of the stanza's health.  If this is '<id>ok</id>' then <backrest/> is functioning normally.  The '<id>wal archive min/max</id>' shows the minimum and maximum WAL currently stored in the archive.  Note that there may be gaps due to archive retention policies or other reasons.
+
+                The '<id>backup/expire running</id>' message will appear beside the '<id>status</id>' information if one of those commands is currently running on the host.
+
+                The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).
+
+                The '<id>timestamp start/stop</id>' defines the time period when the backup ran.  The '<id>timestamp stop</id>' can be used to determine the backup to use when performing Point-In-Time Recovery.  More information about Point-In-Time Recovery can be found in the <link page="user-guide" section="/pitr">Point-In-Time Recovery</link> section.
+
+                The '<id>wal start/stop</id>' defines the WAL range that is required to make the database consistent when restoring.  The <cmd>backup</cmd> command will ensure that this WAL range is in the archive before completing.
+
+                The '<id>database size</id>' is the full uncompressed size of the database while '<id>backup size</id>' is the amount of data actually backed up (these will be the same for full backups).  The '<id>repository size</id>' includes all the files from this backup and any referenced backups that are required to restore the database while '<id>repository backup size</id>' includes only the files in this backup (these will also be the same for full backups).  Repository sizes reflect compressed file sizes if compression is enabled in <backrest/> or the filesystem.
+
+                The '<id>backup reference list</id>' contains the additional backups that are required to restore this backup.</text>
 
                 <option-list>
                     <!-- OPERATION - INFO COMMAND - OUTPUT OPTION -->

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -96,6 +96,15 @@
                 <release-improvement-list>
                     <release-item>
                         <release-item-contributor-list>
+                            <release-item-ideator id="christophe.courtois"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Move info command text to the reference and link to user guide.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                             <release-item-contributor id="heath.lord"/>
                             <release-item-reviewer id="david.steele"/>
                         </release-item-contributor-list>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -1249,19 +1249,7 @@
                 </execute>
             </execute-list>
 
-            <p>Each stanza has a separate section and it is possible to limit output to a single stanza with the <br-option>--stanza</br-option> option.  The stanza '<id>status</id>' gives a brief indication of the stanza's health.  If this is '<id>ok</id>' then <backrest/> is functioning normally.  The '<id>wal archive min/max</id>' shows the minimum and maximum WAL currently stored in the archive.  Note that there may be gaps due to archive retention policies or other reasons.</p>
-
-            <p>The '<id>backup/expire running</id>' message will appear beside the '<id>status</id>' information if one of those commands is currently running on the host.</p>
-
-            <p>The backups are displayed oldest to newest.  The oldest backup will <i>always</i> be a full backup (indicated by an <id>F</id> at the end of the label) but the newest backup can be full, differential (ends with <id>D</id>), or incremental (ends with <id>I</id>).</p>
-
-            <p>The '<id>timestamp start/stop</id>' defines the time period when the backup ran.  The '<id>timestamp stop</id>' can be used to determine the backup to use when performing Point-In-Time Recovery.  More information about Point-In-Time Recovery can be found in the <link section="/pitr">Point-In-Time Recovery</link> section.</p>
-
-            <p>The '<id>wal start/stop</id>' defines the WAL range that is required to make the database consistent when restoring.  The <cmd>backup</cmd> command will ensure that this WAL range is in the archive before completing.</p>
-
-            <p>The '<id>database size</id>' is the full uncompressed size of the database while '<id>backup size</id>' is the amount of data actually backed up (these will be the same for full backups).  The '<id>repository size</id>' includes all the files from this backup and any referenced backups that are required to restore the database while '<id>repository backup size</id>' includes only the files in this backup (these will also be the same for full backups).  Repository sizes reflect compressed file sizes if compression is enabled in <backrest/> or the filesystem.</p>
-
-            <p>The '<id>backup reference list</id>' contains the additional backups that are required to restore this backup.</p>
+            <cmd-description key="info"/>
         </section>
 
         <!-- SECTION => QUICKSTART - PERFORM RESTORE -->


### PR DESCRIPTION
This means the same text will appear in both places, which should make it easier to find.

Also update the link code to allow both page and section to be specified rather than only one or the other.