### PR TITLE
Rename page checksum error to error list in info text output.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -29,7 +29,7 @@
                     </release-item>
 
                     <release-item>
-                        <github-pull-request id="1434"/>
+                        <github-pull-request id="1519"/>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -29,6 +29,17 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1434"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Rename page checksum error to error list in info text output.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="1434"/>
 
                         <release-item-contributor-list>

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -35,7 +35,7 @@ VARIANT_STRDEF_STATIC(ARCHIVE_KEY_MAX_VAR,                          "max");
 VARIANT_STRDEF_STATIC(BACKREST_KEY_FORMAT_VAR,                      "format");
 VARIANT_STRDEF_STATIC(BACKREST_KEY_VERSION_VAR,                     "version");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_BACKREST_VAR,                      "backrest");
-VARIANT_STRDEF_STATIC(BACKUP_KEY_FILE_ERROR_VAR,                    "file-error");
+VARIANT_STRDEF_STATIC(BACKUP_KEY_ERROR_LIST_VAR,                    "error-list");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_DATABASE_REF_VAR,                  "database-ref");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_INFO_VAR,                          "info");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_LABEL_VAR,                         "label");
@@ -522,7 +522,7 @@ backupListAdd(
         }
 
         kvPut(
-            varKv(backupInfo), BACKUP_KEY_FILE_ERROR_VAR,
+            varKv(backupInfo), BACKUP_KEY_ERROR_LIST_VAR,
             (!varLstEmpty(checksumPageErrorList) ? varNewVarLst(checksumPageErrorList) : NULL));
 
         manifestFree(repoData->manifest);
@@ -898,11 +898,11 @@ formatTextBackup(const DbGroup *dbGroup, String *resultStr)
             strCat(resultStr, LF_STR);
         }
 
-        if (kvGet(backupInfo, BACKUP_KEY_FILE_ERROR_VAR) != NULL)
+        if (kvGet(backupInfo, BACKUP_KEY_ERROR_LIST_VAR) != NULL)
         {
-            StringList *checksumPageErrorList = strLstNewVarLst(varVarLst(kvGet(backupInfo, BACKUP_KEY_FILE_ERROR_VAR)));
+            StringList *checksumPageErrorList = strLstNewVarLst(varVarLst(kvGet(backupInfo, BACKUP_KEY_ERROR_LIST_VAR)));
 
-            strCatFmt(resultStr, "            file errors: %s\n", strZ(strLstJoin(checksumPageErrorList, ", ")));
+            strCatFmt(resultStr, "            error list: %s\n", strZ(strLstJoin(checksumPageErrorList, ", ")));
         }
     }
 

--- a/src/command/info/info.c
+++ b/src/command/info/info.c
@@ -35,7 +35,7 @@ VARIANT_STRDEF_STATIC(ARCHIVE_KEY_MAX_VAR,                          "max");
 VARIANT_STRDEF_STATIC(BACKREST_KEY_FORMAT_VAR,                      "format");
 VARIANT_STRDEF_STATIC(BACKREST_KEY_VERSION_VAR,                     "version");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_BACKREST_VAR,                      "backrest");
-VARIANT_STRDEF_STATIC(BACKUP_KEY_CHECKSUM_PAGE_ERROR_VAR,           "checksum-page-error");
+VARIANT_STRDEF_STATIC(BACKUP_KEY_FILE_ERROR_VAR,                    "file-error");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_DATABASE_REF_VAR,                  "database-ref");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_INFO_VAR,                          "info");
 VARIANT_STRDEF_STATIC(BACKUP_KEY_LABEL_VAR,                         "label");
@@ -510,7 +510,7 @@ backupListAdd(
             varKv(backupInfo), BACKUP_KEY_TABLESPACE_VAR,
             (!varLstEmpty(tablespaceSection) ? varNewVarLst(tablespaceSection) : NULL));
 
-        // Get the list of files with an error in the page checksum
+        // Get the list of files with an error
         VariantList *checksumPageErrorList = varLstNew();
 
         for (unsigned int fileIdx = 0; fileIdx < manifestFileTotal(repoData->manifest); fileIdx++)
@@ -522,7 +522,7 @@ backupListAdd(
         }
 
         kvPut(
-            varKv(backupInfo), BACKUP_KEY_CHECKSUM_PAGE_ERROR_VAR,
+            varKv(backupInfo), BACKUP_KEY_FILE_ERROR_VAR,
             (!varLstEmpty(checksumPageErrorList) ? varNewVarLst(checksumPageErrorList) : NULL));
 
         manifestFree(repoData->manifest);
@@ -898,14 +898,11 @@ formatTextBackup(const DbGroup *dbGroup, String *resultStr)
             strCat(resultStr, LF_STR);
         }
 
-        if (kvGet(backupInfo, BACKUP_KEY_CHECKSUM_PAGE_ERROR_VAR) != NULL)
+        if (kvGet(backupInfo, BACKUP_KEY_FILE_ERROR_VAR) != NULL)
         {
-            StringList *checksumPageErrorList = strLstNewVarLst(
-                varVarLst(kvGet(backupInfo, BACKUP_KEY_CHECKSUM_PAGE_ERROR_VAR)));
+            StringList *checksumPageErrorList = strLstNewVarLst(varVarLst(kvGet(backupInfo, BACKUP_KEY_FILE_ERROR_VAR)));
 
-            strCatFmt(
-                resultStr, "            page checksum error: %s\n",
-                strZ(strLstJoin(checksumPageErrorList, ", ")));
+            strCatFmt(resultStr, "            file errors: %s\n", strZ(strLstJoin(checksumPageErrorList, ", ")));
         }
     }
 

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -1594,7 +1594,7 @@ testRun(void)
             "            tablespaces:\n"
             "                ts1 (1) => /tblspc/ts1\n"
             "                ts12 (12) => /tblspc/ts12\n"
-            "            page checksum error: base/16384/17000\n",
+            "            file errors: base/16384/17000\n",
             "text - backup set requested");
 
         //--------------------------------------------------------------------------------------------------------------------------
@@ -1628,7 +1628,7 @@ testRun(void)
             "            tablespaces:\n"
             "                ts1 (1) => /tblspc/ts1\n"
             "                ts12 (12) => /tblspc/ts12\n"
-            "            page checksum error: base/16384/17000\n",
+            "            file errors: base/16384/17000\n",
             "text - multi-repo, backup set requested, found on repo2, report stanza and db over all repos");
 
         //--------------------------------------------------------------------------------------------------------------------------
@@ -1701,7 +1701,7 @@ testRun(void)
             "            repo1: backup set size: 2.3MB, backup size: 346B\n"
             "            backup reference list: 20181119-152138F, 20181119-152138F_20181119-152152D\n"
             "            database list: mail (16456), postgres (12173)\n"
-            "            page checksum error: base/16384/17000, base/32768/33000\n",
+            "            file errors: base/16384/17000, base/32768/33000\n",
             "text - backup set requested, no links");
 
         //--------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/command/infoTest.c
+++ b/test/src/module/command/infoTest.c
@@ -1594,7 +1594,7 @@ testRun(void)
             "            tablespaces:\n"
             "                ts1 (1) => /tblspc/ts1\n"
             "                ts12 (12) => /tblspc/ts12\n"
-            "            file errors: base/16384/17000\n",
+            "            error list: base/16384/17000\n",
             "text - backup set requested");
 
         //--------------------------------------------------------------------------------------------------------------------------
@@ -1628,7 +1628,7 @@ testRun(void)
             "            tablespaces:\n"
             "                ts1 (1) => /tblspc/ts1\n"
             "                ts12 (12) => /tblspc/ts12\n"
-            "            file errors: base/16384/17000\n",
+            "            error list: base/16384/17000\n",
             "text - multi-repo, backup set requested, found on repo2, report stanza and db over all repos");
 
         //--------------------------------------------------------------------------------------------------------------------------
@@ -1701,7 +1701,7 @@ testRun(void)
             "            repo1: backup set size: 2.3MB, backup size: 346B\n"
             "            backup reference list: 20181119-152138F, 20181119-152138F_20181119-152152D\n"
             "            database list: mail (16456), postgres (12173)\n"
-            "            file errors: base/16384/17000, base/32768/33000\n",
+            "            error list: base/16384/17000, base/32768/33000\n",
             "text - backup set requested, no links");
 
         //--------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
"file error" makes it clear that other errors may be reported. If checksum-page is true in the manifest but no checksum-page-error list is provided then the error is in alignment, i.e. the file size is not a multiple of the page size, with allowances made for a valid-looking partial page at the end of the file.