### PR TITLE
Fix links and update child process example.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ Examples of test runs are provided in the following sections. There are several 
 
 - `--vm-out` - displays the test output (helpful for monitoring the progress)
 
-- `--vm` - identifies the pre-built container when using Docker, otherwise the setting should be `none`. See [test.yml](https://github.com/pgbackrest/pgbackrest/blob/master.github/workflows/test.yml) for a list of valid vm codes noted by `param: test`.
+- `--vm` - identifies the pre-built container when using Docker, otherwise the setting should be `none`. See [test.yml](https://github.com/pgbackrest/pgbackrest/blob/master/.github/workflows/test.yml) for a list of valid vm codes noted by `param: test`.
 
 For more options, run the test or documentation engine with the `--help` option:
 ```
@@ -244,12 +244,12 @@ pgbackrest/test/test.pl --vm=none --dry-run
     P00   INFO: test begin on x86_64 - log level info
     P00   INFO: configure build
     P00   INFO: builds required: bin
---> P00   INFO: 72 tests selected
+--> P00   INFO: 73 tests selected
                 
-    P00   INFO: P1-T01/72 - vm=none, module=common, test=error
-           [filtered 69 lines of output]
-    P00   INFO: P1-T71/72 - vm=none, module=performance, test=type
-    P00   INFO: P1-T72/72 - vm=none, module=performance, test=storage
+    P00   INFO: P1-T01/73 - vm=none, module=common, test=error
+           [filtered 70 lines of output]
+    P00   INFO: P1-T72/73 - vm=none, module=performance, test=type
+    P00   INFO: P1-T73/73 - vm=none, module=performance, test=storage
 --> P00   INFO: DRY RUN COMPLETED SUCCESSFULLY
 ```
 
@@ -471,14 +471,20 @@ HRN_FORK_BEGIN()
             lockAcquire(cfgOptionStr(cfgOptLockPath), STRDEF("stanza1"), STRDEF("999-ffffffff"), lockTypeBackup, 0, true),
             -1, "create backup/expire lock");
 
-        sleepMSec(1000);
+        // Notify parent that lock has been acquired
+        HRN_FORK_CHILD_NOTIFY_PUT();
+
+        // Wait for parent to allow release lock
+        HRN_FORK_CHILD_NOTIFY_GET();
+
         lockRelease(true);
     }
     HRN_FORK_CHILD_END();
 
     HRN_FORK_PARENT_BEGIN()
     {
-        sleepMSec(250);
+        // Wait for child to acquire lock
+        HRN_FORK_PARENT_NOTIFY_GET(0);
 
         HRN_CFG_LOAD(cfgCmdInfo, argListText);
         TEST_RESULT_STR_Z(
@@ -491,6 +497,8 @@ HRN_FORK_BEGIN()
             "        wal archive min/max (9.4): none present\n",
             "text - single stanza, no valid backups, backup/expire lock detected");
 
+        // Notify child to release lock
+        HRN_FORK_PARENT_NOTIFY_PUT(0);
     }
     HRN_FORK_PARENT_END();
 }
@@ -574,7 +582,7 @@ There are detailed comment blocks above each section that explain the rules for 
 
 The `option:` section is broken into sub-sections by a simple comment divider (e.g. `# Repository options`) under which the options are organized alphabetically by option name. To better explain this section, two hypothetical examples will be discussed. For more details, see [config.yaml](https://github.com/pgbackrest/pgbackrest/blob/master/src/build/config/config.yaml).
 
-#### Example 1: hypothetical command line only option 
+#### EXAMPLE 1 hypothetical command line only option
 ```
 set:
     type: string
@@ -607,7 +615,7 @@ Note that `section:` is not present thereby making this a command-line only opti
 
 - `command-role` - defines the processes for which the option is valid. `main` indicates the option will be used by the main process and not be passed on to other local/remote processes.
 
-#### Example 2: hypothetical configuration file option
+#### EXAMPLE 2 hypothetical configuration file option
 ```
 repo-test-type:
     section: global
@@ -628,7 +636,7 @@ repo-test-type:
 - `repo-test-type` - the name of the option
 
 
-- `section` - the section of the configuration file where this option is valid (omitted for command line only options, see [Example 1](#example-1-hypothetical-command-line-only-option-) above)
+- `section` - the section of the configuration file where this option is valid (omitted for command line only options, see [Example 1](#example-1-hypothetical-command-line-only-option) above)
 
 
 - `type` - the type of the option. Valid values for types are: `boolean`, `hash`, `integer`, `list`, `path`, `size`, `string`, and `time`
@@ -637,7 +645,7 @@ repo-test-type:
 - `group` - indicates that this option is part of the `repo` group of indexed options and therefore will follow the indexing rules e.g. `repo1-test-type`.
 
 
-- `default` - sets a default for the option if the option is not provided when the command is run. The default can be global (as it is here) or it can be specified for a specific command in the command section (as in [Example 1](#example-1-hypothetical-command-line-only-option-) above).
+- `default` - sets a default for the option if the option is not provided when the command is run. The default can be global (as it is here) or it can be specified for a specific command in the command section (as in [Example 1](#example-1-hypothetical-command-line-only-option) above).
 
 
 - `allow-list` - lists the allowable values for the option for all commands for which the option is valid.

--- a/doc/xml/contributing.xml
+++ b/doc/xml/contributing.xml
@@ -328,7 +328,7 @@ myObjToLog(const MyObj *this)
                 <list-item><setting>--test</setting> - the actual test set to be run</list-item>
                 <list-item><setting>--run</setting> - a number identifying the run within a test if testing a single run rather than the entire test</list-item>
                 <list-item><setting>--vm-out</setting> - displays the test output (helpful for monitoring the progress)</list-item>
-                <list-item><setting>--vm</setting> - identifies the pre-built container when using Docker, otherwise the setting should be <code>none</code>. See <link url="{[github-url-master]}.github/workflows/test.yml">test.yml</link> for a list of valid vm codes noted by <code>param: test</code>.</list-item>
+                <list-item><setting>--vm</setting> - identifies the pre-built container when using Docker, otherwise the setting should be <code>none</code>. See <link url="{[github-url-master]}/.github/workflows/test.yml">test.yml</link> for a list of valid vm codes noted by <code>param: test</code>.</list-item>
             </list>
 
             <p>For more options, run the test or documentation engine with the <setting>--help</setting> option:</p>
@@ -518,14 +518,20 @@ HRN_FORK_BEGIN()
             lockAcquire(cfgOptionStr(cfgOptLockPath), STRDEF("stanza1"), STRDEF("999-ffffffff"), lockTypeBackup, 0, true),
             -1, "create backup/expire lock");
 
-        sleepMSec(1000);
+        // Notify parent that lock has been acquired
+        HRN_FORK_CHILD_NOTIFY_PUT();
+
+        // Wait for parent to allow release lock
+        HRN_FORK_CHILD_NOTIFY_GET();
+
         lockRelease(true);
     }
     HRN_FORK_CHILD_END();
 
     HRN_FORK_PARENT_BEGIN()
     {
-        sleepMSec(250);
+        // Wait for child to acquire lock
+        HRN_FORK_PARENT_NOTIFY_GET(0);
 
         HRN_CFG_LOAD(cfgCmdInfo, argListText);
         TEST_RESULT_STR_Z(
@@ -538,6 +544,8 @@ HRN_FORK_BEGIN()
             "        wal archive min/max (9.4): none present\n",
             "text - single stanza, no valid backups, backup/expire lock detected");
 
+        // Notify child to release lock
+        HRN_FORK_PARENT_NOTIFY_PUT(0);
     }
     HRN_FORK_PARENT_END();
 }
@@ -638,7 +646,7 @@ run 8/1 ------------- L2285 no current backups
             <p>The <id>option:</id> section is broken into sub-sections by a simple comment divider (e.g. <code># Repository options</code>) under which the options are organized alphabetically by option name. To better explain this section, two hypothetical examples will be discussed. For more details, see <link url="{[github-url-src]}/build/config/config.yaml">config.yaml</link>.</p>
 
             <section id="option-ex1">
-                <title>Example 1: hypothetical command line only option </title>
+                <title>EXAMPLE 1 hypothetical command line only option</title>
 
                 <code-block>
   set:
@@ -672,7 +680,7 @@ run 8/1 ------------- L2285 no current backups
             </list>
 
             <section id="option-ex2">
-                <title>Example 2: hypothetical configuration file option</title>
+                <title>EXAMPLE 2 hypothetical configuration file option</title>
 
                 <code-block>
   repo-test-type:

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -177,7 +177,12 @@
 
                 <release-improvement-list>
                     <release-item>
-                        <github-pull-request id="1469"/>
+                        <commit subject="Update contributing documentation and add pull request template.">
+                            <github-pull-request id="1469"/>
+                        </commit>
+                        <commit subject="Fix links and update child process example.">
+                            <github-pull-request id="1487"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="cynthia.shang"/>


### PR DESCRIPTION
Removed colon from example titles to fix links, fixed test.yml link and updated the example for the parent/child test process to use latest macros instead of sleeps.
