### PR TITLE
Create standby.signal only on PostgreSQL 12 when restore type is standby.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -24,6 +24,16 @@
 
                         <p>Allow <code>[</code>, <code>#</code>, and <code>space</code> as the first character in database names.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="keith.fiske"/>
+                            <release-item-contributor id="stefan.fercot"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Create <file>standby.signal</file> only on <postgres/> 12 when <cmd>restore</cmd> type is <id>standby</id>.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-feature-list>

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1628,19 +1628,21 @@ restoreRecoveryWriteAutoConf(unsigned int pgVersion, const String *restoreLabel)
                 .noAtomic = true, .noSyncPath = true, .user = dataPath.user, .group = dataPath.group),
             BUFSTR(content));
 
-        // The recovery.signal file is required for targeted recovery
-        storagePutP(
-            storageNewWriteP(
-                storagePgWrite(), PG_FILE_RECOVERYSIGNAL_STR, .noCreatePath = true, .modeFile = recoveryFileMode,
-                .noAtomic = true, .noSyncPath = true, .user = dataPath.user, .group = dataPath.group),
-            NULL);
-
         // The standby.signal file is required for standby mode
         if (strEq(cfgOptionStr(cfgOptType), RECOVERY_TYPE_STANDBY_STR))
         {
             storagePutP(
                 storageNewWriteP(
                     storagePgWrite(), PG_FILE_STANDBYSIGNAL_STR, .noCreatePath = true, .modeFile = recoveryFileMode,
+                    .noAtomic = true, .noSyncPath = true, .user = dataPath.user, .group = dataPath.group),
+                NULL);
+        }
+        // The recovery.signal file is required for targeted recovery
+        else
+        {
+            storagePutP(
+                storageNewWriteP(
+                    storagePgWrite(), PG_FILE_RECOVERYSIGNAL_STR, .noCreatePath = true, .modeFile = recoveryFileMode,
                     .noAtomic = true, .noSyncPath = true, .user = dataPath.user, .group = dataPath.group),
                 NULL);
         }

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1637,7 +1637,7 @@ restoreRecoveryWriteAutoConf(unsigned int pgVersion, const String *restoreLabel)
                     .noAtomic = true, .noSyncPath = true, .user = dataPath.user, .group = dataPath.group),
                 NULL);
         }
-        // The recovery.signal file is required for targeted recovery
+        // Else the recovery.signal file is required for targeted recovery
         else
         {
             storagePutP(

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1604,7 +1604,7 @@ testRun(void)
                 RECOVERY_SETTING_HEADER
                 "restore_command = 'my_restore_command'\n",
             "check postgresql.auto.conf");
-        TEST_RESULT_BOOL(storageExistsP(storagePg(), PG_FILE_RECOVERYSIGNAL_STR), true, "recovery.signal exists");
+        TEST_RESULT_BOOL(storageExistsP(storagePg(), PG_FILE_RECOVERYSIGNAL_STR), false, "recovery.signal exists");
         TEST_RESULT_BOOL(storageExistsP(storagePg(), PG_FILE_STANDBYSIGNAL_STR), true, "standby.signal missing");
 
         TEST_RESULT_LOG("P00   INFO: write updated {[path]}/pg/postgresql.auto.conf");


### PR DESCRIPTION
When restore type `standby` is provided, the `recovery.signal` isn't needed and may lead to some confusion (see #1236).

Lately, when using `pg_basebackup --write-recovery-conf`, only the `standby.signal` file is created. This change would then align with that behaviour.