### PR TITLE
Use infoBackupDataByLabel() to log backup size.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -66,6 +66,9 @@
                         <commit subject="Include backup_label and tablespace_map file sizes in log output.">
                             <github-pull-request id="1568"/>
                         </commit>
+                        <commit subject="Use infoBackupDataByLabel() to log backup size.">
+                            <github-pull-request id="1573"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-ideator id="mahomed.hussein"/>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -2127,10 +2127,10 @@ cmdBackup(void)
         backupComplete(infoBackup, manifest);
 
         // Backup info
-        InfoBackupData *infoBackupDataPtr = infoBackupDataByLabel(infoBackup,  manifestData(manifest)->backupLabel);
         LOG_INFO_FMT(
             "%s backup size = %s, file total = %u", strZ(strIdToStr(manifestData(manifest)->backupType)),
-            strZ(strSizeFormat(infoBackupDataPtr->backupInfoSizeDelta)), manifestFileTotal(manifest));
+            strZ(strSizeFormat(infoBackupDataByLabel(infoBackup,  manifestData(manifest)->backupLabel)->backupInfoSizeDelta)),
+            manifestFileTotal(manifest));
     }
     MEM_CONTEXT_TEMP_END();
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -2111,12 +2111,10 @@ cmdBackup(void)
         backupComplete(infoBackup, manifest);
 
         // Backup info
-        const InfoBackupData *const infoBackupData = infoBackupDataByLabel(infoBackup,  manifestData(manifest)->backupLabel);
+        InfoBackupData *infoBackupDataPtr = infoBackupDataByLabel(infoBackup,  manifestData(manifest)->backupLabel);
         LOG_INFO_FMT(
             "%s backup size = %s, file total = %u", strZ(strIdToStr(manifestData(manifest)->backupType)),
-            infoBackupData->backupInfoSizeDelta > 1048576 ? strZ(strSizeFormat(infoBackupData->backupInfoSizeDelta))
-            : strZ(strCatFmt(strNew(),"%s (%s)", strZ(strNewFmt("%" PRIu64 "B", infoBackupData->backupInfoSizeDelta)),
-            strZ(strSizeFormat(infoBackupData->backupInfoSizeDelta)))), manifestFileTotal(manifest));
+            strZ(strSizeFormat(infoBackupDataPtr->backupInfoSizeDelta)), manifestFileTotal(manifest));
     }
     MEM_CONTEXT_TEMP_END();
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1325,7 +1325,7 @@ testRun(void)
         ProtocolParallelJob *job = protocolParallelJobNew(VARSTRDEF("key"), protocolCommandNew(strIdFromZ("x")));
         protocolParallelJobErrorSet(job, errorTypeCode(&AssertError), STRDEF("error message"));
 
-        TEST_ERROR(backupJobResult((Manifest *)1, NULL, STRDEF("log"), strLstNew(), job, 0, NULL, NULL), AssertError, "error message");
+        TEST_ERROR(backupJobResult((Manifest *)1, NULL, STRDEF("log"), strLstNew(), job, 0, NULL), AssertError, "error message");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("report host/100% progress on noop result");
@@ -1354,10 +1354,9 @@ testRun(void)
         OBJ_NEW_END();
 
         uint64_t sizeProgress = 0;
-        uint64_t sizeCopied = 0;
 
         TEST_RESULT_VOID(
-            backupJobResult(manifest, STRDEF("host"), STRDEF("log-test"), strLstNew(), job, 0, &sizeProgress, &sizeCopied), "log noop result");
+            backupJobResult(manifest, STRDEF("host"), STRDEF("log-test"), strLstNew(), job, 0, &sizeProgress), "log noop result");
 
         TEST_RESULT_LOG("P00 DETAIL: match file from prior backup host:log-test (0B, 100%)");
     }


### PR DESCRIPTION
Eliminate summing and passing of copied files sizes for logging backup size.   Instead, utilize infoBackupDataByLabel to pull the backup size for the log message.
Reference: https://github.com/pgbackrest/pgbackrest/projects/2#card-72983773