### PR TITLE
Fix stack overflow in cipher passphrase generation.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -14,6 +14,18 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.33dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="bsiara"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix stack overflow in cipher passphrase generation.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-development-list>
                     <release-item>
                         <commit subject="Enhance expire command multi-repo support."/>
@@ -9065,6 +9077,11 @@
         <contributor id="bruno.friedmann">
             <contributor-name-display>Bruno Friedmann</contributor-name-display>
             <contributor-id type="github">tigerfoot</contributor-id>
+        </contributor>
+
+        <contributor id="bsiara">
+            <contributor-name-display>bsiara</contributor-name-display>
+            <contributor-id type="github">bsiara</contributor-id>
         </contributor>
 
         <contributor id="camilo.aguilar">

--- a/src/command/stanza/common.c
+++ b/src/command/stanza/common.c
@@ -27,8 +27,10 @@ cipherPassGen(CipherType cipherType)
     if (cipherType != cipherTypeNone)
     {
         unsigned char buffer[48]; // 48 is the amount of entropy needed to get a 64 base key
+        char cipherPassSubChar[65];
+        ASSERT(encodeToStrSize(encodeBase64, sizeof(buffer)) + 1 == sizeof(cipherPassSubChar));
+
         cryptoRandomBytes(buffer, sizeof(buffer));
-        char cipherPassSubChar[64];
         encodeToStr(encodeBase64, buffer, sizeof(buffer), cipherPassSubChar);
         result = strNew(cipherPassSubChar);
     }


### PR DESCRIPTION
The destination buffer on the stack was not large enough to contain the zero-terminating character.

Increase the buffer size and add an assertion to prevent regressions.

Found on arm64 running musl libc. Other architectures and glibc do not seem to be affected though it is clearly a bug.