### PR TITLE
httpRequestError: Log verb

### DIFF
--- a/src/common/io/http/request.c
+++ b/src/common/io/http/request.c
@@ -252,7 +252,7 @@ httpRequestError(const HttpRequest *this, HttpResponse *response)
     // Output path/query
     strCatZ(error, ":\n*** Path/Query ***:");
 
-    strCatFmt(error, "\n%s", strZ(httpRequestPath(this)));
+    strCatFmt(error, "\n%s %s", strZ(httpRequestVerb(this)), strZ(httpRequestPath(this)));
 
     if (httpRequestQuery(this) != NULL)
         strCatFmt(error, "?%s", strZ(httpQueryRenderP(httpRequestQuery(this), .redact = true)));


### PR DESCRIPTION
The httpRequestError method is logging everything except the actual HTTP
verb, fix that.

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
