### PR TITLE
Dockerfile - To run everywhere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+RUN    apt-get update && \
+       apt-get upgrade -y && \
+       apt-get install -y rsync git devscripts build-essential valgrind lcov autoconf \
+       autoconf-archive libssl-dev zlib1g-dev libxml2-dev libpq-dev pkg-config \
+       libxml-checker-perl libyaml-perl libdbd-pg-perl liblz4-dev liblz4-tool \
+       zstd libzstd-dev bzip2 libbz2-dev
+
+WORKDIR /pgbackrest
+
+ADD . /pgbackrest
+
+RUN cd /pgbackrest/src && \
+       ./configure && \
+       make && \
+       mv /pgbackrest/src/pgbackrest /usr/bin/pgbackrest && \
+       chmod 755 /usr/bin/pgbackrest
+
+ENTRYPOINT [ "/usr/bin/pgbackrest" ]
+


### PR DESCRIPTION
As many of the libraries are dynamically linked, it might not be possible to run a binary on system where there's no distribution's package manager is bundling everything together. In such scenarios, this docker file would be helpful and would make this utility accessible on a wider range of systems.

I tried to statically link the whole binary and use the docker `scratch` image to reduce the size but compilation failed. Moving the binary alone into an empty image also fails because there are dependencies on external libraries.

To build, from root of the git repo:
```
docker build -t pgbackrest .
```
And to run:
```
docker run -it --rm pgbackrest
```
Or you can make an alias like so:

```
alias pgbackrest='docker run -it --rm pgrest'

# Now it just works as if a normal binary:
pgbackrest version
```
Hope this is useful. Looking forward to feedback/adjustments.
