### PR TITLE
Clear error when a CATCH() block finishes.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -25,6 +25,17 @@
 
                         <p>Add support for more <code>Pack</code> types.</p>
                     </release-item>
+
+                    <release-item>
+                        <github-pull-request id="1427"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="cynthia.shang"/>
+                        </release-item-contributor-list>
+
+                        <p>Clear error when a <code>CATCH()</code> block finishes.</p>
+                    </release-item>
                 </release-development-list>
             </release-core-list>
 

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -297,6 +297,8 @@ errorInternalTry(const char *fileName, const char *functionName, int fileLine)
 void
 errorInternalPropagate(void)
 {
+    assert(errorContext.error.errorType != NULL);
+
     // Mark the error as uncaught
     errorContext.tryList[errorContext.tryTotal].uncaught = true;
 
@@ -327,6 +329,13 @@ errorInternalProcess(bool catch)
     {
         for (unsigned int handlerIdx = 0; handlerIdx < errorContext.handlerTotal; handlerIdx++)
             errorContext.handlerList[handlerIdx](errorTryDepth());
+    }
+
+    // !!!
+    if (errorContext.tryList[errorContext.tryTotal].state == errorStateCatch &&
+        !errorContext.tryList[errorContext.tryTotal].uncaught)
+    {
+        errorContext.error.errorType = NULL;
     }
 
     // Increment the state

--- a/src/common/error.c
+++ b/src/common/error.c
@@ -47,6 +47,16 @@ typedef enum {errorStateBegin, errorStateTry, errorStateCatch, errorStateFinal, 
 /***********************************************************************************************************************************
 Track error handling
 ***********************************************************************************************************************************/
+typedef struct Error
+{
+    const ErrorType *errorType;                                     // Error type
+    const char *fileName;                                           // Source file where the error occurred
+    const char *functionName;                                       // Function where the error occurred
+    int fileLine;                                                   // Source file line where the error occurred
+    const char *message;                                            // Description of the error
+    const char *stackTrace;                                         // Stack trace
+} Error;
+
 static struct
 {
     // Array of jump buffers
@@ -66,15 +76,7 @@ static struct
     } tryList[ERROR_TRY_MAX + 1];
 
     // Last error
-    struct
-    {
-        const ErrorType *errorType;                                     // Error type
-        const char *fileName;                                           // Source file where the error occurred
-        const char *functionName;                                       // Function where the error occurred
-        int fileLine;                                                   // Source file line where the error occurred
-        const char *message;                                            // Description of the error
-        const char *stackTrace;                                         // Stack trace
-    } error;
+    Error error;
 } errorContext;
 
 /***********************************************************************************************************************************
@@ -175,6 +177,8 @@ errorTypeExtends(const ErrorType *child, const ErrorType *parent)
 const ErrorType *
 errorType(void)
 {
+    assert(errorContext.error.errorType != NULL);
+
     return errorContext.error.errorType;
 }
 
@@ -189,6 +193,8 @@ errorCode(void)
 const char *
 errorFileName(void)
 {
+    assert(errorContext.error.fileName != NULL);
+
     return errorContext.error.fileName;
 }
 
@@ -196,6 +202,8 @@ errorFileName(void)
 const char *
 errorFunctionName(void)
 {
+    assert(errorContext.error.functionName != NULL);
+
     return errorContext.error.functionName;
 }
 
@@ -203,6 +211,8 @@ errorFunctionName(void)
 int
 errorFileLine(void)
 {
+    assert(errorContext.error.fileLine != 0);
+
     return errorContext.error.fileLine;
 }
 
@@ -210,6 +220,8 @@ errorFileLine(void)
 const char *
 errorMessage(void)
 {
+    assert(errorContext.error.message != NULL);
+
     return errorContext.error.message;
 }
 
@@ -224,6 +236,8 @@ errorName(void)
 const char *
 errorStackTrace(void)
 {
+    assert(errorContext.error.stackTrace != NULL);
+
     return errorContext.error.stackTrace;
 }
 
@@ -331,11 +345,11 @@ errorInternalProcess(bool catch)
             errorContext.handlerList[handlerIdx](errorTryDepth());
     }
 
-    // !!!
+    // Any catch blocks have been processed and none of them called RETHROW() so clear the error
     if (errorContext.tryList[errorContext.tryTotal].state == errorStateCatch &&
         !errorContext.tryList[errorContext.tryTotal].uncaught)
     {
-        errorContext.error.errorType = NULL;
+        errorContext.error = (Error){0};
     }
 
     // Increment the state

--- a/src/common/error.h
+++ b/src/common/error.h
@@ -80,7 +80,7 @@ const ErrorType *errorTypeParent(const ErrorType *errorType);
 bool errorTypeExtends(const ErrorType *child, const ErrorType *parent);
 
 /***********************************************************************************************************************************
-Functions to get information about the current error
+Functions to get information about the current error within a CATCH() block. Invalid outside a CATCH() block.
 ***********************************************************************************************************************************/
 // Error type
 const ErrorType *errorType(void);

--- a/src/common/memContext.c
+++ b/src/common/memContext.c
@@ -826,58 +826,48 @@ memContextFree(MemContext *this)
         // freeing so the parent needs to remain active until they are all gone.
         this->state = memContextStateFreeing;
 
-        // Execute callback if defined
-        bool rethrow = false;
-
-        if (this->callbackFunction)
+        // !!! Execute callback if defined
+        TRY_BEGIN()
         {
-            TRY_BEGIN()
-            {
+            if (this->callbackFunction)
                 this->callbackFunction(this->callbackArgument);
-            }
-            CATCH_ANY()
+        }
+        FINALLY()
+        {
+            // Free child context allocations
+            if (this->contextChildListSize > 0)
             {
-                rethrow = true;
+                for (unsigned int contextIdx = 0; contextIdx < this->contextChildListSize; contextIdx++)
+                    if (this->contextChildList[contextIdx])
+                        memFreeInternal(this->contextChildList[contextIdx]);
+
+                memFreeInternal(this->contextChildList);
+                this->contextChildListSize = 0;
             }
-            TRY_END();
+
+            // Free memory allocations
+            if (this->allocListSize > 0)
+            {
+                for (unsigned int allocIdx = 0; allocIdx < this->allocListSize; allocIdx++)
+                    if (this->allocList[allocIdx] != NULL)
+                        memFreeInternal(this->allocList[allocIdx]);
+
+                memFreeInternal(this->allocList);
+                this->allocListSize = 0;
+            }
+
+            // If the context index is lower than the current free index in the parent then replace it
+            if (this->contextParent != NULL && this->contextParentIdx < this->contextParent->contextChildFreeIdx)
+                this->contextParent->contextChildFreeIdx = this->contextParentIdx;
+
+            // Make top context active again
+            if (this == &contextTop)
+                this->state = memContextStateActive;
+            // Else reset the memory context so it can be reused
+            else
+                *this = (MemContext){.state = memContextStateFree};
         }
-
-        // Free child context allocations
-        if (this->contextChildListSize > 0)
-        {
-            for (unsigned int contextIdx = 0; contextIdx < this->contextChildListSize; contextIdx++)
-                if (this->contextChildList[contextIdx])
-                    memFreeInternal(this->contextChildList[contextIdx]);
-
-            memFreeInternal(this->contextChildList);
-            this->contextChildListSize = 0;
-        }
-
-        // Free memory allocations
-        if (this->allocListSize > 0)
-        {
-            for (unsigned int allocIdx = 0; allocIdx < this->allocListSize; allocIdx++)
-                if (this->allocList[allocIdx] != NULL)
-                    memFreeInternal(this->allocList[allocIdx]);
-
-            memFreeInternal(this->allocList);
-            this->allocListSize = 0;
-        }
-
-        // If the context index is lower than the current free index in the parent then replace it
-        if (this->contextParent != NULL && this->contextParentIdx < this->contextParent->contextChildFreeIdx)
-            this->contextParent->contextChildFreeIdx = this->contextParentIdx;
-
-        // Make top context active again
-        if (this == &contextTop)
-            this->state = memContextStateActive;
-        // Else reset the memory context so it can be reused
-        else
-            *this = (MemContext){.state = memContextStateFree};
-
-        // Rethrow the error that was caught in the callback
-        if (rethrow)
-            RETHROW();
+        TRY_END();
     }
 
     FUNCTION_TEST_RETURN_VOID();

--- a/src/common/memContext.c
+++ b/src/common/memContext.c
@@ -826,12 +826,13 @@ memContextFree(MemContext *this)
         // freeing so the parent needs to remain active until they are all gone.
         this->state = memContextStateFreeing;
 
-        // !!! Execute callback if defined
+        // Execute callback if defined
         TRY_BEGIN()
         {
             if (this->callbackFunction)
                 this->callbackFunction(this->callbackArgument);
         }
+        // Finish cleanup even if the callback fails
         FINALLY()
         {
             // Free child context allocations

--- a/src/main.c
+++ b/src/main.c
@@ -61,10 +61,12 @@ main(int argListSize, const char *argList[])
     // Initialize statistics collector
     statInit();
 
-    volatile int result = 0;
-
     // Initialize exit handler
     exitInit();
+
+    // Process commands
+    volatile int result = 0;
+    volatile bool error = false;
 
     TRY_BEGIN()
     {
@@ -248,9 +250,10 @@ main(int argListSize, const char *argList[])
     }
     CATCH_ANY()
     {
+        error = true;
         result = exitSafe(result, true, 0);
     }
     TRY_END();
 
-    FUNCTION_LOG_RETURN(INT, result > 1 ? result : exitSafe(result, false, 0));
+    FUNCTION_LOG_RETURN(INT, error ? result : exitSafe(result, false, 0));
 }

--- a/src/main.c
+++ b/src/main.c
@@ -61,8 +61,7 @@ main(int argListSize, const char *argList[])
     // Initialize statistics collector
     statInit();
 
-    volatile bool result = 0;
-    volatile bool error = false;
+    volatile int result = 0;
 
     // Initialize exit handler
     exitInit();
@@ -249,9 +248,9 @@ main(int argListSize, const char *argList[])
     }
     CATCH_ANY()
     {
-        error = true;
+        result = exitSafe(result, true, 0);
     }
     TRY_END();
 
-    FUNCTION_LOG_RETURN(INT, exitSafe(result, error, 0));
+    FUNCTION_LOG_RETURN(INT, result > 1 ? result : exitSafe(result, false, 0));
 }

--- a/test/src/module/common/errorTest.c
+++ b/test/src/module/common/errorTest.c
@@ -187,6 +187,7 @@ testRun(void)
         TRY_END();
 
         assert(errorTryDepth() == 0);
+        assert(errorType() == NULL);
 
         assert(tryDone);
         assert(catchDone);
@@ -230,6 +231,8 @@ testRun(void)
             finallyDone = true;
         }
         TRY_END();
+
+        assert(errorType() == NULL);
 
         assert(tryDone);
         assert(catchDone);

--- a/test/src/module/common/errorTest.c
+++ b/test/src/module/common/errorTest.c
@@ -187,7 +187,7 @@ testRun(void)
         TRY_END();
 
         assert(errorTryDepth() == 0);
-        assert(errorType() == NULL);
+        assert(memcmp(&errorContext.error, &(Error){0}, sizeof(Error)) == 0);
 
         assert(tryDone);
         assert(catchDone);
@@ -232,7 +232,7 @@ testRun(void)
         }
         TRY_END();
 
-        assert(errorType() == NULL);
+        assert(memcmp(&errorContext.error, &(Error){0}, sizeof(Error)) == 0);
 
         assert(tryDone);
         assert(catchDone);


### PR DESCRIPTION
It is better to clear errors after the catch block completes rather than leave them set until the next error. This also make is possible to tell when a error is currently being handled, which a function further down the stack might use to modify its behavior. Currently this is only useful in testing, but clearing the error seems like a good idea in general.

Two places used errors outside the CATCH() block. Mem context cleanup now uses a FINALLY() which is a better implementation anyway. The error handling in main() now calls exitSafe() from withing the CATCH() block.