### PR TITLE
Retry errors in S3 batch file delete.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -20,6 +20,21 @@
                     <p><b>IMPORTANT NOTE</b>: Repository size reported by the <cmd>info</cmd> command is now entirely based on what <backrest/> has written to storage. Previously, in certain cases, <backrest/> could detect if additional compression was being applied by the storage but this is no longer supported.</p>
                 </text>
 
+                <release-bug-list>
+                    <release-item>
+                        <github-issue id="1650"/>
+                        <github-pull-request id="1653"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="alex.richman"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="reid.thompson"/>
+                        </release-item-contributor-list>
+
+                        <p>Retry errors in S3 batch file delete.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-feature-list>
                     <release-item>
                         <github-issue id="1430"/>
@@ -10546,6 +10561,11 @@
         <contributor id="ales.zeleny">
             <contributor-name-display>Ale&amp;scaron; Zelen&amp;yacute;</contributor-name-display>
             <contributor-id type="github">aleszeleny</contributor-id>
+        </contributor>
+
+        <contributor id="alex.richman">
+            <contributor-name-display>Alex Richman</contributor-name-display>
+            <contributor-id type="github">alex-richman-onesignal</contributor-id>
         </contributor>
 
         <contributor id="anderson.a.mallmann">

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -1304,7 +1304,7 @@ testRun(void)
                 TEST_RESULT_VOID(storagePathRemoveP(s3, STRDEF("/path/to"), .recurse = true), "remove");
 
                 // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("remove error");
+                TEST_TITLE("path remove error and retry");
 
                 testRequestP(service, s3, HTTP_VERB_GET, "/bucket/?list-type=2&prefix=path%2F");
                 testResponseP(
@@ -1333,12 +1333,13 @@ testRun(void)
                     .content =
                         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                         "<DeleteResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-                            "<Error><Key>sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"
+                            "<Error><Key>path/sample2.txt</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"
                             "</DeleteResult>");
 
-                TEST_ERROR(
-                    storagePathRemoveP(s3, STRDEF("/path"), .recurse = true), FileRemoveError,
-                    "unable to remove file 'sample2.txt': [AccessDenied] Access Denied");
+                testRequestP(service, s3, HTTP_VERB_DELETE, "/bucket/path/sample2.txt");
+                testResponseP(service, .code = 204);
+
+                TEST_RESULT_VOID(storagePathRemoveP(s3, STRDEF("/path"), .recurse = true), "remove path");
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("remove file");


### PR DESCRIPTION
If the entire batch failed it would be retried, but individual file errors were not retried. This could cause pgBackRest to terminate during expiration or when removing an unresumable backup.

Rather than retry the entire batch, delete the errored files individually to take advantage of the HTTP retry rather than adding a new retry loop. These errors seems rare enough that it should not be a performance issue.