### PR TITLE
Automatically create data directory on restore.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -25,7 +25,7 @@
                             <release-item-reviewer id="david.steele"/>
                         </release-item-contributor-list>
 
-                        <p>Automatically create data directories on restore.</p>
+                        <p>Automatically create data directories on <cmd>restore</cmd>.</p>
                     </release-item>
                 </release-improvement-list>
 

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -25,7 +25,7 @@
                             <release-item-reviewer id="david.steele"/>
                         </release-item-contributor-list>
 
-                        <p>Automatically create data directories on <cmd>restore</cmd>.</p>
+                        <p>Automatically create data directory on <cmd>restore</cmd>.</p>
                     </release-item>
                 </release-improvement-list>
 

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -14,6 +14,21 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.35dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-improvement-list>
+                    <release-item>
+                        <github-issue id="1445"/>
+                        <github-pull-request id="1454"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="chris.bandy"/>
+                            <release-item-contributor id="stefan.fercot"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Automatically create data directories on restore.</p>
+                    </release-item>
+                </release-improvement-list>
+
                 <release-development-list>
                     <release-item>
                         <github-pull-request id="1424"/>
@@ -9764,6 +9779,11 @@
 
         <contributor id="chiranjeevi.ravilla">
             <contributor-name-display>Chiranjeevi Ravilla</contributor-name-display>
+        </contributor>
+
+        <contributor id="chris.bandy">
+            <contributor-name-display>Chris Bandy</contributor-name-display>
+            <contributor-id type="github">cbandy</contributor-id>
         </contributor>
 
         <contributor id="chris.barber">

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -59,11 +59,6 @@ restorePathValidate(void)
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        // The PGDATA directory must exist
-        // ??? We should remove this requirement in a separate commit.  What's the harm in creating the dir assuming we have perms?
-        if (!storagePathExistsP(storagePg(), NULL))
-            THROW_FMT(PathMissingError, "$PGDATA directory '%s' does not exist", strZ(cfgOptionDisplay(cfgOptPgPath)));
-
         // PostgreSQL must not be running
         if (storageExistsP(storagePg(), PG_FILE_POSTMASTERPID_STR))
         {

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1898,7 +1898,6 @@ testRun(void)
             manifestPathAdd(
                 manifest,
                 &(ManifestPath){.name = MANIFEST_TARGET_PGDATA_STR, .mode = 0700, .group = groupName(), .user = userName()});
-            storagePathCreateP(storagePgWrite(), NULL);
 
             // Global directory
             manifestPathAdd(
@@ -1998,7 +1997,6 @@ testRun(void)
             "P00   INFO: repo2: restore backup set 20161219-212741F\n"
             "P00 DETAIL: check '" TEST_PATH "/pg' exists\n"
             "P00 DETAIL: check '" TEST_PATH "/ts/1' exists\n"
-            "P00 DETAIL: update mode for '" TEST_PATH "/pg' to 0700\n"
             "P00 DETAIL: create path '" TEST_PATH "/pg/global'\n"
             "P00 DETAIL: create path '" TEST_PATH "/pg/pg_tblspc'\n"
             "P00 DETAIL: create symlink '" TEST_PATH "/pg/pg_tblspc/1' to '" TEST_PATH "/ts/1'\n"
@@ -2043,6 +2041,9 @@ testRun(void)
         hrnCfgArgKeyRawStrId(argList, cfgOptRepoCipherType, 2, cipherTypeAes256Cbc);
         hrnCfgEnvKeyRawZ(cfgOptRepoCipherPass, 2, TEST_CIPHER_PASS);
         HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        // Munge PGDATA mode so it gets fixed
+        HRN_STORAGE_MODE(storagePg(), NULL, 0777);
 
         // Store backup.info to repo1 - repo1 will be selected because of the priority order
         HRN_INFO_PUT(storageRepoIdxWrite(0), INFO_BACKUP_PATH_FILE, TEST_RESTORE_BACKUP_INFO "\n" TEST_RESTORE_BACKUP_INFO_DB);
@@ -2115,6 +2116,7 @@ testRun(void)
             "P00 DETAIL: check '" TEST_PATH "/pg' exists\n"
             "P00 DETAIL: check '" TEST_PATH "/ts/1' exists\n"
             "P00   INFO: remove invalid files/links/paths from '" TEST_PATH "/pg'\n"
+            "P00 DETAIL: update mode for '" TEST_PATH "/pg' to 0700\n"
             "P00 DETAIL: remove invalid file '" TEST_PATH "/pg/bogus-file'\n"
             "P00 DETAIL: remove link '" TEST_PATH "/pg/pg_tblspc/1' because destination changed\n"
             "P00 DETAIL: remove special file '" TEST_PATH "/pg/pipe'\n"

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -331,21 +331,13 @@ testRun(void)
         const String *repoPath = STRDEF(TEST_PATH "/repo");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error on data directory missing");
+        TEST_TITLE("error when pg appears to be running");
 
         StringList *argList = strLstNew();
         strLstAddZ(argList, "--stanza=test1");
         strLstAdd(argList, strNewFmt("--repo1-path=%s", strZ(repoPath)));
         strLstAdd(argList, strNewFmt("--pg1-path=%s", strZ(pgPath)));
         HRN_CFG_LOAD(cfgCmdRestore, argList);
-
-        TEST_ERROR(restorePathValidate(), PathMissingError, "$PGDATA directory '" TEST_PATH "/pg' does not exist");
-
-        // Create PGDATA
-        storagePathCreateP(storagePgWrite(), NULL);
-
-        // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error when pg appears to be running");
 
         storagePutP(storageNewWriteP(storagePgWrite(), STRDEF("postmaster.pid")), NULL);
 


### PR DESCRIPTION
As mentioned in issue #1445, the restore command creates restore paths (including pgdata) if they don't already exist. Removing this protection will improve user experience since we also set the path mode.

```
$ pgbackrest/test/test.pl --vm-build --vm=f32
$ pgbackrest/test/test.pl --vm-out --dev --module=command --test=restore --coverage-only --vm=f32
2021-07-08 07:55:26.110 P00   INFO: P1-T1/1 - vm=f32, module=command, test=restore (13.55s)
2021-07-08 07:55:26.644 P00   INFO: tested modules have full coverage
2021-07-08 07:55:26.645 P00   INFO: writing C coverage report
2021-07-08 07:55:26.818 P00   INFO: TESTS COMPLETED SUCCESSFULLY (15s)
```