### PR TITLE
Fix option warnings breaking async archive-get/archive-push.

### DIFF
--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -1108,8 +1108,8 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
         if (config->paramList != NULL && !config->help && !parseRuleCommand[config->command].parameterAllowed)
             THROW(ParamInvalidError, "command does not allow parameters");
 
-        // Enable logging (except for local and remote commands) so config file warnings will be output
-        if (config->commandRole != cfgCmdRoleLocal && config->commandRole != cfgCmdRoleRemote && resetLogLevel)
+        // Enable logging for default commands so config file warnings will be output
+        if (config->commandRole == cfgCmdRoleDefault && resetLogLevel)
             logInit(logLevelWarn, logLevelWarn, logLevelOff, false, 0, 1, false);
 
         // Only continue if command options need to be validated, i.e. a real command is running or we are getting help for a


### PR DESCRIPTION
Option warnings will cause the async process to fail because a warning is logged but stdout is closed so the process aborts.

This bug has existed for quite some time, but it was made worse by abb8ebe because now the async role can have different valid options than the default role. Previously at least a warning would be emitted before the async process died.

Fix this by only allowing warnings for the default role. Warnings were already suppressed for local and remote roles so the logic already exists.