### PR TITLE
Remove unused FUNCTION_LOG_VERIFY_WAL_RANGE* defines.

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -41,11 +41,6 @@ Data Types and Structures
 #define FUNCTION_LOG_VERIFY_INFO_FILE_FORMAT(value, buffer, bufferSize)                                                            \
     objToLog(&value, "VerifyInfoFile", buffer, bufferSize)
 
-#define FUNCTION_LOG_VERIFY_WAL_RANGE_TYPE                                                                                         \
-    VerifyWalRange
-#define FUNCTION_LOG_VERIFY_WAL_RANGE_FORMAT(value, buffer, bufferSize)                                                            \
-    objToLog(&value, "VerifyWalRange", buffer, bufferSize)
-
 // Structure for verifying repository info files
 typedef struct VerifyInfoFile
 {


### PR DESCRIPTION
The defined for FUNCTION_LOG_VERIFY_WAL_RANGE* are not used in the current verify.c and are currently not planned in the continuing development of the verify command, so they are dead code and are therefore being removed.