### PR TITLE
Exclude content-length from S3 signed headers.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -102,6 +102,16 @@
 
                     <release-item>
                         <release-item-contributor-list>
+                            <release-item-ideator id="brian.p.bockelman"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Exclude <id>content-length</id> from <proper>S3</proper> signed headers.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                             <release-item-reviewer id="cynthia.shang"/>
                         </release-item-contributor-list>
 
@@ -9189,6 +9199,11 @@
         <contributor id="brian.faherty">
             <contributor-name-display>Brian Faherty</contributor-name-display>
             <contributor-id type="github">scrummyin</contributor-id>
+        </contributor>
+
+        <contributor id="brian.p.bockelman">
+            <contributor-name-display>Brian P Bockelman</contributor-name-display>
+            <contributor-id type="github">bbockelm</contributor-id>
         </contributor>
 
         <contributor id="brian.peterson">

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -34,9 +34,11 @@ Defaults
 /***********************************************************************************************************************************
 S3 HTTP headers
 ***********************************************************************************************************************************/
-STRING_STATIC(S3_HEADER_CONTENT_SHA256_STR,                         "x-amz-content-sha256");
-STRING_STATIC(S3_HEADER_DATE_STR,                                   "x-amz-date");
-STRING_STATIC(S3_HEADER_TOKEN_STR,                                  "x-amz-security-token");
+#define S3_HEADER_PREFIX                                            "x-amz-"
+    STRING_STATIC(S3_HEADER_PREFIX_STR,                             S3_HEADER_PREFIX);
+STRING_STATIC(S3_HEADER_CONTENT_SHA256_STR,                         S3_HEADER_PREFIX "content-sha256");
+STRING_STATIC(S3_HEADER_DATE_STR,                                   S3_HEADER_PREFIX "date");
+STRING_STATIC(S3_HEADER_TOKEN_STR,                                  S3_HEADER_PREFIX "security-token");
 
 /***********************************************************************************************************************************
 S3 query tokens
@@ -208,7 +210,7 @@ storageS3Auth(
 
             // Skip headers that do not require signing
             if (!strEq(headerKeyLower, HTTP_HEADER_HOST_STR) && !strEq(headerKeyLower, HTTP_HEADER_CONTENT_MD5_STR) &&
-                !strBeginsWithZ(headerKeyLower, "x-amz-"))
+                !strBeginsWith(headerKeyLower, S3_HEADER_PREFIX_STR))
                 continue;
 
             strCatFmt(canonicalRequest, "%s:%s\n", strZ(headerKeyLower), strZ(httpHeaderGet(httpHeader, headerKey)));

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -206,8 +206,9 @@ storageS3Auth(
             const String *headerKey = strLstGet(headerList, headerIdx);
             const String *headerKeyLower = strLower(strDup(headerKey));
 
-            // Skip the authorization header -- if it exists this is a retry
-            if (strEq(headerKeyLower, HTTP_HEADER_AUTHORIZATION_STR))
+            // Skip headers that do not require signing
+            if (!strEq(headerKeyLower, HTTP_HEADER_HOST_STR) && !strEq(headerKeyLower, HTTP_HEADER_CONTENT_MD5_STR) &&
+                !strBeginsWithZ(headerKeyLower, "x-amz-"))
                 continue;
 
             strCatFmt(canonicalRequest, "%s:%s\n", strZ(headerKeyLower), strZ(httpHeaderGet(httpHeader, headerKey)));

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -34,11 +34,9 @@ Defaults
 /***********************************************************************************************************************************
 S3 HTTP headers
 ***********************************************************************************************************************************/
-#define S3_HEADER_PREFIX                                            "x-amz-"
-    STRING_STATIC(S3_HEADER_PREFIX_STR,                             S3_HEADER_PREFIX);
-STRING_STATIC(S3_HEADER_CONTENT_SHA256_STR,                         S3_HEADER_PREFIX "content-sha256");
-STRING_STATIC(S3_HEADER_DATE_STR,                                   S3_HEADER_PREFIX "date");
-STRING_STATIC(S3_HEADER_TOKEN_STR,                                  S3_HEADER_PREFIX "security-token");
+STRING_STATIC(S3_HEADER_CONTENT_SHA256_STR,                         "x-amz-content-sha256");
+STRING_STATIC(S3_HEADER_DATE_STR,                                   "x-amz-date");
+STRING_STATIC(S3_HEADER_TOKEN_STR,                                  "x-amz-security-token");
 
 /***********************************************************************************************************************************
 S3 query tokens
@@ -208,9 +206,8 @@ storageS3Auth(
             const String *headerKey = strLstGet(headerList, headerIdx);
             const String *headerKeyLower = strLower(strDup(headerKey));
 
-            // Skip headers that do not require signing
-            if (!strEq(headerKeyLower, HTTP_HEADER_HOST_STR) && !strEq(headerKeyLower, HTTP_HEADER_CONTENT_MD5_STR) &&
-                !strBeginsWith(headerKeyLower, S3_HEADER_PREFIX_STR))
+            // Skip the authorization (exists on retry) and content-length headers since they do not need to be signed
+            if (strEq(headerKeyLower, HTTP_HEADER_AUTHORIZATION_STR) || strEq(headerKeyLower, HTTP_HEADER_CONTENT_LENGTH_STR))
                 continue;
 
             strCatFmt(canonicalRequest, "%s:%s\n", strZ(headerKeyLower), strZ(httpHeaderGet(httpHeader, headerKey)));

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -57,14 +57,13 @@ testRequest(IoWrite *write, Storage *s3, const char *verb, const char *path, Tes
     {
         strCatFmt(
             request,
-                "authorization:AWS4-HMAC-SHA256 Credential=%s/\?\?\?\?\?\?\?\?/us-east-1/s3/aws4_request,"
-                    "SignedHeaders=content-length",
-                param.accessKey == NULL ? strZ(driver->accessKey) : param.accessKey);
+            "authorization:AWS4-HMAC-SHA256 Credential=%s/\?\?\?\?\?\?\?\?/us-east-1/s3/aws4_request,SignedHeaders=",
+            param.accessKey == NULL ? strZ(driver->accessKey) : param.accessKey);
 
         if (param.content != NULL)
-            strCatZ(request, ";content-md5");
+            strCatZ(request, "content-md5;");
 
-        strCatZ(request, ";host;x-amz-content-sha256;x-amz-date");
+        strCatZ(request, "host;x-amz-content-sha256;x-amz-date");
 
         if (securityToken != NULL)
             strCatZ(request, ";x-amz-security-token");


### PR DESCRIPTION
The `content-length` header was being signed since it was the only header that didn't need to be and it seemed simpler just to sign it as well. However, some proxies munge this header causing authentication failure.