### PR TITLE
WIP - Add checkpoint_timeout warning

### DIFF
--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -852,12 +852,13 @@ backupStart(BackupData *backupData)
 
             // When the start-fast option is disabled and db-timeout is smaller than checkpoint_timeout, the command may timeout
             // before the backup actually starts
-            if (!cfgOptionBool(cfgOptStartFast) && cfgOptionTest(cfgOptDbTimeout) &&
+            if (!cfgOptionBool(cfgOptStartFast) &&
                 cfgOptionInt64(cfgOptDbTimeout) <= (int64_t)(dbCheckpointTimeout(backupData->dbPrimary) * MSEC_PER_SEC))
             {
-                LOG_WARN(
-                    CFGOPT_START_FAST " is disabled and " CFGOPT_DB_TIMEOUT " is smaller than the checkpoint_timeout reported by the"
-                    " database. The timeout may occur before the backup actually starts.");
+                LOG_WARN_FMT(
+                    CFGOPT_START_FAST " is disabled and " CFGOPT_DB_TIMEOUT " (%lds) is smaller than the checkpoint_timeout (%us)"
+                    " reported by the database - timeout may occur before the backup actually starts",
+                    cfgOptionInt64(cfgOptDbTimeout) / (int64_t)(MSEC_PER_SEC), dbCheckpointTimeout(backupData->dbPrimary));
             }
 
             MEM_CONTEXT_PRIOR_BEGIN()

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -852,13 +852,13 @@ backupStart(BackupData *backupData)
 
             // When the start-fast option is disabled and db-timeout is smaller than checkpoint_timeout, the command may timeout
             // before the backup actually starts
-            int64_t dbTimeout = cfgOptionInt64(cfgOptDbTimeout) / (int64_t)(MSEC_PER_SEC);
-            if (!cfgOptionBool(cfgOptStartFast) && dbTimeout <= dbCheckpointTimeout(backupData->dbPrimary))
+            if (!cfgOptionBool(cfgOptStartFast) &&
+                cfgOptionInt64(cfgOptDbTimeout) <= (int64_t)(dbCheckpointTimeout(backupData->dbPrimary) * MSEC_PER_SEC))
             {
                 LOG_WARN_FMT(
-                    CFGOPT_START_FAST " is disabled and " CFGOPT_DB_TIMEOUT " (%lds) is smaller than the checkpoint_timeout (%us)"
-                    " reported by the database - timeout may occur before the backup actually starts", dbTimeout,
-                    dbCheckpointTimeout(backupData->dbPrimary));
+                    CFGOPT_START_FAST " is disabled and " CFGOPT_DB_TIMEOUT " (%ss) is smaller than the checkpoint_timeout (%us)"
+                    " reported by the database - timeout may occur before the backup actually starts",
+                    strZ(cfgOptionDisplay(cfgOptDbTimeout)), dbCheckpointTimeout(backupData->dbPrimary));
             }
 
             MEM_CONTEXT_PRIOR_BEGIN()

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -852,13 +852,13 @@ backupStart(BackupData *backupData)
 
             // When the start-fast option is disabled and db-timeout is smaller than checkpoint_timeout, the command may timeout
             // before the backup actually starts
-            if (!cfgOptionBool(cfgOptStartFast) &&
-                cfgOptionInt64(cfgOptDbTimeout) <= (int64_t)(dbCheckpointTimeout(backupData->dbPrimary) * MSEC_PER_SEC))
+            int64_t dbTimeout = cfgOptionInt64(cfgOptDbTimeout) / (int64_t)(MSEC_PER_SEC);
+            if (!cfgOptionBool(cfgOptStartFast) && dbTimeout <= dbCheckpointTimeout(backupData->dbPrimary))
             {
                 LOG_WARN_FMT(
                     CFGOPT_START_FAST " is disabled and " CFGOPT_DB_TIMEOUT " (%lds) is smaller than the checkpoint_timeout (%us)"
-                    " reported by the database - timeout may occur before the backup actually starts",
-                    cfgOptionInt64(cfgOptDbTimeout) / (int64_t)(MSEC_PER_SEC), dbCheckpointTimeout(backupData->dbPrimary));
+                    " reported by the database - timeout may occur before the backup actually starts", dbTimeout,
+                    dbCheckpointTimeout(backupData->dbPrimary));
             }
 
             MEM_CONTEXT_PRIOR_BEGIN()

--- a/src/db/db.h
+++ b/src/db/db.h
@@ -30,6 +30,7 @@ typedef struct DbPub
     const String *archiveMode;                                      // The archive_mode reported by the database
     const String *archiveCommand;                                   // The archive_command reported by the database
     const String *pgDataPath;                                       // Data directory reported by the database
+    unsigned int checkpointTimeout;                                 // The checkpoint timeout reported by the database
     unsigned int pgVersion;                                         // Version as reported by the database
 } DbPub;
 
@@ -52,6 +53,13 @@ __attribute__((always_inline)) static inline const String *
 dbPgDataPath(const Db *const this)
 {
     return THIS_PUB(Db)->pgDataPath;
+}
+
+// Checkpoint timeout loaded from the checkpoint_timeout GUC
+__attribute__((always_inline)) static inline unsigned int
+dbCheckpointTimeout(const Db *const this)
+{
+    return THIS_PUB(Db)->checkpointTimeout;
 }
 
 // Version loaded from the server_version_num GUC

--- a/test/src/common/harnessPq.h
+++ b/test/src/common/harnessPq.h
@@ -68,24 +68,27 @@ Macros for defining groups of functions that implement various queries and comma
         "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"                          \
             " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"                                   \
             " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"                                     \
-            " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text\"]",                               \
+            " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text,"                                  \
+            " (select setting from pg_catalog.pg_settings where name = 'checkpoint_timeout')::int4\"]",                            \
         .resultInt = 1},                                                                                                           \
     {.session = sessionParam, .function = HRNPQ_CONSUMEINPUT},                                                                     \
     {.session = sessionParam, .function = HRNPQ_ISBUSY},                                                                           \
     {.session = sessionParam, .function = HRNPQ_GETRESULT},                                                                        \
     {.session = sessionParam, .function = HRNPQ_RESULTSTATUS, .resultInt = PGRES_TUPLES_OK},                                       \
     {.session = sessionParam, .function = HRNPQ_NTUPLES, .resultInt = 1},                                                          \
-    {.session = sessionParam, .function = HRNPQ_NFIELDS, .resultInt = 4},                                                          \
+    {.session = sessionParam, .function = HRNPQ_NFIELDS, .resultInt = 5},                                                          \
     {.session = sessionParam, .function = HRNPQ_FTYPE, .param = "[0]", .resultInt = HRNPQ_TYPE_INT},                               \
     {.session = sessionParam, .function = HRNPQ_FTYPE, .param = "[1]", .resultInt = HRNPQ_TYPE_TEXT},                              \
     {.session = sessionParam, .function = HRNPQ_FTYPE, .param = "[2]", .resultInt = HRNPQ_TYPE_TEXT},                              \
     {.session = sessionParam, .function = HRNPQ_FTYPE, .param = "[3]", .resultInt = HRNPQ_TYPE_TEXT},                              \
+    {.session = sessionParam, .function = HRNPQ_FTYPE, .param = "[4]", .resultInt = HRNPQ_TYPE_INT},                               \
     {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,0]", .resultZ = STRINGIFY(versionParam)},                   \
     {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,1]", .resultZ = pgPathParam},                               \
     {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,2]", .resultZ = archiveMode == NULL ? "on"                  \
         : archiveMode},                                                                                                            \
     {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = archiveCommand == NULL ? PROJECT_BIN        \
         : archiveCommand},                                                                                                         \
+    {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,4]", .resultInt = 300},                                     \
     {.session = sessionParam, .function = HRNPQ_CLEAR},                                                                            \
     {.session = sessionParam, .function = HRNPQ_GETRESULT, .resultNull = true}
 

--- a/test/src/common/harnessPq.h
+++ b/test/src/common/harnessPq.h
@@ -88,7 +88,7 @@ Macros for defining groups of functions that implement various queries and comma
         : archiveMode},                                                                                                            \
     {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = archiveCommand == NULL ? PROJECT_BIN        \
         : archiveCommand},                                                                                                         \
-    {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,4]", .resultInt = 300},                                     \
+    {.session = sessionParam, .function = HRNPQ_GETVALUE, .param = "[0,4]", .resultZ = STRINGIFY(versionParam)},                   \
     {.session = sessionParam, .function = HRNPQ_CLEAR},                                                                            \
     {.session = sessionParam, .function = HRNPQ_GETRESULT, .resultNull = true}
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1688,6 +1688,8 @@ testRun(void)
 
             TEST_RESULT_LOG(
                 "P00   INFO: execute exclusive pg_start_backup(): backup begins after the next regular checkpoint completes\n"
+                "P00   WARN: start-fast is disabled and db-timeout (1800s) is smaller than the checkpoint_timeout (90500s)"
+                " reported by the database - timeout may occur before the backup actually starts\n"
                 "P00   INFO: backup start archive = 0000000105D944C000000000, lsn = 5d944c0/0\n"
                 "P00   WARN: resumable backup 20191002-070640F of same type exists -- remove invalid files and resume\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (8KB, [PCT]) checksum [SHA1]\n"
@@ -1827,6 +1829,8 @@ testRun(void)
 
             TEST_RESULT_LOG(
                 "P00   INFO: execute exclusive pg_start_backup(): backup begins after the next regular checkpoint completes\n"
+                "P00   WARN: start-fast is disabled and db-timeout (1800s) is smaller than the checkpoint_timeout (90500s)"
+                " reported by the database - timeout may occur before the backup actually starts\n"
                 "P00   INFO: backup start archive = 0000000105D95D3000000000, lsn = 5d95d30/0\n"
                 "P00   WARN: resumable backup 20191003-105320F of same type exists -- remove invalid files and resume\n"
                 "P00 DETAIL: remove path '" TEST_PATH "/repo/backup/test1/20191003-105320F/pg_data/bogus_path' from resumed"
@@ -1990,6 +1994,8 @@ testRun(void)
                 "P00   INFO: last backup label = 20191003-105320F, version = " PROJECT_VERSION "\n"
                 "P00   WARN: diff backup cannot alter compress-type option to 'none', reset to value in 20191003-105320F\n"
                 "P00   INFO: execute exclusive pg_start_backup(): backup begins after the next regular checkpoint completes\n"
+                "P00   WARN: start-fast is disabled and db-timeout (1800s) is smaller than the checkpoint_timeout (90500s)"
+                " reported by the database - timeout may occur before the backup actually starts\n"
                 "P00   INFO: backup start archive = 0000000105D9759000000000, lsn = 5d97590/0\n"
                 "P00   WARN: file 'time-mismatch2' has timestamp in the future, enabling delta checksum\n"
                 "P00   WARN: resumable backup 20191003-105320F_20191004-144000D of same type exists"
@@ -2306,6 +2312,8 @@ testRun(void)
 
             TEST_RESULT_LOG(
                 "P00   INFO: execute non-exclusive pg_start_backup(): backup begins after the next regular checkpoint completes\n"
+                "P00   WARN: start-fast is disabled and db-timeout (1800s) is smaller than the checkpoint_timeout (110000s)"
+                " reported by the database - timeout may occur before the backup actually starts\n"
                 "P00   INFO: backup start archive = 0000000105DB5DE000000000, lsn = 5db5de0/0\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/base/1/3 (32KB, [PCT]) checksum [SHA1]\n"
                 "P00   WARN: invalid page checksums found in file " TEST_PATH "/pg1/base/1/3 at pages 0, 2-3\n"
@@ -2432,6 +2440,8 @@ testRun(void)
             TEST_RESULT_LOG(
                 "P00   INFO: last backup label = 20191027-181320F, version = " PROJECT_VERSION "\n"
                 "P00   INFO: execute non-exclusive pg_start_backup(): backup begins after the next regular checkpoint completes\n"
+                "P00   WARN: start-fast is disabled and db-timeout (1800s) is smaller than the checkpoint_timeout (110000s)"
+                " reported by the database - timeout may occur before the backup actually starts\n"
                 "P00   INFO: backup start archive = 0000000105DB764000000000, lsn = 5db7640/0");
 
             // Remove partial backup so it won't be resumed (since it errored before any checksums were written)
@@ -2457,6 +2467,8 @@ testRun(void)
             hrnCfgArgRawStrId(argList, cfgOptType, backupTypeIncr);
             hrnCfgArgRawBool(argList, cfgOptDelta, true);
             hrnCfgArgRawBool(argList, cfgOptRepoHardlink, true);
+            // With start-fast being disabled, increase db-timeout to be greater than checkpoint_timeout
+            hrnCfgArgRawZ(argList, cfgOptDbTimeout, "110001");
             HRN_CFG_LOAD(cfgCmdBackup, argList);
 
             // Update pg_control timestamp

--- a/test/src/module/db/dbTest.c
+++ b/test/src/module/db/dbTest.c
@@ -196,23 +196,26 @@ testRun(void)
                 "[\"select (select setting from pg_catalog.pg_settings where name = 'server_version_num')::int4,"
                     " (select setting from pg_catalog.pg_settings where name = 'data_directory')::text,"
                     " (select setting from pg_catalog.pg_settings where name = 'archive_mode')::text,"
-                    " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text\"]",
+                    " (select setting from pg_catalog.pg_settings where name = 'archive_command')::text,"
+                    " (select setting from pg_catalog.pg_settings where name = 'checkpoint_timeout')::int4\"]",
                 .resultInt = 1},
             {.session = 1, .function = HRNPQ_CONSUMEINPUT},
             {.session = 1, .function = HRNPQ_ISBUSY},
             {.session = 1, .function = HRNPQ_GETRESULT},
             {.session = 1, .function = HRNPQ_RESULTSTATUS, .resultInt = PGRES_TUPLES_OK},
             {.session = 1, .function = HRNPQ_NTUPLES, .resultInt = 1},
-            {.session = 1, .function = HRNPQ_NFIELDS, .resultInt = 4},
+            {.session = 1, .function = HRNPQ_NFIELDS, .resultInt = 5},
             {.session = 1, .function = HRNPQ_FTYPE, .param = "[0]", .resultInt = HRNPQ_TYPE_INT},
             {.session = 1, .function = HRNPQ_FTYPE, .param = "[1]", .resultInt = HRNPQ_TYPE_TEXT},
             {.session = 1, .function = HRNPQ_FTYPE, .param = "[2]", .resultInt = HRNPQ_TYPE_TEXT},
             {.session = 1, .function = HRNPQ_FTYPE, .param = "[3]", .resultInt = HRNPQ_TYPE_TEXT},
+            {.session = 1, .function = HRNPQ_FTYPE, .param = "[4]", .resultInt = HRNPQ_TYPE_INT},
             {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,0]", .resultZ = "0"},
             {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,1]", .resultZ = "value"},
             {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,2]", .resultZ = "value"},
             {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,3]", .resultZ = ""},
             {.session = 1, .function = HRNPQ_GETISNULL, .param = "[0,3]", .resultInt = 1},
+            {.session = 1, .function = HRNPQ_GETVALUE, .param = "[0,4]", .resultZ = "300"},
             {.session = 1, .function = HRNPQ_CLEAR},
             {.session = 1, .function = HRNPQ_GETRESULT, .resultNull = true},
 


### PR DESCRIPTION
In the backup command, add a warning if `start-fast` is disabled and PG `checkpoint_timeout` is greater than `db-timeout`.
In such cases, we might timeout before the checkpoint occurs and the backup really starts.

Note: WIP regarding the tests part