### PR TITLE
Use cfgOptionStrId() instead of cfgOptionStr() where appropriate.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -21,6 +21,9 @@
                         <commit subject="Simplify strIdFrom*() functions.">
                             <github-pull-request id="1551"/>
                         </commit>
+                        <commit subject="Use cfgOptionStrId() instead of cfgOptionStr() where appropriate.">
+                            <github-pull-request id="1554"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -413,7 +413,7 @@ cmdArchivePush(void)
                 // Push the file to the archive
                 ArchivePushFileResult fileResult = archivePushFile(
                     walFile, cfgOptionBool(cfgOptArchiveHeaderCheck), archiveInfo.pgVersion, archiveInfo.pgSystemId, archiveFile,
-                    compressTypeEnum(cfgOptionStr(cfgOptCompressType)), cfgOptionInt(cfgOptCompressLevel), archiveInfo.repoList,
+                    compressTypeEnum(cfgOptionStrId(cfgOptCompressType)), cfgOptionInt(cfgOptCompressLevel), archiveInfo.repoList,
                     archiveInfo.errorList);
 
                 // If a warning was returned then log it
@@ -526,7 +526,7 @@ cmdArchivePushAsync(void)
         ArchivePushAsyncData jobData =
         {
             .walPath = strLstGet(commandParam, 0),
-            .compressType = compressTypeEnum(cfgOptionStr(cfgOptCompressType)),
+            .compressType = compressTypeEnum(cfgOptionStrId(cfgOptCompressType)),
             .compressLevel = cfgOptionInt(cfgOptCompressLevel),
         };
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -368,7 +368,7 @@ backupBuildIncrPrior(const InfoBackup *infoBackup)
                     strZ(manifestData(result)->backrestVersion));
 
                 // Warn if compress-type option changed
-                if (compressTypeEnum(cfgOptionStr(cfgOptCompressType)) != manifestPriorData->backupOptionCompressType)
+                if (compressTypeEnum(cfgOptionStrId(cfgOptCompressType)) != manifestPriorData->backupOptionCompressType)
                 {
                     LOG_WARN_FMT(
                         "%s backup cannot alter " CFGOPT_COMPRESS_TYPE " option to '%s', reset to value in %s",
@@ -701,7 +701,8 @@ backupResumeFind(const Manifest *manifest, const String *cipherPassBackup)
                             }
                             // Check compression. Compression can't be changed between backups so resume won't work either.
                             else if (
-                                manifestResumeData->backupOptionCompressType != compressTypeEnum(cfgOptionStr(cfgOptCompressType)))
+                                manifestResumeData->backupOptionCompressType !=
+                                    compressTypeEnum(cfgOptionStrId(cfgOptCompressType)))
                             {
                                 reason = strNewFmt(
                                     "new compression '%s' does not match resumable compression '%s'",
@@ -777,7 +778,7 @@ backupResume(Manifest *manifest, const String *cipherPassBackup)
             {
                 .manifest = manifest,
                 .manifestResume = manifestResume,
-                .compressType = compressTypeEnum(cfgOptionStr(cfgOptCompressType)),
+                .compressType = compressTypeEnum(cfgOptionStrId(cfgOptCompressType)),
                 .delta = cfgOptionBool(cfgOptDelta),
                 .backupPath = strNewFmt(STORAGE_REPO_BACKUP "/%s", strZ(manifestData(manifest)->backupLabel)),
             };
@@ -902,7 +903,7 @@ backupFilePut(BackupData *backupData, Manifest *manifest, const String *name, ti
         {
             // Create file
             const String *manifestName = strNewFmt(MANIFEST_TARGET_PGDATA "/%s", strZ(name));
-            CompressType compressType = compressTypeEnum(cfgOptionStr(cfgOptCompressType));
+            CompressType compressType = compressTypeEnum(cfgOptionStrId(cfgOptCompressType));
 
             StorageWrite *write = storageNewWriteP(
                 storageRepoWrite(),
@@ -1648,7 +1649,7 @@ backupProcess(BackupData *backupData, Manifest *manifest, const String *lsnStart
         {
             .backupLabel = backupLabel,
             .backupStandby = backupStandby,
-            .compressType = compressTypeEnum(cfgOptionStr(cfgOptCompressType)),
+            .compressType = compressTypeEnum(cfgOptionStrId(cfgOptCompressType)),
             .compressLevel = cfgOptionInt(cfgOptCompressLevel),
             .cipherType = cfgOptionStrId(cfgOptRepoCipherType),
             .cipherSubPass = manifestCipherSubPass(manifest),
@@ -1844,7 +1845,7 @@ backupArchiveCheckCopy(Manifest *manifest, unsigned int walSegmentSize, const St
 
                         // Get compression type of the WAL segment and backup
                         CompressType archiveCompressType = compressTypeFromName(archiveFile);
-                        CompressType backupCompressType = compressTypeEnum(cfgOptionStr(cfgOptCompressType));
+                        CompressType backupCompressType = compressTypeEnum(cfgOptionStrId(cfgOptCompressType));
 
                         // Open the archive file
                         StorageRead *read = storageNewReadP(
@@ -1886,7 +1887,7 @@ backupArchiveCheckCopy(Manifest *manifest, unsigned int walSegmentSize, const St
                                 storageRepoWrite(),
                                 strNewFmt(
                                     STORAGE_REPO_BACKUP "/%s/%s%s", strZ(manifestData(manifest)->backupLabel), strZ(manifestName),
-                                    strZ(compressExtStr(compressTypeEnum(cfgOptionStr(cfgOptCompressType)))))));
+                                    strZ(compressExtStr(compressTypeEnum(cfgOptionStrId(cfgOptCompressType)))))));
 
                         // Add to manifest
                         ManifestFile file =
@@ -2041,7 +2042,8 @@ cmdBackup(void)
 
         // Validate the manifest using the copy start time
         manifestBuildValidate(
-            manifest, cfgOptionBool(cfgOptDelta), backupTime(backupData, true), compressTypeEnum(cfgOptionStr(cfgOptCompressType)));
+            manifest, cfgOptionBool(cfgOptDelta), backupTime(backupData, true),
+            compressTypeEnum(cfgOptionStrId(cfgOptCompressType)));
 
         // Build an incremental backup if type is not full (manifestPrior will be freed in this call)
         if (!backupBuildIncr(infoBackup, manifest, manifestPrior, backupStartResult.walSegmentName))

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1606,7 +1606,7 @@ restoreRecoveryOption(unsigned int pgVersion)
         {
             // Write the recovery target
             kvPut(
-                result, VARSTR(strNewFmt(RECOVERY_TARGET "_%s", strZ(cfgOptionStr(cfgOptType)))),
+                result, VARSTR(strNewFmt(RECOVERY_TARGET "_%s", strZ(strIdToStr(cfgOptionStrId(cfgOptType))))),
                 VARSTR(cfgOptionStr(cfgOptTarget)));
 
             // Write recovery_target_inclusive

--- a/src/common/compress/helper.c
+++ b/src/common/compress/helper.c
@@ -35,6 +35,7 @@ Configuration for supported and future compression types
 ***********************************************************************************************************************************/
 static const struct CompressHelperLocal
 {
+    StringId typeId;                                                // Compress type id
     const String *const type;                                       // Compress type -- must be extension without period prefixed
     const String *const ext;                                        // File extension with period prefixed
     StringId compressType;                                          // Type of the compression filter
@@ -45,10 +46,12 @@ static const struct CompressHelperLocal
 } compressHelperLocal[] =
 {
     {
+        .typeId = STRID5("none", 0x2b9ee0),
         .type = STRDEF(COMPRESS_TYPE_NONE),
         .ext = STRDEF(""),
     },
     {
+        .typeId = STRID5("bz2", 0x73420),
         .type = STRDEF(BZ2_EXT),
         .ext = STRDEF("." BZ2_EXT),
         .compressType = BZ2_COMPRESS_FILTER_TYPE,
@@ -58,6 +61,7 @@ static const struct CompressHelperLocal
         .levelDefault = 9,
     },
     {
+        .typeId = STRID5("gz", 0x3470),
         .type = STRDEF(GZ_EXT),
         .ext = STRDEF("." GZ_EXT),
         .compressType = GZ_COMPRESS_FILTER_TYPE,
@@ -67,6 +71,7 @@ static const struct CompressHelperLocal
         .levelDefault = 6,
     },
     {
+        .typeId = STRID6("lz4", 0x2068c1),
         .type = STRDEF(LZ4_EXT),
         .ext = STRDEF("." LZ4_EXT),
 #ifdef HAVE_LIBLZ4
@@ -78,6 +83,7 @@ static const struct CompressHelperLocal
 #endif
     },
     {
+        .typeId = STRID5("zst", 0x527a0),
         .type = STRDEF(ZST_EXT),
         .ext = STRDEF("." ZST_EXT),
 #ifdef HAVE_LIBZST
@@ -89,12 +95,9 @@ static const struct CompressHelperLocal
 #endif
     },
     {
+        .typeId = STRID5("xz", 0x3580),
         .type = STRDEF(XZ_EXT),
         .ext = STRDEF("." XZ_EXT),
-    },
-    {
-        .type = STRDEF(BZ2_EXT),
-        .ext = STRDEF("." BZ2_EXT),
     },
 };
 
@@ -103,24 +106,24 @@ static const struct CompressHelperLocal
 
 /**********************************************************************************************************************************/
 CompressType
-compressTypeEnum(const String *type)
+compressTypeEnum(const StringId type)
 {
     FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(STRING, type);
+        FUNCTION_TEST_PARAM(STRING_ID, type);
     FUNCTION_TEST_END();
 
-    ASSERT(type != NULL);
+    ASSERT(type != 0);
 
     CompressType result = compressTypeNone;
 
     for (; result < COMPRESS_LIST_SIZE; result++)
     {
-        if (strEq(type, compressHelperLocal[result].type))
+        if (type == compressHelperLocal[result].typeId)
             break;
     }
 
     if (result == COMPRESS_LIST_SIZE)
-        THROW_FMT(AssertError, "invalid compression type '%s'", strZ(type));
+        THROW_FMT(AssertError, "invalid compression type '%s'", strZ(strIdToStr(type)));
 
     FUNCTION_TEST_RETURN(result);
 }

--- a/src/common/compress/helper.h
+++ b/src/common/compress/helper.h
@@ -26,7 +26,7 @@ typedef enum
     compressTypeXz,                                                 // xz/lzma
 } CompressType;
 
-#include <common/type/string.h>
+#include <common/type/stringId.h>
 #include <common/io/filter/group.h>
 
 /***********************************************************************************************************************************
@@ -40,7 +40,7 @@ supported type is not in this list then it should cause an integration test to f
 Functions
 ***********************************************************************************************************************************/
 // Get enum from a compression type string
-CompressType compressTypeEnum(const String *type);
+CompressType compressTypeEnum(StringId type);
 
 // Check that a valid compress type is compiled into this binary.  Errors when the compress type is not present.
 void compressTypePresent(CompressType type);

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -65,38 +65,64 @@ static char logBuffer[LOG_BUFFER_SIZE];
 /**********************************************************************************************************************************/
 #define LOG_LEVEL_TOTAL                                             (LOG_LEVEL_MAX + 1)
 
-static const char *const logLevelList[LOG_LEVEL_TOTAL] =
+static const struct LogLevel
 {
-    "OFF",
-    "ASSERT",
-    "ERROR",
-    "PROTOCOL",
-    "WARN",
-    "INFO",
-    "DETAIL",
-    "DEBUG",
-    "TRACE",
+    const StringId id;                                              // Id
+    const char *const name;                                         // Name
+} logLevelList[LOG_LEVEL_TOTAL] =
+{
+    {
+        .id = STRID5("off", 0x18cf0),
+        .name = "OFF",
+    },
+    {
+        // No id here because this level is not user selectable
+        .name = "ASSERT",
+    },
+    {
+        .id = STRID5("error", 0x127ca450),
+        .name = "ERROR",
+    },
+    {
+        .id = STRID5("warn", 0x748370),
+        .name = "WARN",
+    },
+    {
+        .id = STRID5("info", 0x799c90),
+        .name = "INFO",
+    },
+    {
+        .id = STRID5("detail", 0x1890d0a40),
+        .name = "DETAIL",
+    },
+    {
+        .id = STRID5("debug", 0x7a88a40),
+        .name = "DEBUG",
+    },
+    {
+        .id = STRID5("trace", 0x5186540),
+        .name = "TRACE",
+    },
 };
 
 LogLevel
-logLevelEnum(const char *logLevel)
+logLevelEnum(const StringId logLevelId)
 {
     FUNCTION_TEST_BEGIN();
-        FUNCTION_TEST_PARAM(STRINGZ, logLevel);
+        FUNCTION_TEST_PARAM(STRING_ID, logLevelId);
     FUNCTION_TEST_END();
 
-    ASSERT(logLevel != NULL);
+    ASSERT(logLevelId != 0);
 
     LogLevel result = logLevelOff;
 
     // Search for the log level
     for (; result < LOG_LEVEL_TOTAL; result++)
-        if (strcasecmp(logLevel, logLevelList[result]) == 0)
+        if (logLevelId == logLevelList[result].id)
             break;
 
-    // If the log level was not found
-    if (result == LOG_LEVEL_TOTAL)
-        THROW_FMT(AssertError, "log level '%s' not found", logLevel);
+    // Check that the log level was found
+    CHECK(result != LOG_LEVEL_TOTAL);
 
     FUNCTION_TEST_RETURN(result);
 }
@@ -110,7 +136,7 @@ logLevelStr(LogLevel logLevel)
 
     ASSERT(logLevel <= LOG_LEVEL_MAX);
 
-    FUNCTION_TEST_RETURN(logLevelList[logLevel]);
+    FUNCTION_TEST_RETURN(logLevelList[logLevel].name);
 }
 
 /**********************************************************************************************************************************/

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -8,6 +8,7 @@ Log Handler
 #include <stdbool.h>
 
 #include "common/logLevel.h"
+#include "common/type/stringId.h"
 
 /***********************************************************************************************************************************
 Max size allowed for a single log message including header
@@ -36,7 +37,7 @@ bool logFileSet(const char *logFile);
 bool logAny(LogLevel logLevel);
 
 // Convert log level to string and vice versa
-LogLevel logLevelEnum(const char *logLevel);
+LogLevel logLevelEnum(StringId logLevelId);
 const char *logLevelStr(LogLevel logLevel);
 
 /***********************************************************************************************************************************

--- a/src/common/logLevel.h
+++ b/src/common/logLevel.h
@@ -12,7 +12,6 @@ typedef enum
     logLevelOff,
     logLevelAssert,
     logLevelError,
-    logLevelProtocol,
     logLevelWarn,
     logLevelInfo,
     logLevelDetail,

--- a/src/config/load.c
+++ b/src/config/load.c
@@ -40,15 +40,13 @@ cfgLoadLogSetting(void)
     unsigned int logProcessMax = 1;
 
     if (cfgOptionValid(cfgOptLogLevelConsole))
-        logLevelConsole = logLevelEnum(strZ(cfgOptionStr(cfgOptLogLevelConsole)));
+        logLevelConsole = logLevelEnum(cfgOptionStrId(cfgOptLogLevelConsole));
 
     if (cfgOptionValid(cfgOptLogLevelStderr))
-    {
-        logLevelStdErr = logLevelEnum(strZ(cfgOptionStr(cfgOptLogLevelStderr)));
-    }
+        logLevelStdErr = logLevelEnum(cfgOptionStrId(cfgOptLogLevelStderr));
 
     if (cfgOptionValid(cfgOptLogLevelFile))
-        logLevelFile = logLevelEnum(strZ(cfgOptionStr(cfgOptLogLevelFile)));
+        logLevelFile = logLevelEnum(cfgOptionStrId(cfgOptLogLevelFile));
 
     if (cfgOptionValid(cfgOptLogTimestamp))
         logTimestamp = cfgOptionBool(cfgOptLogTimestamp);
@@ -95,7 +93,7 @@ cfgLoadUpdateOption(void)
                 for (unsigned int repoIdx = 0; repoIdx < cfgOptionGroupIdxTotal(cfgOptGrpRepo); repoIdx++)
                 {
                     if (optionIdx != repoIdx && !(cfgOptionIdxTest(cfgOptRepoHost, repoIdx)) &&
-                        strEq(cfgOptionIdxStr(cfgOptRepoType, optionIdx), cfgOptionIdxStr(cfgOptRepoType, repoIdx)) &&
+                        cfgOptionIdxStrId(cfgOptRepoType, optionIdx) == cfgOptionIdxStrId(cfgOptRepoType, repoIdx) &&
                         strEq(cfgOptionIdxStr(cfgOptRepoPath, optionIdx), cfgOptionIdxStr(cfgOptRepoPath, repoIdx)))
                     {
                         THROW_FMT(
@@ -339,14 +337,14 @@ cfgLoadUpdateOption(void)
 
     // Check that selected compress type has been compiled into this binary
     if (cfgOptionValid(cfgOptCompressType))
-        compressTypePresent(compressTypeEnum(cfgOptionStr(cfgOptCompressType)));
+        compressTypePresent(compressTypeEnum(cfgOptionStrId(cfgOptCompressType)));
 
     // Update compress-level default based on the compression type
     if (cfgOptionValid(cfgOptCompressLevel) && cfgOptionSource(cfgOptCompressLevel) == cfgSourceDefault)
     {
         cfgOptionSet(
             cfgOptCompressLevel, cfgSourceDefault,
-            VARINT64(compressLevelDefault(compressTypeEnum(cfgOptionStr(cfgOptCompressType)))));
+            VARINT64(compressLevelDefault(compressTypeEnum(cfgOptionStrId(cfgOptCompressType)))));
     }
 
     FUNCTION_LOG_RETURN_VOID();

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -1903,7 +1903,7 @@ manifestLoadCallback(void *callbackData, const String *section, const String *ke
             // This new option allows any type of compression to be specified.  It must be parsed after the option above so the
             // value does not get overwritten.  Since options are stored in alpha order this should always be true.
             else if (strEq(key, MANIFEST_KEY_OPTION_COMPRESS_TYPE_STR))
-                manifest->pub.data.backupOptionCompressType = compressTypeEnum(varStr(value));
+                manifest->pub.data.backupOptionCompressType = compressTypeEnum(strIdFromStr(varStr(value)));
             else if (strEq(key, MANIFEST_KEY_OPTION_HARDLINK_STR))
                 manifest->pub.data.backupOptionHardLink = varBool(value);
             else if (strEq(key, MANIFEST_KEY_OPTION_ONLINE_STR))

--- a/test/src/module/common/compressTest.c
+++ b/test/src/module/common/compressTest.c
@@ -335,9 +335,9 @@ testRun(void)
     {
         TEST_TITLE("compressTypeEnum()");
 
-        TEST_RESULT_UINT(compressTypeEnum(STRDEF("none")), compressTypeNone, "none enum");
-        TEST_RESULT_UINT(compressTypeEnum(STRDEF("gz")), compressTypeGz, "gz enum");
-        TEST_ERROR(compressTypeEnum(STRDEF(BOGUS_STR)), AssertError, "invalid compression type 'BOGUS'");
+        TEST_RESULT_UINT(compressTypeEnum(strIdFromZ("none")), compressTypeNone, "none enum");
+        TEST_RESULT_UINT(compressTypeEnum(strIdFromZ("gz")), compressTypeGz, "gz enum");
+        TEST_ERROR(compressTypeEnum(strIdFromZ(BOGUS_STR)), AssertError, "invalid compression type 'BOGUS'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("compressTypeStr()");

--- a/test/src/module/common/logTest.c
+++ b/test/src/module/common/logTest.c
@@ -102,10 +102,10 @@ testRun(void)
     // *****************************************************************************************************************************
     if (testBegin("logLevelEnum() and logLevelStr()"))
     {
-        TEST_ERROR(logLevelEnum(BOGUS_STR), AssertError, "log level 'BOGUS' not found");
-        TEST_RESULT_INT(logLevelEnum("OFF"), logLevelOff, "log level 'OFF' found");
-        TEST_RESULT_INT(logLevelEnum("info"), logLevelInfo, "log level 'info' found");
-        TEST_RESULT_INT(logLevelEnum("TRACE"), logLevelTrace, "log level 'TRACE' found");
+        TEST_ERROR(logLevelEnum(strIdFromZ(BOGUS_STR)), AssertError, "check 'result != LOG_LEVEL_TOTAL' failed");
+        TEST_RESULT_INT(logLevelEnum(strIdFromZ("off")), logLevelOff, "log level 'OFF' found");
+        TEST_RESULT_INT(logLevelEnum(strIdFromZ("info")), logLevelInfo, "log level 'info' found");
+        TEST_RESULT_INT(logLevelEnum(strIdFromZ("trace")), logLevelTrace, "log level 'TRACE' found");
 
         TEST_ERROR(logLevelStr(999), AssertError, "assertion 'logLevel <= LOG_LEVEL_MAX' failed");
         TEST_RESULT_Z(logLevelStr(logLevelOff), "OFF", "log level 'OFF' found");

--- a/test/src/module/config/loadTest.c
+++ b/test/src/module/config/loadTest.c
@@ -499,7 +499,7 @@ testRun(void)
         hrnCfgArgRawNegate(argList, cfgOptCompress);
         HRN_CFG_LOAD(cfgCmdArchivePush, argList);
 
-        TEST_RESULT_STR_Z(cfgOptionStr(cfgOptCompressType), "none", "compress-type=none");
+        TEST_RESULT_UINT(cfgOptionStrId(cfgOptCompressType), CFGOPTVAL_COMPRESS_TYPE_NONE, "compress-type=none");
         TEST_RESULT_INT(cfgOptionInt(cfgOptCompressLevel), 0, "compress-level=0");
         TEST_RESULT_BOOL(cfgOptionValid(cfgOptCompress), false, "compress is not valid");
 
@@ -512,7 +512,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptCompressLevel, "9");
         HRN_CFG_LOAD(cfgCmdArchivePush, argList);
 
-        TEST_RESULT_STR_Z(cfgOptionStr(cfgOptCompressType), "gz", "compress-type=gz");
+        TEST_RESULT_UINT(cfgOptionStrId(cfgOptCompressType), CFGOPTVAL_COMPRESS_TYPE_GZ, "compress-type=gz");
         TEST_RESULT_INT(cfgOptionInt(cfgOptCompressLevel), 9, "compress-level=9");
         TEST_RESULT_BOOL(cfgOptionValid(cfgOptCompress), false, "compress is not valid");
 
@@ -525,7 +525,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptCompressType, "gz");
         HRN_CFG_LOAD(cfgCmdArchivePush, argList);
 
-        TEST_RESULT_STR_Z(cfgOptionStr(cfgOptCompressType), "gz", "compress-type=gz");
+        TEST_RESULT_UINT(cfgOptionStrId(cfgOptCompressType), CFGOPTVAL_COMPRESS_TYPE_GZ, "compress-type=gz");
         TEST_RESULT_INT(cfgOptionInt(cfgOptCompressLevel), 6, "compress-level=6");
         TEST_RESULT_BOOL(cfgOptionValid(cfgOptCompress), false, "compress is not valid");
 
@@ -550,7 +550,7 @@ testRun(void)
 
         // Only the error case is tested here, success is tested in cfgLoad()
         TEST_RESULT_VOID(cfgLoadLogFile(), "attempt to open bogus log file");
-        TEST_RESULT_STR_Z(cfgOptionStr(cfgOptLogLevelFile), "off", "log-level-file should now be off");
+        TEST_RESULT_UINT(cfgOptionStrId(cfgOptLogLevelFile), CFGOPTVAL_LOG_LEVEL_FILE_OFF, "log-level-file should now be off");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
The compress-type, repo-type and log-level-* options have allow lists, which means it is more efficient to treat them as StringIds.

For compress-type and log-level-* also update the functions that convert them to enums.