### PR TITLE
Update command/control and command/command tests to use standard patterns.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -144,6 +144,9 @@
                         <commit subject="Update command/archive tests to use standard patterns.">
                             <github-pull-request id="1449"/>
                         </commit>
+                        <commit subject="Update command/control and command/command tests to use standard patterns.">
+                            <github-pull-request id="1456"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="cynthia.shang"/>

--- a/test/src/module/command/commandTest.c
+++ b/test/src/module/command/commandTest.c
@@ -74,17 +74,19 @@ testRun(void)
 
         TEST_RESULT_VOID(cmdBegin(), "command begin");
 
-        #define RESULT_OPTION                                                                                                      \
-             " --no-config --db-include=db1 --db-include=db2 --exec-id=1-test --pg1-path=/pg1 --pg2-path=/pg2"                     \
-             " --recovery-option=standby_mode=on --recovery-option=primary_conninfo=blah --repo1-cipher-pass=<redacted>"           \
-             " --repo1-cipher-type=aes-256-cbc --reset-repo1-host --repo1-path=\"/path/to the/repo\" --stanza=test"
-
-        TEST_RESULT_LOG("P00   INFO: restore command begin " PROJECT_VERSION ":" RESULT_OPTION);
+        TEST_RESULT_LOG(
+            "P00   INFO: restore command begin " PROJECT_VERSION ": --no-config --db-include=db1 --db-include=db2 --exec-id=1-test"
+            " --pg1-path=/pg1 --pg2-path=/pg2 --recovery-option=standby_mode=on --recovery-option=primary_conninfo=blah"
+            " --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --reset-repo1-host --repo1-path=\"/path/to the/repo\""
+            " --stanza=test");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("check options in cache");
 
-        TEST_RESULT_STR_Z(cmdOption(), RESULT_OPTION, "option cache");
+        TEST_RESULT_STR_Z(
+            cmdOption(), " --no-config --db-include=db1 --db-include=db2 --exec-id=1-test --pg1-path=/pg1 --pg2-path=/pg2"
+            " --recovery-option=standby_mode=on --recovery-option=primary_conninfo=blah --repo1-cipher-pass=<redacted>"
+            " --repo1-cipher-type=aes-256-cbc --reset-repo1-host --repo1-path=\"/path/to the/repo\" --stanza=test", "option cache");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("command begin does not log when level is too low");

--- a/test/src/module/command/controlTest.c
+++ b/test/src/module/command/controlTest.c
@@ -98,16 +98,15 @@ testRun(void)
 
         TEST_RESULT_VOID(cmdStop(), "no stanza, stop file already exists");
         TEST_RESULT_LOG("P00   WARN: stop file already exists for all stanzas");
-        HRN_STORAGE_REMOVE(hrnStorage, "lock/all" STOP_FILE_EXT, .errorOnMissing = true, .comment = "remove stop file");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("stop file error");
 
+        HRN_STORAGE_REMOVE(hrnStorage, "lock/all" STOP_FILE_EXT, .errorOnMissing = true, .comment = "remove stop file");
         HRN_STORAGE_MODE(hrnStorage, "lock", .mode = 0444);
         TEST_ERROR(
             cmdStop(), FileOpenError, "unable to get info for path/file '" HRN_PATH "/lock/all.stop': [13] Permission denied");
-        HRN_STORAGE_MODE(hrnStorage, "lock", .comment = "reset lock path mode to default");
-        HRN_STORAGE_PATH_REMOVE(hrnStorage, "lock", .recurse = true, .errorOnMissing = true, .comment = "remove the lock path");
+        HRN_STORAGE_MODE(hrnStorage, "lock", .mode = 0700);
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("stanza stop file create");
@@ -115,8 +114,11 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptStanza, "db");
         HRN_CFG_LOAD(cfgCmdStop, argList);
 
+        HRN_STORAGE_PATH_REMOVE(hrnStorage, "lock", .recurse = true, .errorOnMissing = true, .comment = "remove the lock path");
         TEST_RESULT_VOID(cmdStop(), "stanza, create stop file");
-        TEST_STORAGE_LIST(hrnStorage, "lock", "db" STOP_FILE_EXT "\n", .comment = "only stanza stop exists in lock path");
+        TEST_STORAGE_LIST(
+            hrnStorage, "lock", "db" STOP_FILE_EXT "\n",
+            .comment = "lock path and file created, only stanza stop exists in lock path");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("stanza stop file already exists");


### PR DESCRIPTION
In the commandTest the HRN_STORAGE_REMOVE replacement uses .errorOnMissing when the code being tested added the file. The reason for this is 3 fold:

1. to ensure that an inadvertent typo in the path/file name does not go undetected,
2. to ensure that nothing else has removed the file prior to the call, and
3. consistency

Also, added "stanza" to comment when a stanza stop file is removed vs an "all" stop file.