### PR TITLE
Add pg-database option.

### DIFF
--- a/build/lib/pgBackRestBuild/Config/Data.pm
+++ b/build/lib/pgBackRestBuild/Config/Data.pm
@@ -298,6 +298,7 @@ use constant CFGOPT_PG_HOST_CONFIG_PATH                             => CFGOPT_PG
 use constant CFGOPT_PG_HOST_PORT                                    => CFGOPT_PG_HOST . '-port';
 use constant CFGOPT_PG_HOST_USER                                    => CFGOPT_PG_HOST . '-user';
 
+use constant CFGOPT_PG_DATABASE                                     => CFGDEF_PREFIX_PG . '-database';
 use constant CFGOPT_PG_PATH                                         => CFGDEF_PREFIX_PG . '-path';
 use constant CFGOPT_PG_PORT                                         => CFGDEF_PREFIX_PG . '-port';
 use constant CFGOPT_PG_SOCKET_PATH                                  => CFGDEF_PREFIX_PG . '-socket-path';
@@ -2734,6 +2735,16 @@ my %hConfigDefine =
             'db?-user' => {&CFGDEF_RESET => false},
         },
         &CFGDEF_REQUIRED => false,
+    },
+
+    &CFGOPT_PG_DATABASE =>
+    {
+        &CFGDEF_GROUP => CFGOPTGRP_PG,
+        &CFGDEF_SECTION => CFGDEF_SECTION_STANZA,
+        &CFGDEF_TYPE => CFGDEF_TYPE_STRING,
+        &CFGDEF_DEFAULT => 'postgres',
+        &CFGDEF_COMMAND => CFGOPT_PG_PORT,
+        &CFGDEF_DEPEND => CFGOPT_PG_PORT,
     },
 
     &CFGOPT_PG_PATH =>

--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -1062,6 +1062,17 @@
                         <example>1</example>
                     </config-key>
 
+                    <!-- ======================================================================================================= -->
+                    <config-key id="pg-database" name="PostgreSQL Database">
+                        <summary><postgres/> database user.</summary>
+
+                        <text>The database name used when connecting to <postgres/>. The default is usually best but some installations may not contain this database.
+
+                        Note that for legacy reasons the setting of <id>PGDATABASE</id> will be ignored.</text>
+
+                        <example>backupdb</example>
+                    </config-key>
+
                     <!-- CONFIG - STANZA SECTION - PG-PATH KEY -->
                     <config-key id="pg-path" name="PostgreSQL Path">
                         <summary><postgres/> data directory.</summary>

--- a/doc/xml/reference.xml
+++ b/doc/xml/reference.xml
@@ -1064,11 +1064,11 @@
 
                     <!-- ======================================================================================================= -->
                     <config-key id="pg-database" name="PostgreSQL Database">
-                        <summary><postgres/> database user.</summary>
+                        <summary><postgres/> database.</summary>
 
                         <text>The database name used when connecting to <postgres/>. The default is usually best but some installations may not contain this database.
 
-                        Note that for legacy reasons the setting of <id>PGDATABASE</id> will be ignored.</text>
+                        Note that for legacy reasons the setting of the <id>PGDATABASE</id> environment variable will be ignored.</text>
 
                         <example>backupdb</example>
                     </config-key>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -66,6 +66,14 @@
 
                         <p>Add <br-option>repo-azure-endpoint</br-option> option.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Add <br-option>pg-database</br-option> option.</p>
+                    </release-item>
                 </release-feature-list>
 
                 <release-improvement-list>

--- a/src/config/config.auto.c
+++ b/src/config/config.auto.c
@@ -659,6 +659,14 @@ static ConfigOptionData configOptionData[CFG_OPTION_TOTAL] = CONFIG_OPTION_LIST
     //------------------------------------------------------------------------------------------------------------------------------
     CONFIG_OPTION
     (
+        CONFIG_OPTION_NAME("pg-database")
+        CONFIG_OPTION_GROUP(true)
+        CONFIG_OPTION_GROUP_ID(cfgOptGrpPg)
+    )
+
+    //------------------------------------------------------------------------------------------------------------------------------
+    CONFIG_OPTION
+    (
         CONFIG_OPTION_NAME("pg-host")
         CONFIG_OPTION_GROUP(true)
         CONFIG_OPTION_GROUP_ID(cfgOptGrpPg)

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -203,7 +203,7 @@ Option constants
 #define CFGOPT_TYPE                                                 "type"
     STRING_DECLARE(CFGOPT_TYPE_STR);
 
-#define CFG_OPTION_TOTAL                                            125
+#define CFG_OPTION_TOTAL                                            126
 
 /***********************************************************************************************************************************
 Command enum
@@ -291,6 +291,7 @@ typedef enum
     cfgOptOnline,
     cfgOptOutput,
     cfgOptPg,
+    cfgOptPgDatabase,
     cfgOptPgHost,
     cfgOptPgHostCmd,
     cfgOptPgHostConfig,

--- a/src/config/define.auto.c
+++ b/src/config/define.auto.c
@@ -2279,6 +2279,44 @@ static ConfigDefineOptionData configDefineOptionData[] = CFGDEFDATA_OPTION_LIST
     // -----------------------------------------------------------------------------------------------------------------------------
     CFGDEFDATA_OPTION
     (
+        CFGDEFDATA_OPTION_NAME("pg-database")
+        CFGDEFDATA_OPTION_REQUIRED(true)
+        CFGDEFDATA_OPTION_SECTION(cfgDefSectionStanza)
+        CFGDEFDATA_OPTION_TYPE(cfgDefOptTypeString)
+        CFGDEFDATA_OPTION_INTERNAL(false)
+
+        CFGDEFDATA_OPTION_INDEX_TOTAL(8)
+        CFGDEFDATA_OPTION_SECURE(false)
+
+        CFGDEFDATA_OPTION_HELP_SECTION("stanza")
+        CFGDEFDATA_OPTION_HELP_SUMMARY("PostgreSQL database user.")
+        CFGDEFDATA_OPTION_HELP_DESCRIPTION
+        (
+            "The database name used when connecting to PostgreSQL. The default is usually best but some installations may not "
+                "contain this database.\n"
+            "\n"
+            "Note that for legacy reasons the setting of PGDATABASE will be ignored."
+        )
+
+        CFGDEFDATA_OPTION_COMMAND_LIST
+        (
+            CFGDEFDATA_OPTION_COMMAND(cfgCmdBackup)
+            CFGDEFDATA_OPTION_COMMAND(cfgCmdCheck)
+            CFGDEFDATA_OPTION_COMMAND(cfgCmdStanzaCreate)
+            CFGDEFDATA_OPTION_COMMAND(cfgCmdStanzaDelete)
+            CFGDEFDATA_OPTION_COMMAND(cfgCmdStanzaUpgrade)
+        )
+
+        CFGDEFDATA_OPTION_OPTIONAL_LIST
+        (
+            CFGDEFDATA_OPTION_OPTIONAL_DEPEND(cfgOptPgPath)
+            CFGDEFDATA_OPTION_OPTIONAL_DEFAULT("postgres")
+        )
+    )
+
+    // -----------------------------------------------------------------------------------------------------------------------------
+    CFGDEFDATA_OPTION
+    (
         CFGDEFDATA_OPTION_NAME("pg-host")
         CFGDEFDATA_OPTION_REQUIRED(false)
         CFGDEFDATA_OPTION_SECTION(cfgDefSectionStanza)

--- a/src/config/define.auto.c
+++ b/src/config/define.auto.c
@@ -2289,13 +2289,13 @@ static ConfigDefineOptionData configDefineOptionData[] = CFGDEFDATA_OPTION_LIST
         CFGDEFDATA_OPTION_SECURE(false)
 
         CFGDEFDATA_OPTION_HELP_SECTION("stanza")
-        CFGDEFDATA_OPTION_HELP_SUMMARY("PostgreSQL database user.")
+        CFGDEFDATA_OPTION_HELP_SUMMARY("PostgreSQL database.")
         CFGDEFDATA_OPTION_HELP_DESCRIPTION
         (
             "The database name used when connecting to PostgreSQL. The default is usually best but some installations may not "
                 "contain this database.\n"
             "\n"
-            "Note that for legacy reasons the setting of PGDATABASE will be ignored."
+            "Note that for legacy reasons the setting of the PGDATABASE environment variable will be ignored."
         )
 
         CFGDEFDATA_OPTION_COMMAND_LIST

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -542,6 +542,81 @@ static const struct option optionList[] =
         .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | cfgOptPg,
     },
 
+    // pg-database option
+    // -----------------------------------------------------------------------------------------------------------------------------
+    {
+        .name = "pg1-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (0 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg1-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (0 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg2-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (1 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg2-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (1 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg3-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (2 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg3-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (2 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg4-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (3 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg4-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (3 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg5-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (4 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg5-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (4 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg6-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (5 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg6-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (5 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg7-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (6 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg7-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (6 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "pg8-database",
+        .has_arg = required_argument,
+        .val = PARSE_OPTION_FLAG | (7 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+    {
+        .name = "reset-pg8-database",
+        .val = PARSE_OPTION_FLAG | PARSE_RESET_FLAG | (7 << PARSE_KEY_IDX_SHIFT) | cfgOptPgDatabase,
+    },
+
     // pg-host option and deprecations
     // -----------------------------------------------------------------------------------------------------------------------------
     {
@@ -2850,6 +2925,7 @@ static const ConfigOption optionResolveOrder[] =
     cfgOptArchiveCheck,
     cfgOptArchiveCopy,
     cfgOptForce,
+    cfgOptPgDatabase,
     cfgOptPgHost,
     cfgOptPgHostCmd,
     cfgOptPgHostConfig,

--- a/src/db/helper.c
+++ b/src/db/helper.c
@@ -30,8 +30,9 @@ dbGetIdx(unsigned int pgIdx)
         {
             result = dbNew(
                 pgClientNew(
-                    cfgOptionIdxStrNull(cfgOptPgSocketPath, pgIdx), cfgOptionIdxUInt(cfgOptPgPort, pgIdx), PG_DB_POSTGRES_STR,
-                    cfgOptionIdxStrNull(cfgOptPgUser, pgIdx), (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC)),
+                    cfgOptionIdxStrNull(cfgOptPgSocketPath, pgIdx), cfgOptionIdxUInt(cfgOptPgPort, pgIdx),
+                    cfgOptionIdxStr(cfgOptPgDatabase, pgIdx), cfgOptionIdxStrNull(cfgOptPgUser, pgIdx),
+                    (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC)),
                 NULL, applicationName);
         }
         else

--- a/src/db/protocol.c
+++ b/src/db/protocol.c
@@ -64,7 +64,7 @@ dbProtocol(const String *command, const VariantList *paramList, ProtocolServer *
             {
                 // Only a single db is passed to the remote
                 PgClient *pgClient = pgClientNew(
-                    cfgOptionStrNull(cfgOptPgSocketPath), cfgOptionUInt(cfgOptPgPort), PG_DB_POSTGRES_STR,
+                    cfgOptionStrNull(cfgOptPgSocketPath), cfgOptionUInt(cfgOptPgPort), cfgOptionStr(cfgOptPgDatabase),
                     cfgOptionStrNull(cfgOptPgUser), (TimeMSec)(cfgOptionDbl(cfgOptDbTimeout) * MSEC_PER_SEC));
                 pgClientOpen(pgClient);
 

--- a/src/postgres/interface.c
+++ b/src/postgres/interface.c
@@ -50,11 +50,6 @@ really old storage with 512-byte sectors.  This is true across all versions of P
 #define PG_CONTROL_DATA_SIZE                                        ((unsigned int)(512))
 
 /***********************************************************************************************************************************
-Name of default PostgreSQL database used for running all queries and commands
-***********************************************************************************************************************************/
-STRING_EXTERN(PG_DB_POSTGRES_STR,                                   PG_DB_POSTGRES);
-
-/***********************************************************************************************************************************
 PostgreSQL interface definitions
 
 Each supported version of PostgreSQL must have interface files named postgres/interface/vXXX.c/h that implement the functions

--- a/src/postgres/interface.h
+++ b/src/postgres/interface.h
@@ -61,12 +61,6 @@ Defines for various Postgres paths and files
     STRING_DECLARE(PG_NAME_XLOG_STR);
 
 /***********************************************************************************************************************************
-Name of default PostgreSQL database used for running all queries and commands
-***********************************************************************************************************************************/
-#define PG_DB_POSTGRES                                              "postgres"
-    STRING_DECLARE(PG_DB_POSTGRES_STR);
-
-/***********************************************************************************************************************************
 Define default page size
 
 Page size can only be changed at compile time and is not known to be well-tested, so only the default page size is supported.

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -143,6 +143,7 @@ testRun(void)
         strLstAddZ(argList, "--stanza=test1");
         strLstAddZ(argList, "--repo1-retention-full=1");
         strLstAddZ(argList, "--pg1-path=/pg1");
+        strLstAddZ(argList, "--pg1-database=backupdb");
         harnessCfgLoad(cfgCmdBackup, argList);
 
         // -------------------------------------------------------------------------------------------------------------------------
@@ -151,7 +152,7 @@ testRun(void)
         harnessPqScriptSet((HarnessPq [])
         {
             // Connect to primary
-            HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
+            HRNPQ_MACRO_OPEN(1, "dbname='backupdb' port=5432"),
             HRNPQ_MACRO_SET_SEARCH_PATH(1),
             HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
 
@@ -199,7 +200,7 @@ testRun(void)
         harnessPqScriptSet((HarnessPq [])
         {
             // Connect to primary
-            HRNPQ_MACRO_OPEN_LE_91(1, "dbname='postgres' port=5432", PG_VERSION_83, "/pg1", NULL, NULL),
+            HRNPQ_MACRO_OPEN_LE_91(1, "dbname='backupdb' port=5432", PG_VERSION_83, "/pg1", NULL, NULL),
 
             // Get advisory lock
             HRNPQ_MACRO_ADVISORY_LOCK(1, true),
@@ -226,7 +227,7 @@ testRun(void)
         harnessPqScriptSet((HarnessPq [])
         {
             // Connect to primary
-            HRNPQ_MACRO_OPEN_GE_92(1, "dbname='postgres' port=5432", PG_VERSION_95, "/pg1", false, NULL, NULL),
+            HRNPQ_MACRO_OPEN_GE_92(1, "dbname='backupdb' port=5432", PG_VERSION_95, "/pg1", false, NULL, NULL),
 
             // Get start time
             HRNPQ_MACRO_TIME_QUERY(1, 1000),
@@ -282,7 +283,7 @@ testRun(void)
         harnessPqScriptSet((HarnessPq [])
         {
             // Connect to primary
-            HRNPQ_MACRO_OPEN_GE_92(1, "dbname='postgres' port=5432", PG_VERSION_95, "/pg1", false, NULL, NULL),
+            HRNPQ_MACRO_OPEN_GE_92(1, "dbname='backupdb' port=5432", PG_VERSION_95, "/pg1", false, NULL, NULL),
 
             // Start backup when backup is in progress
             HRNPQ_MACRO_ADVISORY_LOCK(1, true),
@@ -321,7 +322,7 @@ testRun(void)
         harnessPqScriptSet((HarnessPq [])
         {
             // Connect to primary
-            HRNPQ_MACRO_OPEN_GE_96(1, "dbname='postgres' port=5432", PG_VERSION_96, "/pg1", false, NULL, NULL),
+            HRNPQ_MACRO_OPEN_GE_96(1, "dbname='backupdb' port=5432", PG_VERSION_96, "/pg1", false, NULL, NULL),
 
             // Start backup
             HRNPQ_MACRO_ADVISORY_LOCK(1, true),

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -72,6 +72,7 @@ testRun(void)
                 StringList *argList = strLstNew();
                 strLstAddZ(argList, "--stanza=test1");
                 strLstAddZ(argList, "--pg1-path=/path/to/pg");
+                strLstAddZ(argList, "--pg1-database=testdb");
                 strLstAddZ(argList, "--" CFGOPT_REMOTE_TYPE "=" PROTOCOL_REMOTE_TYPE_PG);
                 strLstAddZ(argList, "--process=0");
                 harnessCfgLoadRole(cfgCmdBackup, cfgCmdRoleRemote, argList);
@@ -79,13 +80,13 @@ testRun(void)
                 // Set script
                 harnessPqScriptSet((HarnessPq [])
                 {
-                    HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
+                    HRNPQ_MACRO_OPEN(1, "dbname='testdb' port=5432"),
                     HRNPQ_MACRO_SET_SEARCH_PATH(1),
                     HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
                     HRNPQ_MACRO_VALIDATE_QUERY(1, PG_VERSION_84, "/pgdata", NULL, NULL),
                     HRNPQ_MACRO_CLOSE(1),
 
-                    HRNPQ_MACRO_OPEN(1, "dbname='postgres' port=5432"),
+                    HRNPQ_MACRO_OPEN(1, "dbname='testdb' port=5432"),
                     HRNPQ_MACRO_SET_SEARCH_PATH(1),
                     HRNPQ_MACRO_SET_CLIENT_ENCODING(1),
                     HRNPQ_MACRO_VALIDATE_QUERY(1, PG_VERSION_84, "/pgdata", NULL, NULL),


### PR DESCRIPTION
In some rare cases there is no postgres database so this option may be used to specify an alternate database.