### PR TITLE
Add recovery start time to online backup restore log.

### DIFF
--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -2225,9 +2225,21 @@ cmdRestore(void)
         // Validate the manifest
         restoreManifestValidate(jobData.manifest, backupData.backupSet);
 
-        // Log the backup set to restore
-        LOG_INFO_FMT(
+        // Log the backup set to restore. If the backup was online then append the time recovery will start from.
+        String *const message = strNewFmt(
             "repo%u: restore backup set %s", cfgOptionGroupIdxToKey(cfgOptGrpRepo, backupData.repoIdx), strZ(backupData.backupSet));
+
+        if (manifestData(jobData.manifest)->backupOptionOnline)
+        {
+            struct tm timePart;
+            char timeBuffer[20];
+            time_t backupTimestampStart = manifestData(jobData.manifest)->backupTimestampStart;
+
+            strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %H:%M:%S", localtime_r(&backupTimestampStart, &timePart));
+            strCatFmt(message, ", recovery will start at %s", timeBuffer);
+        }
+
+        LOG_INFO(strZ(message));
 
         // Map manifest
         restoreManifestMap(jobData.manifest);

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -153,6 +153,9 @@ testRun(void)
     // Create default storage object for testing
     Storage *storageTest = storagePosixNewP(TEST_PATH_STR, .write = true);
 
+    // The tests expect the timezone to be UTC
+    setenv("TZ", "UTC", true);
+
     // *****************************************************************************************************************************
     if (testBegin("restoreFile()"))
     {

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -153,9 +153,6 @@ testRun(void)
     // Create default storage object for testing
     Storage *storageTest = storagePosixNewP(TEST_PATH_STR, .write = true);
 
-    // The tests expect the timezone to be UTC
-    setenv("TZ", "UTC", true);
-
     // *****************************************************************************************************************************
     if (testBegin("restoreFile()"))
     {
@@ -2634,6 +2631,8 @@ testRun(void)
         manifest->pub.data.backupOptionOnline = true;
         manifest->pub.data.backupTimestampStart = 1482182958;
 
+        hrnLogReplaceAdd("[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}", NULL, "TIME", false);
+
         manifestSave(
             manifest,
             storageWriteIo(
@@ -2643,7 +2642,7 @@ testRun(void)
         TEST_RESULT_VOID(cmdRestore(), "successful restore");
 
         TEST_RESULT_LOG(
-            "P00   INFO: repo2: restore backup set 20161219-212741F_20161219-212918I, recovery will start at 2016-12-19 21:29:18\n"
+            "P00   INFO: repo2: restore backup set 20161219-212741F_20161219-212918I, recovery will start at [TIME]\n"
             "P00   INFO: map link 'pg_hba.conf' to '../config/pg_hba.conf'\n"
             "P00   INFO: map link 'pg_wal' to '../wal'\n"
             "P00   INFO: map link 'postgresql.conf' to '../config/postgresql.conf'\n"

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -2627,10 +2627,20 @@ testRun(void)
         // Write recovery.conf so we don't get a preserve warning
         HRN_STORAGE_PUT_Z(storagePgWrite(), PG_FILE_RECOVERYCONF, "Some Settings");
 
+        // Update the manifest with online = true to test recovery start time logging
+        manifest->pub.data.backupOptionOnline = true;
+        manifest->pub.data.backupTimestampStart = 1482182958;
+
+        manifestSave(
+            manifest,
+            storageWriteIo(
+                storageNewWriteP(storageRepoWrite(),
+                STRDEF(STORAGE_REPO_BACKUP "/" TEST_LABEL "/" BACKUP_MANIFEST_FILE))));
+
         TEST_RESULT_VOID(cmdRestore(), "successful restore");
 
         TEST_RESULT_LOG(
-            "P00   INFO: repo2: restore backup set 20161219-212741F_20161219-212918I\n"
+            "P00   INFO: repo2: restore backup set 20161219-212741F_20161219-212918I, recovery will start at 2016-12-19 21:29:18\n"
             "P00   INFO: map link 'pg_hba.conf' to '../config/pg_hba.conf'\n"
             "P00   INFO: map link 'pg_wal' to '../wal'\n"
             "P00   INFO: map link 'postgresql.conf' to '../config/postgresql.conf'\n"


### PR DESCRIPTION
This helps give an idea of how much recovery needs to be done to reach the end of the WAL stream.