### PR TITLE
Fix detection of circular symlinks.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -14,6 +14,21 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.35dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <github-issue id="1447"/>
+                        <github-pull-request id="1452"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="rohit.raveendran"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix detection of circular symlinks.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-improvement-list>
                     <release-item>
                         <github-issue id="1445"/>
@@ -10280,6 +10295,11 @@
         <contributor id="rakshitha.br">
             <contributor-name-display>Rakshitha-BR</contributor-name-display>
             <contributor-id type="github">Rakshitha-BR</contributor-id>
+        </contributor>
+
+        <contributor id="rohit.raveendran">
+            <contributor-name-display>Rohit Raveendran</contributor-name-display>
+            <contributor-id type="github">rohitrav33ndran</contributor-id>
         </contributor>
 
         <contributor id="ronan.dunklau">

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -987,7 +987,7 @@ manifestBuildCallback(void *data, const StorageInfo *info)
                 buildData.storagePg, linkPgPath, .followLink = true, .ignoreMissing = true);
             linkedInfo.name = linkName;
 
-            // If the link destination exists then proceed as usual
+            // If the link destination exists then build the target
             if (linkedInfo.exists)
             {
                 // If a path link then recurse
@@ -1005,9 +1005,6 @@ manifestBuildCallback(void *data, const StorageInfo *info)
                     target.path = strPath(info->linkDestination);
                     target.file = strBase(info->linkDestination);
                 }
-
-                // Use the callback to add and do all related checks
-                manifestBuildCallback(&buildData, &linkedInfo);
             }
             // Else dummy up the target with a destination so manifestLinkCheck() can be run.  This is so errors about links with
             // destinations in PGDATA will take precedence over missing a destination.  We will probably simplify this once the
@@ -1025,6 +1022,9 @@ manifestBuildCallback(void *data, const StorageInfo *info)
             // If the link check was successful but the destination does not exist then check it again to generate an error
             if (!linkedInfo.exists)
                 storageInfoP(buildData.storagePg, linkPgPath, .followLink = true);
+
+            // Recurse into the link destination
+            manifestBuildCallback(&buildData, &linkedInfo);
 
             break;
         }

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -702,6 +702,18 @@ testRun(void)
             "check manifest");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("error on circular link");
+
+        THROW_ON_SYS_ERROR(symlink(TEST_PATH "/wal", TEST_PATH "/wal/wal") == -1, FileOpenError, "unable to create symlink");
+
+        TEST_ERROR(
+            manifestNewBuild(storagePg, PG_VERSION_92, hrnPgCatalogVersion(PG_VERSION_92), false, false, NULL, NULL),
+            LinkDestinationError,
+            "link 'pg_xlog/wal' (" TEST_PATH "/wal) destination is the same directory as link 'pg_xlog' (" TEST_PATH "/wal)");
+
+        HRN_STORAGE_REMOVE(storageTest, TEST_PATH "/wal/wal");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("manifest with all features - 9.4, checksum-page");
 
         // Version


### PR DESCRIPTION
Links were followed before they were checked for validity so a circular link would send the manifest build into endless recursion leading to a crash. Fix by moving the recursion after the link check.

Note that this issue has existed since the C migration and was not introduced by the refactor in eba013b4.