### PR TITLE
Fix repo-ls / on S3 repositories.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -45,6 +45,16 @@
 
                         <p>Fix stack overflow in cipher passphrase generation.</p>
                     </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="lesovsky.alexey"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix <cmd>repo-ls</cmd> <id>/</id> on <proper>S3</proper> repositories.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-feature-list>
@@ -9521,6 +9531,11 @@
         <contributor id="leonardo.gg.avellar">
             <contributor-name-display>Leonardo GG Avellar</contributor-name-display>
             <contributor-id type="github">L30Bola</contributor-id>
+        </contributor>
+
+        <contributor id="lesovsky.alexey">
+            <contributor-name-display>Lesovsky Alexey</contributor-name-display>
+            <contributor-id type="github">lesovsky</contributor-id>
         </contributor>
 
         <contributor id="lev.kokotov">

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -673,8 +673,13 @@ storageS3Info(THIS_VOID, const String *file, StorageInfoLevel level, StorageInte
     {
         const HttpHeader *httpHeader = httpResponseHeader(httpResponse);
 
-        result.size = cvtZToUInt64(strZ(httpHeaderGet(httpHeader, HTTP_HEADER_CONTENT_LENGTH_STR)));
-        result.timeModified = httpDateToTime(httpHeaderGet(httpHeader, HTTP_HEADER_LAST_MODIFIED_STR));
+        const String *const contentLength = httpHeaderGet(httpHeader, HTTP_HEADER_CONTENT_LENGTH_STR);
+        CHECK(contentLength != NULL);
+        result.size = cvtZToUInt64(strZ(contentLength));
+
+        const String *const lastModified = httpHeaderGet(httpHeader, HTTP_HEADER_LAST_MODIFIED_STR);
+        CHECK(lastModified != NULL);
+        result.timeModified = httpDateToTime(lastModified);
     }
 
     FUNCTION_LOG_RETURN(STORAGE_INFO, result);

--- a/test/src/module/storage/azureTest.c
+++ b/test/src/module/storage/azureTest.c
@@ -476,6 +476,11 @@ testRun(void)
                 TEST_RESULT_VOID(storagePutP(write, BUFSTRDEF("12345678901234567890")), "write");
 
                 // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("info for / does not exist");
+
+                TEST_RESULT_BOOL(storageInfoP(storage, NULL, .ignoreMissing = true).exists, false, "info for /");
+
+                // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("info for missing file");
 
                 testRequestP(service, HTTP_VERB_HEAD, "/BOGUS");

--- a/test/src/module/storage/gcsTest.c
+++ b/test/src/module/storage/gcsTest.c
@@ -595,6 +595,11 @@ testRun(void)
                     strZ(hrnServerHost()));
 
                 // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("info for / does not exist");
+
+                TEST_RESULT_BOOL(storageInfoP(storage, NULL, .ignoreMissing = true).exists, false, "info for /");
+
+                // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("info for missing file");
 
                 testRequestP(service, HTTP_VERB_GET, .object = "BOGUS", .query = "fields=size%2Cupdated");

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -178,6 +178,11 @@ testRun(void)
             storageInfoP(storageTest, fileNoPerm), FileOpenError, STORAGE_ERROR_INFO ": [13] Permission denied", strZ(fileNoPerm));
 #endif // TEST_CONTAINER_REQUIRED
 
+        // -----------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("info for / exists");
+
+        TEST_RESULT_BOOL(storageInfoP(storagePosixNewP(FSLASH_STR), NULL).exists, true, "info for /");
+
         // -------------------------------------------------------------------------------------------------------------------------
         String *fileName = strNewFmt("%s/fileinfo", testPath());
 

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -734,6 +734,11 @@ testRun(void)
                 TEST_RESULT_BOOL(storageExistsP(s3, strNew("BOGUS")), false, "check");
 
                 // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("info for / does not exist");
+
+                TEST_RESULT_BOOL(storageInfoP(s3, NULL, .ignoreMissing = true).exists, false, "info for /");
+
+                // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("info for missing file");
 
                 // File missing


### PR DESCRIPTION
S3 returns 200 for HEAD / which indicates it is a file but does not return the expected headers which causes an error.

Rather than fix this for S3, just automatically return / as not existing for any storage that does not support paths.

Also add some defensive checks to prevent this from generating a segfault if it happens again.