### PR TITLE
Add empty archive array to info command json when stanza missing.

### DIFF
--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -508,6 +508,7 @@ stanzaInfoList(const String *stanza, StringList *stanzaList, const String *backu
 
         kvPut(varKv(stanzaInfo), STANZA_KEY_DB_VAR, varNewVarLst(varLstNew()));
         kvPut(varKv(stanzaInfo), STANZA_KEY_BACKUP_VAR, varNewVarLst(varLstNew()));
+        kvPut(varKv(stanzaInfo), KEY_ARCHIVE_VAR, varNewVarLst(varLstNew()));
 
         stanzaStatus(
             INFO_STANZA_STATUS_CODE_MISSING_STANZA_PATH, INFO_STANZA_STATUS_MESSAGE_MISSING_STANZA_PATH_STR, false, stanzaInfo);

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -51,6 +51,7 @@ testRun(void)
             infoRender(),
             "["
                 "{"
+                    "\"archive\":[],"
                     "\"backup\":[],"
                     "\"db\":[],"
                     "\"name\":\"stanza1\","
@@ -1209,36 +1210,6 @@ testRun(void)
             "            backup reference list: 20181119-152138F, 20181119-152138F_20181119-152152D\n"
             "            database list: none\n",
             "text - backup set requested, no db and no checksum error");
-
-        // Stanza not found
-        //--------------------------------------------------------------------------------------------------------------------------
-        argList2 = strLstDup(argList);
-        strLstAddZ(argList2, "--stanza=silly");
-        harnessCfgLoad(cfgCmdInfo, argList2);
-        TEST_RESULT_STR_Z(
-            infoRender(),
-            "["
-                "{"
-                     "\"backup\":[],"
-                     "\"db\":[],"
-                     "\"name\":\"silly\","
-                     "\"status\":{"
-                        "\"code\":1,"
-                        "\"lock\":{\"backup\":{\"held\":false}},"
-                        "\"message\":\"missing stanza path\""
-                    "}"
-                "}"
-            "]",
-            "json - missing stanza path");
-
-        StringList *argListText2 = strLstDup(argListText);
-        strLstAddZ(argListText2, "--stanza=silly");
-        harnessCfgLoad(cfgCmdInfo, argListText2);
-        TEST_RESULT_STR_Z(
-            infoRender(),
-            "stanza: silly\n"
-            "    status: error (missing stanza path)\n",
-            "text - missing stanza path");
 
         // Stanza found
         //--------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
There is an inconsistency when the json is output for the case when a stanza is requested and it does not exist in the repo. This was the only case where the archive array was not added to the json. Adding it will simplify the upcoming multi-repo support code.

Also, a redundant test was removed rather than updating it for this case. 