### PR TITLE
Rename default command role to main.

### DIFF
--- a/build/lib/pgBackRestBuild/Config/BuildParse.pm
+++ b/build/lib/pgBackRestBuild/Config/BuildParse.pm
@@ -361,7 +361,7 @@ sub buildConfigParse
         #---------------------------------------------------------------------------------------------------------------------------
         my $strBuildSourceSub = "";
 
-        foreach my $strCommandRole (CFGCMD_ROLE_DEFAULT, CFGCMD_ROLE_ASYNC, CFGCMD_ROLE_LOCAL, CFGCMD_ROLE_REMOTE)
+        foreach my $strCommandRole (CFGCMD_ROLE_MAIN, CFGCMD_ROLE_ASYNC, CFGCMD_ROLE_LOCAL, CFGCMD_ROLE_REMOTE)
         {
             $strBuildSourceSub = "";
 

--- a/build/lib/pgBackRestBuild/Config/Data.pm
+++ b/build/lib/pgBackRestBuild/Config/Data.pm
@@ -37,9 +37,9 @@ use constant CFGCMD_VERSION                                         => 'version'
 # Command role constants - roles allowed for each command. Commands may have multiple processes that work together to implement
 # their functionality.  These roles allow each process to know what it is supposed to do.
 ####################################################################################################################################
-# Called directly by the user. This is the main part of the command that may or may not spawn other command roles.
-use constant CFGCMD_ROLE_DEFAULT                                    => 'default';
-    push @EXPORT, qw(CFGCMD_ROLE_DEFAULT);
+# Called directly by the user. This is the main process of the command that may or may not spawn other command roles.
+use constant CFGCMD_ROLE_MAIN                                       => 'main';
+    push @EXPORT, qw(CFGCMD_ROLE_MAIN);
 
 # Async worker that is spawned so the main process can return a result while work continues. An async worker may spawn local or
 # remote workers.
@@ -350,9 +350,9 @@ foreach my $strCommand (sort(keys(%{$rhCommandDefine})))
     }
 
     # All commands have the default role
-    if (!defined($rhCommandDefine->{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_DEFAULT}))
+    if (!defined($rhCommandDefine->{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_MAIN}))
     {
-        $rhCommandDefine->{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_DEFAULT} = {};
+        $rhCommandDefine->{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_MAIN} = {};
     }
 }
 

--- a/doc/lib/pgBackRestDoc/Common/DocConfig.pm
+++ b/doc/lib/pgBackRestDoc/Common/DocConfig.pm
@@ -225,7 +225,7 @@ sub process
 
             # Skip the option if it is not valid for this command and the default role. Only options valid for the default role are
             # show in help because that is the only role available to a user.
-            if (!defined($oOptionDefine->{$strOption}{&CFGDEF_COMMAND}{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_DEFAULT}))
+            if (!defined($oOptionDefine->{$strOption}{&CFGDEF_COMMAND}{$strCommand}{&CFGDEF_COMMAND_ROLE}{&CFGCMD_ROLE_MAIN}))
             {
                 next;
             }

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -179,6 +179,8 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1410"/>
+
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>
                             <release-item-reviewer id="cynthia.shang"/>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -180,6 +180,15 @@
 
                     <release-item>
                         <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Rename default command role to main.</p>
+                    </release-item>
+
+                    <release-item>
+                        <release-item-contributor-list>
                             <release-item-contributor id="cynthia.shang"/>
                             <release-item-reviewer id="david.steele"/>
                         </release-item-contributor-list>

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -185,17 +185,17 @@ optionGroup:
 #         (B), else it will still error on the option (A).
 #
 # command-role:
-#   1) Define the command roles for a command. 'default' is valid for all commands and is therefore added programmatically.
+#   1) Define the command roles for a command. 'main' is valid for all commands and is therefore added programmatically.
 #
 #   2) Define the command roles for an option. If not defined, the option will be valid for all roles of all commands for which it
 #      is valid. If command roles are defined for the option, then they override the roles for all commands for which the option is
-#      valid. 'default' must be defined explicitly in this case. For example, if an option is only valid for the 'default' role and
-#      the async role for each command then command-role must list 'default' and 'async', meaning each command has a default role
+#      valid. 'main' must be defined explicitly in this case. For example, if an option is only valid for the 'main' role and
+#      the 'async' role for each command then command-role must list 'main' and 'async', meaning each command has a 'main' role
 #      so the option is valid for that role and for commands that have the 'async' role, it is also valid for the 'async' role of
 #      those commands.
 #
 #   3) Define the command roles for an option command override. If not defined, the option will be valid for all roles of the
-#      command or the roles specified by rule 2) above. 'default' must be defined explicitly in this case. If command roles are
+#      command or the roles specified by rule 2) above. 'main' must be defined explicitly in this case. If command roles are
 #      defined for the option command override, then they override command roles defined for the option (rule 2) above)
 #      and all roles defined for the command (rule 1) above).
 #
@@ -265,7 +265,7 @@ option:
     command:
       expire: {}
     command-role:
-      default: {}
+      main: {}
 
   force:
     type: boolean
@@ -282,7 +282,7 @@ option:
       stanza-delete: {}
       stop: {}
     command-role:
-      default: {}
+      main: {}
 
   online:
     type: boolean
@@ -293,7 +293,7 @@ option:
       stanza-create: {}
       stanza-upgrade: {}
     command-role:
-      default: {}
+      main: {}
 
   output:
     type: string
@@ -309,7 +309,7 @@ option:
           - text
           - json
     command-role:
-      default: {}
+      main: {}
 
   set:
     type: string
@@ -326,7 +326,7 @@ option:
         internal: true
         required: false
     command-role:
-      default: {}
+      main: {}
 
   stanza:
     type: string
@@ -369,7 +369,7 @@ option:
             - time
             - xid
     command-role:
-      default: {}
+      main: {}
 
   target-action:
     type: string
@@ -388,7 +388,7 @@ option:
             - time
             - xid
     command-role:
-      default: {}
+      main: {}
 
   target-exclusive:
     type: boolean
@@ -401,7 +401,7 @@ option:
             - time
             - xid
     command-role:
-      default: {}
+      main: {}
 
   target-timeline:
     type: string
@@ -417,7 +417,7 @@ option:
             - time
             - xid
     command-role:
-      default: {}
+      main: {}
 
   type:
     command:
@@ -439,7 +439,7 @@ option:
           - standby
         default: default
     command-role:
-      default: {}
+      main: {}
     type: string
 
   # Command-line only local/remote options
@@ -511,7 +511,7 @@ option:
       repo-get: {}
       repo-put: {}
     command-role:
-      default: {}
+      main: {}
 
   filter:
     type: string
@@ -519,7 +519,7 @@ option:
     command:
       repo-ls: {}
     command-role:
-      default: {}
+      main: {}
 
   ignore-missing:
     type: boolean
@@ -527,7 +527,7 @@ option:
     command:
       repo-get: {}
     command-role:
-      default: {}
+      main: {}
 
   raw:
     type: boolean
@@ -536,7 +536,7 @@ option:
       repo-get: {}
       repo-put: {}
     command-role:
-      default: {}
+      main: {}
 
   recurse:
     type: boolean
@@ -545,7 +545,7 @@ option:
       repo-ls: {}
       repo-rm: {}
     command-role:
-      default: {}
+      main: {}
 
   sort:
     type: string
@@ -557,7 +557,7 @@ option:
     command:
       repo-ls: {}
     command-role:
-      default: {}
+      main: {}
 
   # General options
   #---------------------------------------------------------------------------------------------------------------------------------
@@ -572,7 +572,7 @@ option:
       backup: {}
       check: {}
     command-role:
-      default: {}
+      main: {}
 
   buffer-size:
     section: global
@@ -630,7 +630,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   # Option is deprecated and should not be referenced outside of cfgLoadUpdateOption()
@@ -642,7 +642,7 @@ option:
       archive-push: {}
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   compress-level:
     section: global
@@ -652,7 +652,7 @@ option:
     command: compress
     command-role:
       async: {}
-      default: {}
+      main: {}
 
   compress-level-network:
     section: global
@@ -675,7 +675,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   compress-type:
@@ -691,7 +691,7 @@ option:
     command: compress
     command-role:
       async: {}
-      default: {}
+      main: {}
 
   db-timeout:
     section: global
@@ -720,7 +720,7 @@ option:
       backup: {}
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   io-timeout:
     section: global
@@ -745,7 +745,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   job-retry-interval:
@@ -807,7 +807,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
 
   protocol-timeout:
     section: global
@@ -863,7 +863,7 @@ option:
         internal: true
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   tcp-keep-alive-count:
@@ -971,7 +971,7 @@ option:
       archive-get: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
 
   archive-push-queue-max:
     section: global
@@ -982,7 +982,7 @@ option:
       archive-push: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
     deprecate:
       archive-queue-max: {}
 
@@ -1000,7 +1000,7 @@ option:
             - true
       check: {}
     command-role:
-      default: {}
+      main: {}
 
   archive-copy:
     section: global
@@ -1013,7 +1013,7 @@ option:
           list:
             - true
     command-role:
-      default: {}
+      main: {}
 
   archive-header-check:
     section: global
@@ -1022,7 +1022,7 @@ option:
     command:
       archive-push: {}
     command-role:
-      default: {}
+      main: {}
       async: {}
 
   archive-mode-check:
@@ -1033,7 +1033,7 @@ option:
       backup: {}
       check: {}
     command-role:
-      default: {}
+      main: {}
     depend:
       option: archive-check
       list:
@@ -1049,7 +1049,7 @@ option:
       stanza-create: {}
       stanza-upgrade: {}
     command-role:
-      default: {}
+      main: {}
 
   checksum-page:
     section: global
@@ -1058,7 +1058,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   exclude:
     section: global
@@ -1067,7 +1067,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   expire-auto:
     section: global
@@ -1076,7 +1076,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   manifest-save-threshold:
     section: global
@@ -1086,7 +1086,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   resume:
     section: global
@@ -1095,7 +1095,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   start-fast:
     section: global
@@ -1104,7 +1104,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   stop-auto:
     section: global
@@ -1113,7 +1113,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
 
   # Restore options
   #---------------------------------------------------------------------------------------------------------------------------------
@@ -1127,7 +1127,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   db-exclude:
     section: global
@@ -1136,7 +1136,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   db-include:
     section: global
@@ -1145,7 +1145,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   link-all:
     section: global
@@ -1154,7 +1154,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   link-map:
     section: global
@@ -1163,7 +1163,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   tablespace-map:
     section: global
@@ -1172,7 +1172,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   tablespace-map-all:
     section: global
@@ -1181,7 +1181,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
 
   recovery-option:
     section: global
@@ -1190,7 +1190,7 @@ option:
     command:
       restore: {}
     command-role:
-      default: {}
+      main: {}
     depend:
       option: type
       list:
@@ -1229,7 +1229,7 @@ option:
     command: pg-local
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     depend:
       option: pg-local
@@ -1252,7 +1252,7 @@ option:
       stanza-upgrade: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     depend:
       option: pg-host
@@ -1318,7 +1318,7 @@ option:
       stanza-upgrade: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   pg-path:
@@ -1391,7 +1391,7 @@ option:
       archive-get:
         command-role:
           async: {}
-          default: {}
+          main: {}
           local: {}
           remote: {}
       archive-push:
@@ -1399,41 +1399,41 @@ option:
           remote: {}
       backup:
         command-role:
-          default: {}
+          main: {}
           local: {}
       check:
         command-role:
           remote: {}
       expire:
         command-role:
-          default: {}
+          main: {}
       info:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-create:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-get:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-ls:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-put:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-rm:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       restore:
         command-role:
-          default: {}
+          main: {}
           local: {}
           remote: {}
       stanza-create:
@@ -1441,7 +1441,7 @@ option:
             remote: {}
       stanza-delete:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       stanza-upgrade:
         command-role:
@@ -1452,7 +1452,7 @@ option:
         command-role: {}
       verify:
         command-role:
-          default: {}
+          main: {}
           local: {}
           remote: {}
 
@@ -1564,7 +1564,7 @@ option:
     command:
       backup: {}
     command-role:
-      default: {}
+      main: {}
     deprecate:
       hardlink: {index: 1, reset: false}
 
@@ -1576,7 +1576,7 @@ option:
     command: repo-local
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     depend:
       option: repo-local
@@ -1607,7 +1607,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     depend:
       option: repo-host
@@ -1621,7 +1621,7 @@ option:
     command: repo-host-cmd
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     default: CFGOPTDEF_CONFIG_PATH "/" PROJECT_CONFIG_FILE
     default-literal: true
@@ -1651,7 +1651,7 @@ option:
     command: repo-host-cmd
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     depend:
       option: repo-host
@@ -1666,7 +1666,7 @@ option:
     command: repo-host-cmd
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
     default: pgbackrest
     depend:
@@ -1704,7 +1704,7 @@ option:
       verify: {}
     command-role:
       async: {}
-      default: {}
+      main: {}
       local: {}
 
   repo-path:
@@ -1726,7 +1726,7 @@ option:
       backup: {}
       expire: {}
     command-role:
-      default: {}
+      main: {}
     deprecate:
       retention-archive: {index: 1, reset: false}
 
@@ -1743,7 +1743,7 @@ option:
       backup: {}
       expire: {}
     command-role:
-      default: {}
+      main: {}
     deprecate:
       retention-archive-type: {index: 1, reset: false}
 
@@ -1757,7 +1757,7 @@ option:
       backup: {}
       expire: {}
     command-role:
-      default: {}
+      main: {}
     deprecate:
       retention-diff: {index: 1, reset: false}
 
@@ -1769,7 +1769,7 @@ option:
     allow-range: [1, 9999999]
     command: repo-retention-full-type
     command-role:
-      default: {}
+      main: {}
     deprecate:
       retention-full: {index: 1, reset: false}
 
@@ -1785,7 +1785,7 @@ option:
       backup: {}
       expire: {}
     command-role:
-      default: {}
+      main: {}
 
   repo-s3-bucket:
     section: global
@@ -1939,66 +1939,66 @@ option:
       archive-get:
         command-role:
           async: {}
-          default: {}
+          main: {}
           local: {}
           remote: {}
       archive-push:
         command-role:
           async: {}
-          default: {}
+          main: {}
           local: {}
           remote: {}
       backup:
         command-role:
-          default: {}
+          main: {}
           local: {}
       check:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       expire:
         command-role:
-          default: {}
+          main: {}
       info:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-create:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-get:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-ls:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-put:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       repo-rm:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       restore:
         command-role:
-          default: {}
+          main: {}
           local: {}
           remote: {}
       stanza-create:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       stanza-delete:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       stanza-upgrade:
         command-role:
-          default: {}
+          main: {}
           remote: {}
       start:
         command-role: {}
@@ -2006,7 +2006,7 @@ option:
         command-role: {}
       verify:
         command-role:
-          default: {}
+          main: {}
           local: {}
           remote: {}
     deprecate:

--- a/src/command/help/help.c
+++ b/src/command/help/help.c
@@ -397,7 +397,7 @@ helpRender(void)
 
                 for (unsigned int optionId = 0; optionId < CFG_OPTION_TOTAL; optionId++)
                 {
-                    if (cfgParseOptionValid(commandId, cfgCmdRoleDefault, optionId) && !optionData[optionId].internal)
+                    if (cfgParseOptionValid(commandId, cfgCmdRoleMain, optionId) && !optionData[optionId].internal)
                     {
                         const String *section = optionData[optionId].section;
 
@@ -500,7 +500,7 @@ helpRender(void)
                 }
 
                 // Error when option is not found or is invalid for the current command
-                if (!option.found || !cfgParseOptionValid(cfgCommand(), cfgCmdRoleDefault, option.id))
+                if (!option.found || !cfgParseOptionValid(cfgCommand(), cfgCmdRoleMain, option.id))
                     THROW_FMT(OptionInvalidError, "option '%s' is not valid for command '%s'", strZ(optionName), commandName);
 
                 // Output option summary and description. Add a warning for internal options.

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1532,7 +1532,7 @@ restoreRecoveryOption(unsigned int pgVersion)
                 VARSTR(
                     strNewFmt(
                         "%s %s %%f \"%%p\"", strZ(cfgExe()),
-                        strZ(strLstJoin(cfgExecParam(cfgCmdArchiveGet, cfgCmdRoleDefault, optionReplace, true, true), " ")))));
+                        strZ(strLstJoin(cfgExecParam(cfgCmdArchiveGet, cfgCmdRoleMain, optionReplace, true, true), " ")))));
         }
 
         // If recovery type is immediate

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -184,7 +184,7 @@ cfgCommandRoleNameParam(ConfigCommand commandId, ConfigCommandRole commandRoleId
 
     String *result = strNew(cfgCommandName(commandId));
 
-    if (commandRoleId != cfgCmdRoleDefault)
+    if (commandRoleId != cfgCmdRoleMain)
         strCatFmt(result, "%s%s", strZ(separator), strZ(cfgCommandRoleStr(commandRoleId)));
 
     FUNCTION_TEST_RETURN(result);
@@ -231,7 +231,7 @@ cfgCommandRoleEnum(const String *commandRole)
     FUNCTION_TEST_END();
 
     if (commandRole == NULL)
-        FUNCTION_TEST_RETURN(cfgCmdRoleDefault);
+        FUNCTION_TEST_RETURN(cfgCmdRoleMain);
     else if (strEq(commandRole, CONFIG_COMMAND_ROLE_ASYNC_STR))
         FUNCTION_TEST_RETURN(cfgCmdRoleAsync);
     else if (strEq(commandRole, CONFIG_COMMAND_ROLE_LOCAL_STR))
@@ -253,7 +253,7 @@ cfgCommandRoleStr(ConfigCommandRole commandRole)
 
     switch (commandRole)
     {
-        case cfgCmdRoleDefault:
+        case cfgCmdRoleMain:
             break;
 
         case cfgCmdRoleAsync:
@@ -292,8 +292,8 @@ cfgLockRequired(void)
 
     // Local roles never take a lock and the remote role has special logic for locking
     FUNCTION_TEST_RETURN(
-        // If a lock is required for the command and the role is default
-        (configCommandData[cfgCommand()].lockRequired && cfgCommandRole() == cfgCmdRoleDefault) ||
+        // If a lock is required for the command and the role is main
+        (configCommandData[cfgCommand()].lockRequired && cfgCommandRole() == cfgCmdRoleMain) ||
         // Or any command when the role is async
         cfgCommandRole() == cfgCmdRoleAsync);
 }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -21,8 +21,8 @@ what it is supposed to do.
 ***********************************************************************************************************************************/
 typedef enum
 {
-    // Called directly by the user.  This is the main part of the command that may or may not spawn other command roles.
-    cfgCmdRoleDefault = 0,
+    // Called directly by the user. This is the main process of the command that may or may not spawn other command roles.
+    cfgCmdRoleMain = 0,
 
     // Async worker that is spawned so the main process can return a result while work continues.  An async worker may spawn local
     // or remote workers.

--- a/src/config/load.c
+++ b/src/config/load.c
@@ -345,8 +345,8 @@ cfgLoadLogFile(void)
                     strCatFmt(logFile, "-async");
             }
 
-            // Add command role if it is not default
-            if (cfgCommandRole() != cfgCmdRoleDefault)
+            // Add command role if it is not main
+            if (cfgCommandRole() != cfgCmdRoleMain)
                 strCatFmt(logFile, "-%s", strZ(cfgCommandRoleStr(cfgCommandRole())));
 
             // Add process id if local or remote role

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -18,8 +18,8 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleAsync)
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleLocal)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -33,8 +33,8 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleAsync)
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleLocal)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -46,8 +46,8 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleLocal)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -59,7 +59,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -71,7 +71,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
         ),
     ),
 
@@ -83,7 +83,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
         ),
     ),
 
@@ -94,7 +94,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -106,7 +106,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -119,7 +119,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -132,7 +132,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -145,7 +145,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -158,7 +158,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -170,8 +170,8 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleLocal)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -183,7 +183,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -195,7 +195,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -207,7 +207,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -219,7 +219,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
         ),
     ),
 
@@ -230,7 +230,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
         ),
     ),
 
@@ -241,8 +241,8 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleLocal)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
             PARSE_RULE_COMMAND_ROLE(cfgCmdRoleRemote)
         ),
     ),
@@ -254,7 +254,7 @@ static const ParseRuleCommand parseRuleCommand[CFG_COMMAND_TOTAL] =
 
         PARSE_RULE_COMMAND_ROLE_VALID_LIST
         (
-            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleDefault)
+            PARSE_RULE_COMMAND_ROLE(cfgCmdRoleMain)
         ),
     ),
 };
@@ -290,7 +290,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -328,7 +328,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -359,7 +359,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -389,7 +389,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
         ),
@@ -414,7 +414,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
         ),
@@ -438,7 +438,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -463,7 +463,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -489,7 +489,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
         ),
@@ -513,7 +513,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -536,7 +536,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -558,7 +558,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -641,7 +641,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -655,7 +655,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoPut)
@@ -670,7 +670,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -718,7 +718,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
@@ -738,7 +738,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
@@ -763,7 +763,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -810,7 +810,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
@@ -844,7 +844,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -914,7 +914,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -984,7 +984,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1055,7 +1055,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -1070,7 +1070,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -1084,7 +1084,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1144,7 +1144,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
@@ -1164,7 +1164,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
         ),
@@ -1184,7 +1184,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -1198,7 +1198,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1263,7 +1263,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -1282,7 +1282,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoLs)
         ),
@@ -1296,7 +1296,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
@@ -1330,7 +1330,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoGet)
         ),
@@ -1349,7 +1349,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1418,7 +1418,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1471,7 +1471,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1524,7 +1524,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -1544,7 +1544,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -1558,7 +1558,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1613,7 +1613,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1694,7 +1694,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1775,7 +1775,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1856,7 +1856,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1926,7 +1926,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -1993,7 +1993,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2063,7 +2063,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -2083,7 +2083,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2151,7 +2151,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdStanzaCreate)
@@ -2172,7 +2172,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoLs)
@@ -2237,7 +2237,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2277,7 +2277,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2323,7 +2323,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2353,7 +2353,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2384,7 +2384,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2415,7 +2415,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2446,7 +2446,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2477,7 +2477,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2508,7 +2508,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2550,7 +2550,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2609,7 +2609,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2650,7 +2650,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2690,7 +2690,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpPg),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
@@ -2769,7 +2769,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2799,7 +2799,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -2867,7 +2867,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoPut)
@@ -2888,7 +2888,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -2916,7 +2916,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoLs)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoRm)
@@ -2982,7 +2982,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
@@ -3046,7 +3046,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3119,7 +3119,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3193,7 +3193,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3269,7 +3269,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3342,7 +3342,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3424,7 +3424,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3497,7 +3497,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3572,7 +3572,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3641,7 +3641,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3712,7 +3712,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3786,7 +3786,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3868,7 +3868,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -3889,7 +3889,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3944,7 +3944,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -3992,7 +3992,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4041,7 +4041,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4090,7 +4090,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4139,7 +4139,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4188,7 +4188,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4237,7 +4237,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4288,7 +4288,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4357,7 +4357,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
@@ -4379,7 +4379,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
@@ -4408,7 +4408,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
@@ -4430,7 +4430,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
@@ -4452,7 +4452,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
@@ -4480,7 +4480,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4553,7 +4553,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4627,7 +4627,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4701,7 +4701,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4774,7 +4774,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4855,7 +4855,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -4928,7 +4928,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5002,7 +5002,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5075,7 +5075,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5156,7 +5156,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5231,7 +5231,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5306,7 +5306,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5380,7 +5380,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5457,7 +5457,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5534,7 +5534,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_GROUP_MEMBER(true),
         PARSE_RULE_OPTION_GROUP_ID(cfgOptGrpRepo),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5610,7 +5610,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -5629,7 +5629,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5697,7 +5697,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5765,7 +5765,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdExpire)
             PARSE_RULE_OPTION_COMMAND(cfgCmdInfo)
@@ -5814,7 +5814,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRepoLs)
         ),
@@ -5840,7 +5840,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -5896,7 +5896,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -6020,7 +6020,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -6039,7 +6039,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
         ),
@@ -6059,7 +6059,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
         PARSE_RULE_OPTION_MULTI(true),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6073,7 +6073,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6087,7 +6087,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6117,7 +6117,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6157,7 +6157,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6188,7 +6188,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)
         ),
@@ -6222,7 +6222,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -6295,7 +6295,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -6368,7 +6368,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(false),
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchiveGet)
             PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
@@ -6441,7 +6441,7 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         PARSE_RULE_OPTION_REQUIRED(true),
         PARSE_RULE_OPTION_SECTION(cfgSectionCommandLine),
 
-        PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdRestore)

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -177,8 +177,8 @@ typedef enum
 #define PARSE_RULE_OPTION_GROUP_ID(groupIdParam)                                                                                   \
     .groupId = groupIdParam
 
-#define PARSE_RULE_OPTION_COMMAND_ROLE_DEFAULT_VALID_LIST(...)                                                                     \
-    .commandRoleValid[cfgCmdRoleDefault] = 0 __VA_ARGS__
+#define PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST(...)                                                                        \
+    .commandRoleValid[cfgCmdRoleMain] = 0 __VA_ARGS__
 
 #define PARSE_RULE_OPTION_COMMAND_ROLE_ASYNC_VALID_LIST(...)                                                                       \
     .commandRoleValid[cfgCmdRoleAsync] = 0 __VA_ARGS__
@@ -931,7 +931,7 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
 
                         // Try getting the command from the valid command list
                         config->command = cfgCommandId(command);
-                        config->commandRole = cfgCmdRoleDefault;
+                        config->commandRole = cfgCmdRoleMain;
 
                         // If not successful then a command role may be appended
                         if (config->command == cfgCmdNone)
@@ -1108,8 +1108,8 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
         if (config->paramList != NULL && !config->help && !parseRuleCommand[config->command].parameterAllowed)
             THROW(ParamInvalidError, "command does not allow parameters");
 
-        // Enable logging for default role so config file warnings will be output
-        if (resetLogLevel && config->commandRole == cfgCmdRoleDefault)
+        // Enable logging for main role so config file warnings will be output
+        if (resetLogLevel && config->commandRole == cfgCmdRoleMain)
             logInit(logLevelWarn, logLevelWarn, logLevelOff, false, 0, 1, false);
 
         // Only continue if command options need to be validated, i.e. a real command is running or we are getting help for a

--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,7 @@ main(int argListSize, const char *argList[])
                     {
                         // Switch to expire command
                         cmdEnd(0, NULL);
-                        cfgCommandSet(cfgCmdExpire, cfgCmdRoleDefault);
+                        cfgCommandSet(cfgCmdExpire, cfgCmdRoleMain);
                         cfgLoadLogFile();
                         cmdBegin();
 

--- a/test/src/common/harnessConfig.c
+++ b/test/src/common/harnessConfig.c
@@ -104,7 +104,7 @@ harnessCfgLoad(ConfigCommand commandId, const StringList *argListParam)
         FUNCTION_HARNESS_PARAM(STRING_LIST, argListParam);
     FUNCTION_HARNESS_END();
 
-    harnessCfgLoadRole(commandId, cfgCmdRoleDefault, argListParam);
+    harnessCfgLoadRole(commandId, cfgCmdRoleMain, argListParam);
 
     FUNCTION_HARNESS_RETURN_VOID();
 }

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -266,7 +266,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptPgHost, "host");
         hrnCfgArgRawZ(argList, cfgOptPgPath, "/pg");
         strLstAddZ(argList, "--" CFGOPT_STANZA "=test2");
-        harnessCfgLoadRole(cfgCmdArchivePush, cfgCmdRoleDefault, argList);
+        harnessCfgLoadRole(cfgCmdArchivePush, cfgCmdRoleMain, argList);
 
         TEST_ERROR(cmdArchivePush(), HostInvalidError, "archive-push command must be run on the PostgreSQL host");
 

--- a/test/src/module/command/commandTest.c
+++ b/test/src/module/command/commandTest.c
@@ -134,7 +134,7 @@ testRun(void)
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("switch to a new command so some options are not valid");
 
-        cfgCommandSet(cfgCmdArchiveGet, cfgCmdRoleDefault);
+        cfgCommandSet(cfgCmdArchiveGet, cfgCmdRoleMain);
 
         TEST_RESULT_VOID(cmdBegin(), "command begin");
         harnessLogResult(

--- a/test/src/module/common/exitTest.c
+++ b/test/src/module/common/exitTest.c
@@ -47,7 +47,7 @@ testRun(void)
     if (testBegin("exitSafe()"))
     {
         harnessCfgLoad(cfgCmdHelp, strLstNew());
-        cfgCommandSet(cfgCmdNone, cfgCmdRoleDefault);
+        cfgCommandSet(cfgCmdNone, cfgCmdRoleMain);
 
         TEST_RESULT_INT(exitSafe(0, false, signalTypeNone), 0, "exit with no command");
 

--- a/test/src/module/config/execTest.c
+++ b/test/src/module/config/execTest.c
@@ -41,7 +41,7 @@ testRun(void)
             "exec archive-get -> archive-get:async");
 
         TEST_RESULT_STRLST_Z(
-            cfgExecParam(cfgCmdBackup, cfgCmdRoleDefault, NULL, false, false),
+            cfgExecParam(cfgCmdBackup, cfgCmdRoleMain, NULL, false, false),
             "--archive-timeout=5\n--no-config\n--exec-id=1-test\n--log-subprocess\n--reset-neutral-umask\n"
                 "--pg1-path=" TEST_PATH "/db path\n--pg2-path=/db2\n--repo1-path=" TEST_PATH "/repo\n--stanza=test1\nbackup\n",
             "exec archive-get -> backup");
@@ -69,7 +69,7 @@ testRun(void)
         kvPut(optionReplace, VARSTRDEF(CFGOPT_LOG_PATH), VARSTRDEF("/log"));
 
         TEST_RESULT_STRLST_Z(
-            cfgExecParam(cfgCmdRestore, cfgCmdRoleDefault, optionReplace, true, false),
+            cfgExecParam(cfgCmdRestore, cfgCmdRoleMain, optionReplace, true, false),
             "--db-include=1\n--db-include=2\n--exec-id=1-test\n--log-path=/log\n--pg1-path=" TEST_PATH "/db path\n"
                 "--recovery-option=a=b\n--recovery-option=c=d\n--repo1-path=/replace/path\nrestore\n",
             "exec restore -> restore");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -1214,11 +1214,11 @@ testRun(void)
         TEST_RESULT_BOOL(cfgLogFile(), true, "    backup command does file logging");
         TEST_RESULT_BOOL(cfgLockRemoteRequired(), true, "    backup command requires remote lock");
         TEST_RESULT_STRLST_Z(cfgCommandParam(), NULL, "    check command arguments");
-        TEST_RESULT_UINT(cfgCommandRoleEnum(NULL), cfgCmdRoleDefault, "command role default enum");
+        TEST_RESULT_UINT(cfgCommandRoleEnum(NULL), cfgCmdRoleMain, "command role main enum");
         TEST_ERROR(cfgCommandRoleEnum(STRDEF("bogus")), CommandInvalidError, "invalid command role 'bogus'");
-        TEST_RESULT_INT(cfgCommandRole(), cfgCmdRoleDefault, "    command role is default");
+        TEST_RESULT_INT(cfgCommandRole(), cfgCmdRoleMain, "    command role is main");
         TEST_RESULT_STR_Z(cfgCommandRoleName(), "backup", "    command/role name is backup");
-        TEST_RESULT_STR_Z(cfgCommandRoleStr(cfgCmdRoleDefault), NULL, "    default role name is NULL");
+        TEST_RESULT_STR_Z(cfgCommandRoleStr(cfgCmdRoleMain), NULL, "    main role name is NULL");
 
         TEST_RESULT_STR_Z(cfgExe(), TEST_BACKREST_EXE, "    exe is set");
 


### PR DESCRIPTION
Main makes more sense because we refer to the main process in the code, not the default process. The word default is pretty overloaded anyway.