### PR TITLE
Use ac_default_prefix as default path for configuration on FreeBSD.

### DIFF
--- a/src/build/configure.ac
+++ b/src/build/configure.ac
@@ -18,6 +18,10 @@ AC_PROG_CC_C99
 AC_CANONICAL_HOST
 AC_SUBST(CFLAGS, "${CFLAGS} -std=c99")
 
+# default path for configuration file
+default_configdir="/etc"
+
+
 case $host_os in
     darwin*)
         AC_SUBST(CPPFLAGS, "${CPPFLAGS} -D_DARWIN_C_SOURCE")
@@ -26,6 +30,13 @@ case $host_os in
     linux*)
         AC_SUBST(CPPFLAGS, "${CPPFLAGS} -D_POSIX_C_SOURCE=200809L")
         ;;
+   freebsd*)
+   	  if (test "x${configdir}" = "x"); then
+        	default_configdir="${ac_default_prefix}/etc"
+	    else
+	        default_configdir="${configdir}"
+   	  fi
+    ;;
 esac
 
 # Check if the C compiler supports _Static_assert()
@@ -152,10 +163,12 @@ AC_CHECK_LIB(
 
 # Set configuration path
 # ----------------------------------------------------------------------------------------------------------------------------------
+
+
 AC_ARG_WITH(
     [configdir], [AS_HELP_STRING([--with-configdir=DIR], [default configuration path])],
     [AC_DEFINE_UNQUOTED([CFGOPTDEF_CONFIG_PATH], ["${withval}"])],
-    [AC_DEFINE_UNQUOTED([CFGOPTDEF_CONFIG_PATH], ["/etc/" PROJECT_BIN])])
+    [AC_DEFINE_UNQUOTED([CFGOPTDEF_CONFIG_PATH], ["${default_configdir}"])])
 
 # Write output
 # ----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
See #1363.

Modifies the `configure.ac` to regenerate `configure` to get the correct path for configuration path.

Tests the OS type, and in the case of FreeBSD sets a variable
to use when defining the default configuration file path.
This makes /usr/local/etc the path for FreeBSD, keeping /etc for Linux
and Darwin.
Tested on FreeBSD 12.2 and Fedora 33.

Since I've no experience in configuring and using autotools, this requires a review because I'm sure there is some AC macro to do this in a single pass.