### PR TITLE
Fix restore delta link mapping when path/file already exists.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -20,6 +20,21 @@
                     <p><b>IMPORTANT NOTE</b>: If the <cmd>restore</cmd> command is unable to find a backup that matches a specified time target then an error will be thrown, whereas before a warning was logged.</p>
                 </text>
 
+                <release-bug-list>
+                    <release-item>
+                        <github-issue id="1588"/>
+                        <github-pull-request id="1589"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="younes.alhroub"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="reid.thompson"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix <cmd>restore</cmd> delta link mapping when path/file already exists.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-feature-list>
                     <release-item>
                         <github-issue id="1537"/>

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -923,7 +923,7 @@ restoreCleanInfoListCallback(void *data, const StorageInfo *info)
         {
             const ManifestFile *manifestFile = manifestFileFindDefault(cleanData->manifest, manifestName, NULL);
 
-            if (manifestFile != NULL)
+            if (manifestFile != NULL && manifestLinkFindDefault(cleanData->manifest, manifestName, NULL) == NULL)
             {
                 restoreCleanOwnership(pgPath, manifestFile->user, manifestFile->group, info->userId, info->groupId, false);
                 restoreCleanMode(pgPath, manifestFile->mode, info);
@@ -964,7 +964,7 @@ restoreCleanInfoListCallback(void *data, const StorageInfo *info)
         {
             const ManifestPath *manifestPath = manifestPathFindDefault(cleanData->manifest, manifestName, NULL);
 
-            if (manifestPath != NULL)
+            if (manifestPath != NULL && manifestLinkFindDefault(cleanData->manifest, manifestName, NULL) == NULL)
             {
                 // Check ownership/permissions
                 restoreCleanOwnership(pgPath, manifestPath->user, manifestPath->group, info->userId, info->groupId, false);

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -2712,6 +2712,14 @@ testRun(void)
         // Write recovery.conf so we don't get a preserve warning
         HRN_STORAGE_PUT_Z(storagePgWrite(), PG_FILE_RECOVERYCONF, "Some Settings");
 
+        // Covert pg_wal to a path so it will be removed
+        HRN_STORAGE_REMOVE(storagePgWrite(), "pg_wal");
+        HRN_STORAGE_PATH_CREATE(storagePgWrite(), "pg_wal");
+
+        // Covert pg_hba.conf to a path so it will be removed
+        HRN_STORAGE_REMOVE(storagePgWrite(), "pg_hba.conf");
+        HRN_STORAGE_PUT_Z(storagePgWrite(), "pg_hba.conf", BOGUS_STR);
+
         // Update the manifest with online = true to test recovery start time logging
         manifest->pub.data.backupOptionOnline = true;
         manifest->pub.data.backupTimestampStart = 1482182958;
@@ -2740,10 +2748,14 @@ testRun(void)
             "P00 DETAIL: skip 'tablespace_map' -- tablespace links will be created based on mappings\n"
             "P00 DETAIL: remove 'global/pg_control' so cluster will not start if restore does not complete\n"
             "P00   INFO: remove invalid files/links/paths from '" TEST_PATH "/pg'\n"
+            "P00 DETAIL: remove invalid file '" TEST_PATH "/pg/pg_hba.conf'\n"
+            "P00 DETAIL: remove invalid path '" TEST_PATH "/pg/pg_wal'\n"
             "P00 DETAIL: remove invalid link '" TEST_PATH "/pg/pg_xact'\n"
             "P00   INFO: remove invalid files/links/paths from '" TEST_PATH "/wal'\n"
             "P00   INFO: remove invalid files/links/paths from '" TEST_PATH "/ts/1/PG_10_201707211'\n"
+            "P00 DETAIL: create symlink '" TEST_PATH "/pg/pg_wal' to '../wal'\n"
             "P00 DETAIL: create path '" TEST_PATH "/pg/pg_xact'\n"
+            "P00 DETAIL: create symlink '" TEST_PATH "/pg/pg_hba.conf' to '../config/pg_hba.conf'\n"
             "P01 DETAIL: restore zeroed file " TEST_PATH "/pg/base/32768/32769 (32KB, 49%)\n"
             "P01 DETAIL: restore file " TEST_PATH "/pg/base/16384/16385 - exists and matches backup (16KB, 74%)"
                 " checksum d74e5f7ebe52a3ed468ba08c5b6aefaccd1ca88f\n"


### PR DESCRIPTION
If a path/file was remapped to a link using either --link-map or --link-all there would be no affect if the path/file already existed. If a link existed it would be properly updated and converting a link to a path/file also worked.

The issue happened during delta cleanup, which failed to check if the existing path/file had been remapped to a link.

Add checks for newly mapped path/file links and remove the old path/file we required.