### PR TITLE
Move retrieval of archiveResult before while loop in verifyArchive().

### DIFF
--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -499,12 +499,12 @@ verifyArchive(void *data)
         // If there are WAL paths then get the file lists
         if (strLstSize(jobData->walPathList) > 0)
         {
+            // Get the archive id info for the current (last) archive id being processed
+            VerifyArchiveResult *archiveResult = lstGetLast(jobData->archiveIdResultList);
+
             do
             {
                 String *walPath = strLstGet(jobData->walPathList, 0);
-
-                // Get the archive id info for the current (last) archive id being processed
-                VerifyArchiveResult *archiveResult = lstGetLast(jobData->archiveIdResultList);
 
                 // Get the WAL files for the first item in the WAL paths list and initialize WAL info and ranges
                 if (strLstSize(jobData->walFileList) == 0)


### PR DESCRIPTION
The result structure for the archive id being processed only needs to be retrieved once so moving it outside of the WAL path list processing loop is more efficient. 