### PR TITLE
Add read range to all storage drivers.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -43,6 +43,17 @@
 
                 <release-development-list>
                     <release-item>
+                        <commit subject="Add read range to all storage drivers."/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="reid.thompson"/>
+                        </release-item-contributor-list>
+
+                        <p>Improve small file support.</p>
+                    </release-item>
+
+                    <release-item>
                         <commit subject="Fix inconsistent group display names in messages."/>
                         <commit subject="Dynamically allocate index to key index map."/>
                         <commit subject="Replace cfgOptionGroupIdxToKey() with cfgOptionGroupName()."/>

--- a/src/common/io/http/header.c
+++ b/src/common/io/http/header.c
@@ -5,6 +5,7 @@ HTTP Header
 
 #include "common/debug.h"
 #include "common/io/http/header.h"
+#include "common/io/http/request.h"
 #include "common/type/keyValue.h"
 
 /***********************************************************************************************************************************
@@ -154,6 +155,32 @@ httpHeaderPut(HttpHeader *this, const String *key, const String *value)
 
     // Store the key
     kvPut(this->kv, VARSTR(key), VARSTR(value));
+
+    FUNCTION_TEST_RETURN(this);
+}
+
+/**********************************************************************************************************************************/
+HttpHeader *
+httpHeaderPutRange(HttpHeader *const this, const uint64_t offset, const Variant *const limit)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(HTTP_HEADER, this);
+        FUNCTION_TEST_PARAM(UINT64, offset);
+        FUNCTION_TEST_PARAM(VARIANT, limit);
+    FUNCTION_TEST_END();
+
+    ASSERT(this != NULL);
+    ASSERT(limit == NULL || varType(limit) == varTypeUInt64);
+
+    if (offset != 0 || limit != NULL)
+    {
+        String *const range = strCatFmt(strNew(), HTTP_HEADER_RANGE_BYTES "=%" PRIu64 "-", offset);
+
+        if (limit != NULL)
+            strCatFmt(range, "%" PRIu64, offset + varUInt64(limit) - 1);
+
+        httpHeaderPut(this, HTTP_HEADER_RANGE_STR, range);
+    }
 
     FUNCTION_TEST_RETURN(this);
 }

--- a/src/common/io/http/header.h
+++ b/src/common/io/http/header.h
@@ -42,6 +42,9 @@ httpHeaderMove(HttpHeader *const this, MemContext *const parentNew)
 // Put a header
 HttpHeader *httpHeaderPut(HttpHeader *this, const String *header, const String *value);
 
+// Put range header when needed
+HttpHeader *httpHeaderPutRange(HttpHeader *this, uint64_t offset, const Variant *limit);
+
 // Should the header be redacted when logging?
 bool httpHeaderRedact(const HttpHeader *this, const String *key);
 

--- a/src/common/io/http/request.c
+++ b/src/common/io/http/request.c
@@ -33,6 +33,7 @@ STRING_EXTERN(HTTP_HEADER_ETAG_STR,                                 HTTP_HEADER_
 STRING_EXTERN(HTTP_HEADER_DATE_STR,                                 HTTP_HEADER_DATE);
 STRING_EXTERN(HTTP_HEADER_HOST_STR,                                 HTTP_HEADER_HOST);
 STRING_EXTERN(HTTP_HEADER_LAST_MODIFIED_STR,                        HTTP_HEADER_LAST_MODIFIED);
+STRING_EXTERN(HTTP_HEADER_RANGE_STR,                                HTTP_HEADER_RANGE);
 #define HTTP_HEADER_USER_AGENT                                      "user-agent"
 
 // 5xx errors that should always be retried

--- a/src/common/io/http/request.h
+++ b/src/common/io/http/request.h
@@ -58,6 +58,9 @@ HTTP Constants
     STRING_DECLARE(HTTP_HEADER_HOST_STR);
 #define HTTP_HEADER_LAST_MODIFIED                                   "last-modified"
     STRING_DECLARE(HTTP_HEADER_LAST_MODIFIED_STR);
+#define HTTP_HEADER_RANGE                                           "range"
+    STRING_DECLARE(HTTP_HEADER_RANGE_STR);
+#define HTTP_HEADER_RANGE_BYTES                                     "bytes"
 
 /***********************************************************************************************************************************
 Constructors

--- a/src/storage/azure/read.c
+++ b/src/storage/azure/read.c
@@ -50,7 +50,9 @@ storageReadAzureOpen(THIS_VOID)
     MEM_CONTEXT_BEGIN(THIS_MEM_CONTEXT())
     {
         this->httpResponse = storageAzureRequestP(
-            this->storage, HTTP_VERB_GET_STR, .path = this->interface.name, .allowMissing = true, .contentIo = true);
+            this->storage, HTTP_VERB_GET_STR, .path = this->interface.name,
+            .header = httpHeaderPutRange(httpHeaderNew(NULL), this->interface.offset, this->interface.limit),
+            .allowMissing = true, .contentIo = true);
     }
     MEM_CONTEXT_END();
 
@@ -106,12 +108,16 @@ storageReadAzureEof(THIS_VOID)
 
 /**********************************************************************************************************************************/
 StorageRead *
-storageReadAzureNew(StorageAzure *storage, const String *name, bool ignoreMissing)
+storageReadAzureNew(
+    StorageAzure *const storage, const String *const name, const bool ignoreMissing, const uint64_t offset,
+    const Variant *const limit)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(STORAGE_AZURE, storage);
         FUNCTION_LOG_PARAM(STRING, name);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
+        FUNCTION_LOG_PARAM(UINT64, offset);
+        FUNCTION_LOG_PARAM(VARIANT, limit);
     FUNCTION_LOG_END();
 
     ASSERT(storage != NULL);
@@ -132,6 +138,8 @@ storageReadAzureNew(StorageAzure *storage, const String *name, bool ignoreMissin
                 .type = STORAGE_AZURE_TYPE,
                 .name = strDup(name),
                 .ignoreMissing = ignoreMissing,
+                .offset = offset,
+                .limit = varDup(limit),
 
                 .ioInterface = (IoReadInterface)
                 {

--- a/src/storage/azure/read.h
+++ b/src/storage/azure/read.h
@@ -10,6 +10,7 @@ Azure Storage Read
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-StorageRead *storageReadAzureNew(StorageAzure *storage, const String *name, bool ignoreMissing);
+StorageRead *storageReadAzureNew(
+    StorageAzure *storage, const String *name, bool ignoreMissing, uint64_t offset, const Variant *limit);
 
 #endif

--- a/src/storage/azure/storage.c
+++ b/src/storage/azure/storage.c
@@ -142,6 +142,7 @@ storageAzureAuth(
             // Generate string to sign
             const String *contentLength = httpHeaderGet(httpHeader, HTTP_HEADER_CONTENT_LENGTH_STR);
             const String *contentMd5 = httpHeaderGet(httpHeader, HTTP_HEADER_CONTENT_MD5_STR);
+            const String *const range = httpHeaderGet(httpHeader, HTTP_HEADER_RANGE_STR);
 
             const String *stringToSign = strNewFmt(
                 "%s\n"                                                  // verb
@@ -155,12 +156,13 @@ storageAzureAuth(
                 "\n"                                                    // If-Match
                 "\n"                                                    // If-None-Match
                 "\n"                                                    // If-Unmodified-Since
-                "\n"                                                    // range
+                "%s\n"                                                  // range
                 "%s"                                                    // Canonicalized headers
                 "/%s%s"                                                 // Canonicalized account/path
                 "%s",                                                   // Canonicalized query
                 strZ(verb), strEq(contentLength, ZERO_STR) ? "" : strZ(contentLength), contentMd5 == NULL ? "" : strZ(contentMd5),
-                strZ(dateTime), strZ(headerCanonical), strZ(this->account), strZ(path), strZ(queryCanonical));
+                strZ(dateTime), range == NULL ? "" : strZ(range), strZ(headerCanonical), strZ(this->account), strZ(path),
+                strZ(queryCanonical));
 
             // Generate authorization header
             httpHeaderPut(
@@ -537,13 +539,14 @@ storageAzureNewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageIn
         FUNCTION_LOG_PARAM(STORAGE_AZURE, this);
         FUNCTION_LOG_PARAM(STRING, file);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
-        (void)param;                                                // No parameters are used
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
+        FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
     ASSERT(file != NULL);
 
-    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadAzureNew(this, file, ignoreMissing));
+    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadAzureNew(this, file, ignoreMissing, param.offset, param.limit));
 }
 
 /**********************************************************************************************************************************/

--- a/src/storage/gcs/read.c
+++ b/src/storage/gcs/read.c
@@ -56,7 +56,9 @@ storageReadGcsOpen(THIS_VOID)
     MEM_CONTEXT_BEGIN(THIS_MEM_CONTEXT())
     {
         this->httpResponse = storageGcsRequestP(
-            this->storage, HTTP_VERB_GET_STR, .object = this->interface.name, .allowMissing = true, .contentIo = true,
+            this->storage, HTTP_VERB_GET_STR, .object = this->interface.name,
+            .header = httpHeaderPutRange(httpHeaderNew(NULL), this->interface.offset, this->interface.limit),
+            .allowMissing = true, .contentIo = true,
             .query = httpQueryAdd(httpQueryNewP(), GCS_QUERY_ALT_STR, GCS_QUERY_MEDIA_STR));
     }
     MEM_CONTEXT_END();
@@ -113,12 +115,16 @@ storageReadGcsEof(THIS_VOID)
 
 /**********************************************************************************************************************************/
 StorageRead *
-storageReadGcsNew(StorageGcs *storage, const String *name, bool ignoreMissing)
+storageReadGcsNew(
+    StorageGcs *const storage, const String *const name, const bool ignoreMissing, const uint64_t offset,
+    const Variant *const limit)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(STORAGE_GCS, storage);
         FUNCTION_LOG_PARAM(STRING, name);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
+        FUNCTION_LOG_PARAM(UINT64, offset);
+        FUNCTION_LOG_PARAM(VARIANT, limit);
     FUNCTION_LOG_END();
 
     ASSERT(storage != NULL);
@@ -139,6 +145,8 @@ storageReadGcsNew(StorageGcs *storage, const String *name, bool ignoreMissing)
                 .type = STORAGE_GCS_TYPE,
                 .name = strDup(name),
                 .ignoreMissing = ignoreMissing,
+                .offset = offset,
+                .limit = varDup(limit),
 
                 .ioInterface = (IoReadInterface)
                 {

--- a/src/storage/gcs/read.h
+++ b/src/storage/gcs/read.h
@@ -10,6 +10,6 @@ GCS Storage Read
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-StorageRead *storageReadGcsNew(StorageGcs *storage, const String *name, bool ignoreMissing);
+StorageRead *storageReadGcsNew(StorageGcs *storage, const String *name, bool ignoreMissing, uint64_t offset, const Variant *limit);
 
 #endif

--- a/src/storage/gcs/storage.c
+++ b/src/storage/gcs/storage.c
@@ -761,13 +761,14 @@ storageGcsNewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageInte
         FUNCTION_LOG_PARAM(STORAGE_GCS, this);
         FUNCTION_LOG_PARAM(STRING, file);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
-        (void)param;                                                // No parameters are used
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
+        FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
     ASSERT(file != NULL);
 
-    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadGcsNew(this, file, ignoreMissing));
+    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadGcsNew(this, file, ignoreMissing, param.offset, param.limit));
 }
 
 /**********************************************************************************************************************************/

--- a/src/storage/posix/read.c
+++ b/src/storage/posix/read.c
@@ -95,6 +95,14 @@ storageReadPosixOpen(THIS_VOID)
         result = true;
     }
 
+    // Seek to offset
+    if (this->interface.offset != 0)
+    {
+        THROW_ON_SYS_ERROR_FMT(
+            lseek(this->fd, (off_t)this->interface.offset, SEEK_SET) == -1, FileOpenError, STORAGE_ERROR_READ_SEEK,
+            this->interface.offset, strZ(this->interface.name));
+    }
+
     FUNCTION_LOG_RETURN(BOOL, result);
 }
 
@@ -203,11 +211,14 @@ storageReadPosixFd(const THIS_VOID)
 
 /**********************************************************************************************************************************/
 StorageRead *
-storageReadPosixNew(StoragePosix *storage, const String *name, bool ignoreMissing, const Variant *limit)
+storageReadPosixNew(
+    StoragePosix *const storage, const String *const name, const bool ignoreMissing, const uint64_t offset,
+    const Variant *const limit)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(STRING, name);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
+        FUNCTION_LOG_PARAM(UINT64, offset);
         FUNCTION_LOG_PARAM(VARIANT, limit);
     FUNCTION_LOG_END();
 
@@ -234,6 +245,7 @@ storageReadPosixNew(StoragePosix *storage, const String *name, bool ignoreMissin
                 .type = STORAGE_POSIX_TYPE,
                 .name = strDup(name),
                 .ignoreMissing = ignoreMissing,
+                .offset = offset,
                 .limit = varDup(limit),
 
                 .ioInterface = (IoReadInterface)

--- a/src/storage/posix/read.h
+++ b/src/storage/posix/read.h
@@ -10,6 +10,7 @@ Posix Storage Read
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-StorageRead *storageReadPosixNew(StoragePosix *storage, const String *name, bool ignoreMissing, const Variant *limit);
+StorageRead *storageReadPosixNew(
+    StoragePosix *storage, const String *name, bool ignoreMissing, uint64_t offset, const Variant *limit);
 
 #endif

--- a/src/storage/posix/storage.c
+++ b/src/storage/posix/storage.c
@@ -310,13 +310,14 @@ storagePosixNewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageIn
         FUNCTION_LOG_PARAM(STORAGE_POSIX, this);
         FUNCTION_LOG_PARAM(STRING, file);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
         FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
     ASSERT(file != NULL);
 
-    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadPosixNew(this, file, ignoreMissing, param.limit));
+    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadPosixNew(this, file, ignoreMissing, param.offset, param.limit));
 }
 
 /**********************************************************************************************************************************/
@@ -545,7 +546,7 @@ storagePosixRemove(THIS_VOID, const String *file, StorageInterfaceRemoveParam pa
 /**********************************************************************************************************************************/
 static const StorageInterface storageInterfacePosix =
 {
-    .feature = 1 << storageFeaturePath | 1 << storageFeatureCompress | 1 << storageFeatureLimitRead,
+    .feature = 1 << storageFeaturePath | 1 << storageFeatureCompress,
 
     .info = storagePosixInfo,
     .infoList = storagePosixInfoList,

--- a/src/storage/read.h
+++ b/src/storage/read.h
@@ -61,6 +61,13 @@ storageReadName(const StorageRead *const this)
     return THIS_PUB(StorageRead)->interface->name;
 }
 
+// Is there a read limit? NULL for no limit.
+__attribute__((always_inline)) static inline uint64_t
+storageReadOffset(const StorageRead *const this)
+{
+    return THIS_PUB(StorageRead)->interface->offset;
+}
+
 // Get file type
 __attribute__((always_inline)) static inline StringId
 storageReadType(const StorageRead *const this)

--- a/src/storage/read.intern.h
+++ b/src/storage/read.intern.h
@@ -16,6 +16,7 @@ typedef struct StorageReadInterface
     bool compressible;                                              // Is this file compressible?
     unsigned int compressLevel;                                     // Level to use for compression
     bool ignoreMissing;
+    uint64_t offset;                                                // Where to start reading in the file
     const Variant *limit;                                           // Limit how many bytes are read (NULL for no limit)
     IoReadInterface ioInterface;
 } StorageReadInterface;

--- a/src/storage/remote/protocol.c
+++ b/src/storage/remote/protocol.c
@@ -355,12 +355,13 @@ storageRemoteOpenReadProtocol(PackRead *const param, ProtocolServer *const serve
     {
         const String *file = pckReadStrP(param);
         bool ignoreMissing = pckReadBoolP(param);
+        const uint64_t offset = pckReadU64P(param);
         const Variant *limit = jsonToVar(pckReadStrP(param));
         const Pack *const filter = pckReadPackP(param);
 
         // Create the read object
         IoRead *fileRead = storageReadIo(
-            storageInterfaceNewReadP(storageRemoteProtocolLocal.driver, file, ignoreMissing, .limit = limit));
+            storageInterfaceNewReadP(storageRemoteProtocolLocal.driver, file, ignoreMissing, .offset = offset, .limit = limit));
 
         // Set filter group based on passed filters
         storageRemoteFilterGroup(ioReadFilterGroup(fileRead), filter);

--- a/src/storage/remote/read.c
+++ b/src/storage/remote/read.c
@@ -74,6 +74,7 @@ storageReadRemoteOpen(THIS_VOID)
 
         pckWriteStrP(param, this->interface.name);
         pckWriteBoolP(param, this->interface.ignoreMissing);
+        pckWriteU64P(param, this->interface.offset);
         pckWriteStrP(param, jsonFromVar(this->interface.limit));
         pckWritePackP(param, ioFilterGroupParamAll(ioReadFilterGroup(storageReadIo(this->read))));
 
@@ -207,8 +208,8 @@ storageReadRemoteEof(THIS_VOID)
 /**********************************************************************************************************************************/
 StorageRead *
 storageReadRemoteNew(
-    StorageRemote *storage, ProtocolClient *client, const String *name, bool ignoreMissing, bool compressible,
-    unsigned int compressLevel, const Variant *limit)
+    StorageRemote *const storage, ProtocolClient *const client, const String *const name, const bool ignoreMissing,
+    const bool compressible, const unsigned int compressLevel, const uint64_t offset, const Variant *const limit)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(STORAGE_REMOTE, storage);
@@ -217,6 +218,7 @@ storageReadRemoteNew(
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
         FUNCTION_LOG_PARAM(BOOL, compressible);
         FUNCTION_LOG_PARAM(UINT, compressLevel);
+        FUNCTION_LOG_PARAM(UINT64, offset);
         FUNCTION_LOG_PARAM(VARIANT, limit);
     FUNCTION_LOG_END();
 
@@ -242,6 +244,7 @@ storageReadRemoteNew(
                 .compressible = compressible,
                 .compressLevel = compressLevel,
                 .ignoreMissing = ignoreMissing,
+                .offset = offset,
                 .limit = varDup(limit),
 
                 .ioInterface = (IoReadInterface)

--- a/src/storage/remote/read.h
+++ b/src/storage/remote/read.h
@@ -13,6 +13,6 @@ Constructors
 ***********************************************************************************************************************************/
 StorageRead *storageReadRemoteNew(
     StorageRemote *storage, ProtocolClient *client, const String *name, bool ignoreMissing, bool compressible,
-    unsigned int compressLevel, const Variant *limit);
+    unsigned int compressLevel, uint64_t offset, const Variant *limit);
 
 #endif

--- a/src/storage/remote/storage.c
+++ b/src/storage/remote/storage.c
@@ -246,6 +246,7 @@ storageRemoteNewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageI
         FUNCTION_LOG_PARAM(STRING, file);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
         FUNCTION_LOG_PARAM(BOOL, param.compressible);
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
         FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
@@ -256,7 +257,7 @@ storageRemoteNewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageI
         STORAGE_READ,
         storageReadRemoteNew(
             this, this->client, file, ignoreMissing, this->compressLevel > 0 ? param.compressible : false, this->compressLevel,
-            param.limit));
+            param.offset, param.limit));
 }
 
 /**********************************************************************************************************************************/

--- a/src/storage/s3/read.h
+++ b/src/storage/s3/read.h
@@ -10,6 +10,7 @@ S3 Storage Read
 /***********************************************************************************************************************************
 Constructors
 ***********************************************************************************************************************************/
-StorageRead *storageReadS3New(StorageS3 *storage, const String *name, bool ignoreMissing);
+StorageRead *storageReadS3New(
+    StorageS3 *storage, const String *name, bool ignoreMissing, uint64_t offset, const Variant *limit);
 
 #endif

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -420,6 +420,7 @@ storageS3RequestAsync(StorageS3 *this, const String *verb, const String *path, S
         FUNCTION_LOG_PARAM(STORAGE_S3, this);
         FUNCTION_LOG_PARAM(STRING, verb);
         FUNCTION_LOG_PARAM(STRING, path);
+        FUNCTION_LOG_PARAM(HTTP_HEADER, param.header);
         FUNCTION_LOG_PARAM(HTTP_QUERY, param.query);
         FUNCTION_LOG_PARAM(BUFFER, param.content);
     FUNCTION_LOG_END();
@@ -432,7 +433,8 @@ storageS3RequestAsync(StorageS3 *this, const String *verb, const String *path, S
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        HttpHeader *requestHeader = httpHeaderNew(this->headerRedactList);
+        HttpHeader *requestHeader = param.header == NULL ?
+            httpHeaderNew(this->headerRedactList) : httpHeaderDup(param.header, this->headerRedactList);
 
         // Set content length
         httpHeaderAdd(
@@ -545,6 +547,7 @@ storageS3Request(StorageS3 *this, const String *verb, const String *path, Storag
         FUNCTION_LOG_PARAM(STORAGE_S3, this);
         FUNCTION_LOG_PARAM(STRING, verb);
         FUNCTION_LOG_PARAM(STRING, path);
+        FUNCTION_LOG_PARAM(HTTP_HEADER, param.header);
         FUNCTION_LOG_PARAM(HTTP_QUERY, param.query);
         FUNCTION_LOG_PARAM(BUFFER, param.content);
         FUNCTION_LOG_PARAM(BOOL, param.allowMissing);
@@ -554,7 +557,7 @@ storageS3Request(StorageS3 *this, const String *verb, const String *path, Storag
     FUNCTION_LOG_RETURN(
         HTTP_RESPONSE,
         storageS3ResponseP(
-            storageS3RequestAsyncP(this, verb, path, .query = param.query, .content = param.content),
+            storageS3RequestAsyncP(this, verb, path, .header = param.header, .query = param.query, .content = param.content),
             .allowMissing = param.allowMissing, .contentIo = param.contentIo));
 }
 
@@ -640,7 +643,7 @@ storageS3ListInternal(
                 }
                 // Else get the response immediately from a sync request
                 else
-                    response = storageS3RequestP(this, HTTP_VERB_GET_STR, FSLASH_STR, query);
+                    response = storageS3RequestP(this, HTTP_VERB_GET_STR, FSLASH_STR, .query = query);
 
                 XmlNode *xmlRoot = xmlDocumentRoot(xmlDocumentNewBuf(httpResponseContent(response)));
 
@@ -655,7 +658,7 @@ storageS3ListInternal(
                     // Store request in the outer temp context
                     MEM_CONTEXT_PRIOR_BEGIN()
                     {
-                        request = storageS3RequestAsyncP(this, HTTP_VERB_GET_STR, FSLASH_STR, query);
+                        request = storageS3RequestAsyncP(this, HTTP_VERB_GET_STR, FSLASH_STR, .query = query);
                     }
                     MEM_CONTEXT_PRIOR_END();
                 }
@@ -801,13 +804,14 @@ storageS3NewRead(THIS_VOID, const String *file, bool ignoreMissing, StorageInter
         FUNCTION_LOG_PARAM(STORAGE_S3, this);
         FUNCTION_LOG_PARAM(STRING, file);
         FUNCTION_LOG_PARAM(BOOL, ignoreMissing);
-        (void)param;                                                // No parameters are used
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
+        FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
     ASSERT(file != NULL);
 
-    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadS3New(this, file, ignoreMissing));
+    FUNCTION_LOG_RETURN(STORAGE_READ, storageReadS3New(this, file, ignoreMissing, param.offset, param.limit));
 }
 
 /**********************************************************************************************************************************/

--- a/src/storage/s3/storage.intern.h
+++ b/src/storage/s3/storage.intern.h
@@ -19,6 +19,7 @@ Functions
 typedef struct StorageS3RequestAsyncParam
 {
     VAR_PARAM_HEADER;
+    const HttpHeader *header;                                       // Headers
     const HttpQuery *query;                                         // Query parameters
     const Buffer *content;                                          // Request content
 } StorageS3RequestAsyncParam;
@@ -45,6 +46,7 @@ HttpResponse *storageS3Response(HttpRequest *request, StorageS3ResponseParam par
 typedef struct StorageS3RequestParam
 {
     VAR_PARAM_HEADER;
+    const HttpHeader *header;                                       // Headers
     const HttpQuery *query;                                         // Query parameters
     const Buffer *content;                                          // Request content
     bool allowMissing;                                              // Allow missing files (caller can check response code)

--- a/src/storage/storage.c
+++ b/src/storage/storage.c
@@ -608,11 +608,11 @@ storageNewRead(const Storage *this, const String *fileExp, StorageNewReadParam p
         FUNCTION_LOG_PARAM(STRING, fileExp);
         FUNCTION_LOG_PARAM(BOOL, param.ignoreMissing);
         FUNCTION_LOG_PARAM(BOOL, param.compressible);
+        FUNCTION_LOG_PARAM(UINT64, param.offset);
         FUNCTION_LOG_PARAM(VARIANT, param.limit);
     FUNCTION_LOG_END();
 
     ASSERT(this != NULL);
-    ASSERT(storageFeature(this, storageFeatureLimitRead) || param.limit == NULL);
     ASSERT(param.limit == NULL || varType(param.limit) == varTypeUInt64);
 
     StorageRead *result = NULL;
@@ -622,7 +622,7 @@ storageNewRead(const Storage *this, const String *fileExp, StorageNewReadParam p
         result = storageReadMove(
             storageInterfaceNewReadP(
                 storageDriver(this), storagePathP(this, fileExp), param.ignoreMissing, .compressible = param.compressible,
-                .limit = param.limit),
+                .offset = param.offset, .limit = param.limit),
             memContextPrior());
     }
     MEM_CONTEXT_TEMP_END();

--- a/src/storage/storage.h
+++ b/src/storage/storage.h
@@ -43,9 +43,6 @@ typedef enum
     // Does the storage support hardlinks?  Hardlinks allow the same file to be linked into multiple paths to save space.
     storageFeatureHardLink,
 
-    // Can the storage limit the amount of data read from a file?
-    storageFeatureLimitRead,
-
     // Does the storage support symlinks?  Symlinks allow paths/files/links to be accessed from another path.
     storageFeatureSymLink,
 
@@ -146,6 +143,9 @@ typedef struct StorageNewReadParam
     VAR_PARAM_HEADER;
     bool ignoreMissing;
     bool compressible;
+
+    // Where to start reading in the file
+    const uint64_t offset;
 
     // Limit bytes to read from the file (must be varTypeUInt64). NULL for no limit.
     const Variant *limit;

--- a/src/storage/storage.intern.h
+++ b/src/storage/storage.intern.h
@@ -30,6 +30,7 @@ Error messages
 #define STORAGE_ERROR_READ_CLOSE                                    "unable to close file '%s' after read"
 #define STORAGE_ERROR_READ_OPEN                                     "unable to open file '%s' for read"
 #define STORAGE_ERROR_READ_MISSING                                  "unable to open missing file '%s' for read"
+#define STORAGE_ERROR_READ_SEEK                                     "unable to seek to %" PRIu64 " in file '%s'"
 
 #define STORAGE_ERROR_INFO                                          "unable to get info for path/file '%s'"
 #define STORAGE_ERROR_INFO_MISSING                                  "unable to get info for missing path/file '%s'"
@@ -88,6 +89,9 @@ typedef struct StorageInterfaceNewReadParam
 
     // Is the file compressible? This is used when the file must be moved across a network and temporary compression is helpful.
     bool compressible;
+
+    // Where to start reading in the file
+    const uint64_t offset;
 
     // Limit bytes read from the file. NULL for no limit.
     const Variant *limit;

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -77,7 +77,18 @@ testRun(void)
         TEST_RESULT_STR_Z(httpHeaderGet(header, STRDEF("key2")), "value2a, value2b", "get value");
         TEST_RESULT_STR(httpHeaderGet(header, STRDEF(BOGUS_STR)), NULL, "get missing value");
 
-        TEST_RESULT_STR_Z(httpHeaderToLog(header), "{key1: 'value1', key2: 'value2a, value2b'}", "log output");
+        TEST_RESULT_STR(httpHeaderGet(httpHeaderPutRange(header, 0, NULL), HTTP_HEADER_RANGE_STR), NULL, "do not put range header");
+        TEST_RESULT_STR_Z(
+            httpHeaderGet(httpHeaderPutRange(header, 1, VARUINT64(21)), HTTP_HEADER_RANGE_STR), "bytes=1-21",
+            "put range header with offset and limit");
+        TEST_RESULT_STR_Z(
+            httpHeaderGet(httpHeaderPutRange(header, 0, VARUINT64(21)), HTTP_HEADER_RANGE_STR), "bytes=0-20",
+            "put range header with offset and limit");
+        TEST_RESULT_STR_Z(
+            httpHeaderGet(httpHeaderPutRange(header, 44, NULL), HTTP_HEADER_RANGE_STR), "bytes=44-",
+            "put range header with offset");
+
+        TEST_RESULT_STR_Z(httpHeaderToLog(header), "{key1: 'value1', key2: 'value2a, value2b', range: 'bytes=44-'}", "log output");
 
         TEST_RESULT_VOID(httpHeaderFree(header), "free header");
 

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -27,6 +27,7 @@ typedef struct TestRequestParam
     const char *content;
     const char *accessKey;
     const char *securityToken;
+    const char *range;
 } TestRequestParam;
 
 #define testRequestP(write, s3, verb, path, ...)                                                                                   \
@@ -64,7 +65,12 @@ testRequest(IoWrite *write, Storage *s3, const char *verb, const char *path, Tes
         if (param.content != NULL)
             strCatZ(request, "content-md5;");
 
-        strCatZ(request, "host;x-amz-content-sha256;x-amz-date");
+        strCatZ(request, "host;");
+
+        if (param.range != NULL)
+            strCatZ(request, "range;");
+
+        strCatZ(request, "x-amz-content-sha256;x-amz-date");
 
         if (securityToken != NULL)
             strCatZ(request, ";x-amz-security-token");
@@ -93,6 +99,10 @@ testRequest(IoWrite *write, Storage *s3, const char *verb, const char *path, Tes
     }
     else
         strCatFmt(request, "host:%s\r\n", strZ(hrnServerHost()));
+
+    // Add range
+    if (param.range != NULL)
+        strCatFmt(request, "range:bytes=%s\r\n", param.range);
 
     // Add content checksum and date if s3 service
     if (s3 != NULL)
@@ -417,13 +427,14 @@ testRun(void)
                     "unable to open missing file '/file.txt' for read");
 
                 // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("get file");
+                TEST_TITLE("get file with offset and limit");
 
-                testRequestP(service, s3, HTTP_VERB_GET, "/file.txt");
+                testRequestP(service, s3, HTTP_VERB_GET, "/file.txt", .range = "1-21");
                 testResponseP(service, .content = "this is a sample file");
 
                 TEST_RESULT_STR_Z(
-                    strNewBuf(storageGetP(storageNewReadP(s3, STRDEF("file.txt")))), "this is a sample file", "get file");
+                    strNewBuf(storageGetP(storageNewReadP(s3, STRDEF("file.txt"), .offset = 1, .limit = VARUINT64(21)))),
+                    "this is a sample file", "get file");
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("get zero-length file");


### PR DESCRIPTION
The range feature allows reading out an arbitrary chunk of a file and will be important for efficient small file support.

Now that all drivers are required to support ranges remove the storageFeatureLimitRead feature flag that was implemented only by the Posix driver.