### PR TITLE
Allow y/n arguments for boolean command-line options.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -47,6 +47,17 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1571"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="reid.thompson"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Allow y/n arguments for boolean command-line options.</p>
+                    </release-item>
+
+                    <release-item>
                         <commit subject="Match backup log size with size reported by info command.">
                             <github-issue id="766"/>
                             <github-pull-request id="1562"/>

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -786,9 +786,6 @@ option:
     section: global
     type: boolean
     default: true
-    allow-list:
-      - y
-      - n
     command:
       archive-get: {}
       archive-push: {}

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -786,6 +786,9 @@ option:
     section: global
     type: boolean
     default: true
+    allow-list:
+      - y
+      - n
     command:
       archive-get: {}
       archive-push: {}

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -1423,8 +1423,8 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
                         option.negate = true;
                     else if (!strEqZ(optionArg, "y"))
                         THROW_FMT(
-                                OptionInvalidValueError, "when using argument with option '--%s', argument must be 'y' or 'n'",
-                                strZ(optionName));
+                                OptionInvalidValueError,
+                                "when using argument with boolean option '--%s', argument must be 'y' or 'n'", strZ(optionName));
                 }
 
                 // If the option requires an argument

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -1417,19 +1417,15 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
                     // Handle boolean (only y/n allowed as argument)
                     if (parseRuleOption[option.id].type == cfgOptTypeBoolean)
                     {
+                        // Validate argument/set negate when argument present
                         if (optionArg != NULL)
                         {
-                            // Validate argument/set negate when indicated
                             if (strEqZ(optionArg, "n"))
-                            {
                                 option.negate = true;
-                            }
                             else if (!strEqZ(optionArg, "y"))
                             {
                                 THROW_FMT(
-                                    OptionInvalidValueError,
-                                    "when using argument with boolean option '--%s', argument must be 'y' or 'n'",
-                                    strZ(optionName));
+                                    OptionInvalidValueError, "boolean option '--%s' argument must be 'y' or 'n'", strZ(optionName));
                             }
                         }
                     }
@@ -1443,6 +1439,7 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
                         optionArg = strNewZ(argList[++argListIdx]);
                     }
                 }
+                // Else error if an argument was found with the option
                 else if (optionArg != NULL)
                     THROW_FMT(OptionInvalidError, "option '%s' does not allow an argument", strZ(optionName));
 

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -1411,6 +1411,16 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
                 if (!option.found)
                     THROW_FMT(OptionInvalidError, "invalid option '--%s'", arg);
 
+                // Handle boolean option with argument
+                if (parseRuleOption[option.id].type == cfgOptTypeBoolean && optionArg != NULL)
+                {
+                    // Is the option negated
+                    if (strEqZ(optionArg, "n"))
+                        option.negate = true;
+                    else if (!strEqZ(optionArg, "y"))
+                        THROW_FMT(OptionInvalidValueError, "boolean option '%s' must be 'y' or 'n'", strZ(optionName));
+                }
+
                 // If the option requires an argument
                 if (parseRuleOption[option.id].type != cfgOptTypeBoolean && !option.negate && !option.reset)
                 {
@@ -1425,8 +1435,11 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
                     }
                 }
                 // Else error if an argument was found with the option
-                else if (optionArg != NULL)
-                    THROW_FMT(OptionInvalidError, "option '%s' does not allow an argument", strZ(optionName));
+//
+// there are now no options that will not accept an argument
+//
+//                else if (optionArg != NULL)
+//                    THROW_FMT(OptionInvalidError, "option '%s' does not allow an argument", strZ(optionName));
 
                 // Error if this option is secure and cannot be passed on the command line
                 if (cfgParseOptionSecure(option.id))

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -628,14 +628,36 @@ testRun(void)
             "option '-bogus' must begin with --");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error when option argument not allowed");
+        TEST_TITLE("error when option argument is invalid");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);
         hrnCfgArgRawZ(argList, cfgOptOnline, "bogus");
         TEST_ERROR(
-            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
-            "option 'online' does not allow an argument");
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidValueError,
+            "boolean option 'online' must be 'y' or 'n'");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("boolean option with negation argument");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        hrnCfgArgRawZ(argList, cfgOptNeutralUmask, "n");
+        strLstAddZ(argList, CFGCMD_BACKUP);
+        TEST_ERROR(
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionRequiredError,
+            "backup command requires option: stanza");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("boolean option with affirmative argument");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        hrnCfgArgRawZ(argList, cfgOptNeutralUmask, "y");
+        strLstAddZ(argList, CFGCMD_BACKUP);
+        TEST_ERROR(
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionRequiredError,
+            "backup command requires option: stanza");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid command");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -668,7 +668,7 @@ testRun(void)
         strLstAddZ(argList, CFGCMD_BACKUP);
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
-            "negated options cannot have an argument '--no-neutral-umask=n'");
+            "option 'no-neutral-umask' does not allow an argument");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error when negated boolean option with affirmative argument");
@@ -679,7 +679,18 @@ testRun(void)
         strLstAddZ(argList, CFGCMD_BACKUP);
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
-            "negated options cannot have an argument '--no-online=y'");
+            "option 'no-online' does not allow an argument");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("error when argumentless option is passed with an argument");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        strLstAddZ(argList, "--reset-pg1-host=xxx");
+        strLstAddZ(argList, CFGCMD_BACKUP);
+        TEST_ERROR(
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
+            "option 'reset-pg1-host' does not allow an argument");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid command");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -635,7 +635,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOnline, "bogus");
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidValueError,
-            "boolean option 'online' must be 'y' or 'n'");
+            "when using argument with option '--online', argument must be 'y' or 'n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("boolean option with negation argument");
@@ -658,6 +658,28 @@ testRun(void)
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionRequiredError,
             "backup command requires option: stanza");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("negated boolean option with argument");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        strLstAddZ(argList, "--no-neutral-umask=n");
+        strLstAddZ(argList, CFGCMD_BACKUP);
+        TEST_ERROR(
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
+            "negated options cannot have an argument '--no-neutral-umask=n'");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("negated boolean option with argument");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        strLstAddZ(argList, "--no-neutral-umask=n");
+        strLstAddZ(argList, CFGCMD_BACKUP);
+        TEST_ERROR(
+            configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
+            "negated options cannot have an argument '--no-neutral-umask=n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid command");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -660,7 +660,7 @@ testRun(void)
             "backup command requires option: stanza");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error when negated boolean option with argument");
+        TEST_TITLE("error when negated boolean option with negative argument");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);
@@ -671,15 +671,15 @@ testRun(void)
             "negated options cannot have an argument '--no-neutral-umask=n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("negated boolean option with argument");
+        TEST_TITLE("negated boolean option with affirmative argument");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);
-        strLstAddZ(argList, "--no-neutral-umask=n");
+        strLstAddZ(argList, "--no-online=y");
         strLstAddZ(argList, CFGCMD_BACKUP);
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidError,
-            "negated options cannot have an argument '--no-neutral-umask=n'");
+            "negated options cannot have an argument '--no-online=y'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid command");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -660,7 +660,7 @@ testRun(void)
             "backup command requires option: stanza");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("negated boolean option with argument");
+        TEST_TITLE("error when negated boolean option with argument");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -635,7 +635,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOnline, "bogus");
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidValueError,
-            "when using argument with option '--online', argument must be 'y' or 'n'");
+            "when using argument with boolean option '--online', argument must be 'y' or 'n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("boolean option with negation argument");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -635,7 +635,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptOnline, "bogus");
         TEST_ERROR(
             configParse(storageTest, strLstSize(argList), strLstPtr(argList), false), OptionInvalidValueError,
-            "when using argument with boolean option '--online', argument must be 'y' or 'n'");
+            "boolean option '--online' argument must be 'y' or 'n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("boolean option with negation argument");

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -671,7 +671,7 @@ testRun(void)
             "negated options cannot have an argument '--no-neutral-umask=n'");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("negated boolean option with affirmative argument");
+        TEST_TITLE("error when negated boolean option with affirmative argument");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);


### PR DESCRIPTION
Allow arguments of y or n for boolean command line options ala how they are allowed in the config file.
Reference project card:
https://github.com/pgbackrest/pgbackrest/projects/2#card-62440553

parse.c 1417-1429  I removed these lines because I believe that at this point there are no options that cannot accept an argument.