### PR TITLE
Limit files that can be bundled.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -128,7 +128,14 @@
                         <commit subject="Optimization for jsonFromStrInternal()."/>
                         <commit subject="Simplify manifest file defaults."/>
                         <commit subject="Simplify filename construction in command/verify module."/>
-                        <commit subject="Bundle files in the repository during backup."/>
+                        <commit subject="Bundle files in the repository during backup.">
+                            <github-issue id="1149"/>
+                            <github-pull-request id="1655"/>
+                        </commit>
+                        <commit subject="Limit files that can be bundled.">
+                            <github-issue id="1149"/>
+                            <github-pull-request id="1662"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1120,7 +1120,7 @@ option:
     internal: true
     section: global
     type: size
-    default: 100MiB
+    default: 20MiB
     allow-range: [1MiB, 1PiB]
     command:
       backup: {}
@@ -1130,6 +1130,11 @@ option:
       option: bundle
       list:
         - true
+
+  bundle-limit:
+    inherit: bundle-size
+    default: 2MiB
+    allow-range: [8KiB, 1PiB]
 
   checksum-page:
     section: global

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1181,10 +1181,6 @@ option:
       backup: {}
     command-role:
       main: {}
-    depend:
-      option: bundle
-      list:
-        - false
 
   start-fast:
     section: global

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1133,6 +1133,17 @@
                         <example>10MiB</example>
                     </config-key>
 
+                    <!-- ======================================================================================================= -->
+                    <config-key id="bundle-limit" name="Repository Bundle Limit">
+                        <summary>Limit for file bundles.</summary>
+
+                        <text>
+                            <p>Size limit for files that will be included in bundles. Files larger than this size will be stored separately.</p>
+                        </text>
+
+                        <example>10MiB</example>
+                    </config-key>
+
                     <!-- CONFIG - BACKUP SECTION - CHECKSUM-PAGE KEY -->
                     <config-key id="checksum-page" name="Page Checksums">
                         <summary>Validate data page checksums.</summary>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1176,7 +1176,8 @@ backupJobResult(
         MEM_CONTEXT_TEMP_BEGIN()
         {
             const unsigned int processId = protocolParallelJobProcessId(job);
-            const uint64_t bundleId = bundle ? varUInt64(protocolParallelJobKey(job)) : 0;
+            const uint64_t bundleId = varType(protocolParallelJobKey(job)) == varTypeUInt64 ?
+                varUInt64(protocolParallelJobKey(job)) : 0;
             PackRead *const jobResult = protocolParallelJobResult(job);
 
             while (!pckReadNullP(jobResult))
@@ -1407,7 +1408,8 @@ typedef struct BackupJobData
     const bool delta;                                               // Is this a checksum delta backup?
     const uint64_t lsnStart;                                        // Starting lsn for the backup
     const bool bundle;                                              // Bundle files?
-    const uint64_t bundleSize;                                      // Target bundle size
+    uint64_t bundleSize;                                            // Target bundle size
+    uint64_t bundleLimit;                                           // Limit on files to bundle
     uint64_t bundleId;                                              // Bundle id
 
     List *queueList;                                                // List of processing queues
@@ -1432,7 +1434,7 @@ backupProcessFilePrimary(RegExp *const standbyExp, const String *const name)
 // Comparator to order ManifestFile objects by size, date, and name
 static const Manifest *backupProcessQueueComparatorManifest = NULL;
 static bool backupProcessQueueComparatorBundle;
-static uint64_t backupProcessQueueComparatorBundleSize;
+static uint64_t backupProcessQueueComparatorBundleLimit;
 
 static int
 backupProcessQueueComparator(const void *item1, const void *item2)
@@ -1450,8 +1452,8 @@ backupProcessQueueComparator(const void *item1, const void *item2)
     ManifestFile file2 = manifestFileUnpack(backupProcessQueueComparatorManifest, *(const ManifestFilePack **)item2);
 
     // If the size differs then that's enough to determine order
-    if (!backupProcessQueueComparatorBundle || file1.size >= backupProcessQueueComparatorBundleSize ||
-        file2.size >= backupProcessQueueComparatorBundleSize)
+    if (!backupProcessQueueComparatorBundle || file1.size > backupProcessQueueComparatorBundleLimit ||
+        file2.size > backupProcessQueueComparatorBundleLimit)
     {
         if (file1.size < file2.size)
             FUNCTION_TEST_RETURN(-1);
@@ -1594,7 +1596,7 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
         // Sort the queues
         backupProcessQueueComparatorManifest = manifest;
         backupProcessQueueComparatorBundle = jobData->bundle;
-        backupProcessQueueComparatorBundleSize = jobData->bundleSize;
+        backupProcessQueueComparatorBundleLimit = jobData->bundleLimit;
 
         for (unsigned int queueIdx = 0; queueIdx < lstSize(jobData->queueList); queueIdx++)
             lstSort(*(List **)lstGet(jobData->queueList, queueIdx), sortOrderDesc);
@@ -1663,6 +1665,8 @@ static ProtocolParallelJob *backupJobCallback(void *data, unsigned int clientIdx
         {
             List *queue = *(List **)lstGet(jobData->queueList, (unsigned int)queueIdx + queueOffset);
             unsigned int fileIdx = 0;
+            bool bundle = jobData->bundle;
+            const String *fileName = NULL;
 
             while (fileIdx < lstSize(queue))
             {
@@ -1682,10 +1686,16 @@ static ProtocolParallelJob *backupJobCallback(void *data, unsigned int clientIdx
 
                     String *const repoFile = strCatFmt(strNew(), STORAGE_REPO_BACKUP "/%s/", strZ(jobData->backupLabel));
 
-                    if (jobData->bundle)
+                    if (bundle && file.size <= jobData->bundleLimit)
                         strCatFmt(repoFile, MANIFEST_PATH_BUNDLE "/%" PRIu64, jobData->bundleId);
                     else
+                    {
+                        CHECK(AssertError, fileTotal == 0, "cannot bundle file");
+
                         strCatFmt(repoFile, "%s%s", strZ(file.name), strZ(compressExtStr(jobData->compressType)));
+                        fileName = file.name;
+                        bundle = false;
+                    }
 
                     pckWriteStrP(param, repoFile);
                     pckWriteU32P(param, jobData->compressType);
@@ -1712,7 +1722,7 @@ static ProtocolParallelJob *backupJobCallback(void *data, unsigned int clientIdx
                 lstRemoveIdx(queue, fileIdx);
 
                 // Break if not bundling or bundle size has been reached
-                if (!jobData->bundle || fileSize >= jobData->bundleSize)
+                if (!bundle || fileSize >= jobData->bundleSize)
                     break;
             }
 
@@ -1721,8 +1731,10 @@ static ProtocolParallelJob *backupJobCallback(void *data, unsigned int clientIdx
                 // Assign job to result
                 MEM_CONTEXT_PRIOR_BEGIN()
                 {
-                    result = protocolParallelJobNew(VARUINT64(jobData->bundleId), command);
-                    jobData->bundleId++;
+                    result = protocolParallelJobNew(bundle ? VARUINT64(jobData->bundleId) : VARSTR(fileName), command);
+
+                    if (bundle)
+                        jobData->bundleId++;
                 }
                 MEM_CONTEXT_PRIOR_END();
 
@@ -1775,7 +1787,6 @@ backupProcess(BackupData *backupData, Manifest *manifest, const String *lsnStart
             .delta = cfgOptionBool(cfgOptDelta),
             .lsnStart = cfgOptionBool(cfgOptOnline) ? pgLsnFromStr(lsnStart) : 0xFFFFFFFFFFFFFFFF,
             .bundle = cfgOptionBool(cfgOptBundle),
-            .bundleSize = cfgOptionTest(cfgOptBundleSize) ? cfgOptionUInt64(cfgOptBundleSize) : 0,
             .bundleId = 1,
 
             // Build expression to identify files that can be copied from the standby when standby backup is supported
@@ -1785,6 +1796,12 @@ backupProcess(BackupData *backupData, Manifest *manifest, const String *lsnStart
                         MANIFEST_TARGET_PGTBLSPC ")/",
                     strZ(pgXactPath(backupData->version)))),
         };
+
+        if (jobData.bundle)
+        {
+            jobData.bundleSize = cfgOptionUInt64(cfgOptBundleSize);
+            jobData.bundleLimit = cfgOptionUInt64(cfgOptBundleLimit);
+        }
 
         // If this is a full backup or hard-linked and paths are supported then create all paths explicitly so that empty paths will
         // exist in to repo. Also create tablespace symlinks when symlinks are available. This makes it possible for the user to

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -674,7 +674,7 @@ backupResumeFind(const Manifest *manifest, const String *cipherPassBackup)
             // Resumable backups do not have backup.manifest
             if (!storageExistsP(storageRepo(), manifestFile))
             {
-                const bool resume = cfgOptionTest(cfgOptResume) && cfgOptionBool(cfgOptResume);
+                const bool resume = cfgOptionBool(cfgOptResume);
                 bool usable = false;
                 const String *reason = STRDEF("partially deleted by prior resume or invalid");
                 Manifest *manifestResume = NULL;

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -54,6 +54,7 @@ Option constants
 #define CFGOPT_BACKUP_STANDBY                                       "backup-standby"
 #define CFGOPT_BUFFER_SIZE                                          "buffer-size"
 #define CFGOPT_BUNDLE                                               "bundle"
+#define CFGOPT_BUNDLE_LIMIT                                         "bundle-limit"
 #define CFGOPT_BUNDLE_SIZE                                          "bundle-size"
 #define CFGOPT_CHECKSUM_PAGE                                        "checksum-page"
 #define CFGOPT_CIPHER_PASS                                          "cipher-pass"
@@ -128,7 +129,7 @@ Option constants
 #define CFGOPT_TLS_SERVER_PORT                                      "tls-server-port"
 #define CFGOPT_TYPE                                                 "type"
 
-#define CFG_OPTION_TOTAL                                            152
+#define CFG_OPTION_TOTAL                                            153
 
 /***********************************************************************************************************************************
 Option value constants
@@ -366,6 +367,7 @@ typedef enum
     cfgOptBackupStandby,
     cfgOptBufferSize,
     cfgOptBundle,
+    cfgOptBundleLimit,
     cfgOptBundleSize,
     cfgOptChecksumPage,
     cfgOptCipherPass,

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -7824,12 +7824,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         (
             PARSE_RULE_OPTIONAL_GROUP
             (
-                PARSE_RULE_OPTIONAL_DEPEND
-                (
-                    PARSE_RULE_VAL_OPT(cfgOptBundle),
-                    PARSE_RULE_VAL_BOOL_FALSE,
-                ),
-
                 PARSE_RULE_OPTIONAL_DEFAULT
                 (
                     PARSE_RULE_VAL_BOOL_TRUE,

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -16,7 +16,6 @@ static const StringPub parseRuleValueStr[] =
     PARSE_RULE_STRPUB("/var/log/pgbackrest"),
     PARSE_RULE_STRPUB("/var/spool/pgbackrest"),
     PARSE_RULE_STRPUB("1"),
-    PARSE_RULE_STRPUB("100MiB"),
     PARSE_RULE_STRPUB("128MiB"),
     PARSE_RULE_STRPUB("15"),
     PARSE_RULE_STRPUB("1800"),
@@ -24,6 +23,8 @@ static const StringPub parseRuleValueStr[] =
     PARSE_RULE_STRPUB("1GiB"),
     PARSE_RULE_STRPUB("1MiB"),
     PARSE_RULE_STRPUB("2"),
+    PARSE_RULE_STRPUB("20MiB"),
+    PARSE_RULE_STRPUB("2MiB"),
     PARSE_RULE_STRPUB("3"),
     PARSE_RULE_STRPUB("443"),
     PARSE_RULE_STRPUB("5432"),
@@ -64,7 +65,6 @@ typedef enum
     parseRuleValStrQT_FS_var_FS_log_FS_pgbackrest_QT,
     parseRuleValStrQT_FS_var_FS_spool_FS_pgbackrest_QT,
     parseRuleValStrQT_1_QT,
-    parseRuleValStrQT_100MiB_QT,
     parseRuleValStrQT_128MiB_QT,
     parseRuleValStrQT_15_QT,
     parseRuleValStrQT_1800_QT,
@@ -72,6 +72,8 @@ typedef enum
     parseRuleValStrQT_1GiB_QT,
     parseRuleValStrQT_1MiB_QT,
     parseRuleValStrQT_2_QT,
+    parseRuleValStrQT_20MiB_QT,
+    parseRuleValStrQT_2MiB_QT,
     parseRuleValStrQT_3_QT,
     parseRuleValStrQT_443_QT,
     parseRuleValStrQT_5432_QT,
@@ -239,6 +241,7 @@ static const int64_t parseRuleValueInt[] =
     1024,
     3600,
     5432,
+    8192,
     8432,
     15000,
     16384,
@@ -259,8 +262,8 @@ static const int64_t parseRuleValueInt[] =
     8388608,
     9999999,
     16777216,
+    20971520,
     86400000,
-    104857600,
     134217728,
     604800000,
     1073741824,
@@ -287,6 +290,7 @@ typedef enum
     parseRuleValInt1024,
     parseRuleValInt3600,
     parseRuleValInt5432,
+    parseRuleValInt8192,
     parseRuleValInt8432,
     parseRuleValInt15000,
     parseRuleValInt16384,
@@ -307,8 +311,8 @@ typedef enum
     parseRuleValInt8388608,
     parseRuleValInt9999999,
     parseRuleValInt16777216,
+    parseRuleValInt20971520,
     parseRuleValInt86400000,
-    parseRuleValInt104857600,
     parseRuleValInt134217728,
     parseRuleValInt604800000,
     parseRuleValInt1073741824,
@@ -1178,6 +1182,45 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION
     (
+        PARSE_RULE_OPTION_NAME("bundle-limit"),
+        PARSE_RULE_OPTION_TYPE(cfgOptTypeSize),
+        PARSE_RULE_OPTION_RESET(true),
+        PARSE_RULE_OPTION_REQUIRED(true),
+        PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),
+
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
+        (
+            PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
+        ),
+
+        PARSE_RULE_OPTIONAL
+        (
+            PARSE_RULE_OPTIONAL_GROUP
+            (
+                PARSE_RULE_OPTIONAL_DEPEND
+                (
+                    PARSE_RULE_VAL_OPT(cfgOptBundle),
+                    PARSE_RULE_VAL_BOOL_TRUE,
+                ),
+
+                PARSE_RULE_OPTIONAL_ALLOW_RANGE
+                (
+                    PARSE_RULE_VAL_INT(parseRuleValInt8192),
+                    PARSE_RULE_VAL_INT(parseRuleValInt1125899906842624),
+                ),
+
+                PARSE_RULE_OPTIONAL_DEFAULT
+                (
+                    PARSE_RULE_VAL_INT(parseRuleValInt2097152),
+                    PARSE_RULE_VAL_STR(parseRuleValStrQT_2MiB_QT),
+                ),
+            ),
+        ),
+    ),
+
+    // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION
+    (
         PARSE_RULE_OPTION_NAME("bundle-size"),
         PARSE_RULE_OPTION_TYPE(cfgOptTypeSize),
         PARSE_RULE_OPTION_RESET(true),
@@ -1207,8 +1250,8 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
 
                 PARSE_RULE_OPTIONAL_DEFAULT
                 (
-                    PARSE_RULE_VAL_INT(parseRuleValInt104857600),
-                    PARSE_RULE_VAL_STR(parseRuleValStrQT_100MiB_QT),
+                    PARSE_RULE_VAL_INT(parseRuleValInt20971520),
+                    PARSE_RULE_VAL_STR(parseRuleValStrQT_20MiB_QT),
                 ),
             ),
         ),
@@ -9166,6 +9209,7 @@ static const ConfigOption optionResolveOrder[] =
     cfgOptBackupStandby,
     cfgOptBufferSize,
     cfgOptBundle,
+    cfgOptBundleLimit,
     cfgOptBundleSize,
     cfgOptChecksumPage,
     cfgOptCipherPass,

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -2981,19 +2981,12 @@ testRun(void)
             HRN_STORAGE_PUT_Z(storagePgWrite(), "postgresql.auto.conf", "CONFIGSTUFF2", .timeModified = 1500000000);
             HRN_STORAGE_PUT_Z(storagePgWrite(), "stuff.conf", "CONFIGSTUFF3", .timeModified = 1500000000);
 
-            // File that will get skipped because it needs to be stored by itself
-            // Buffer *tooBig = bufNew(PG_PAGE_SIZE_DEFAULT * 3);
-            // memset(bufPtr(tooBig), 0, bufSize(tooBig));
-            // bufUsedSet(tooBig, bufSize(tooBig));
-
-            // HRN_STORAGE_PUT(storagePgWrite(), "toobig.dat", tooBig, .timeModified = 1500000010);
-
             // File that will get skipped while bundling smaller files and end up a bundle by itself
             Buffer *bigish = bufNew(PG_PAGE_SIZE_DEFAULT - 1);
             memset(bufPtr(bigish), 0, bufSize(bigish));
             bufUsedSet(bigish, bufSize(bigish));
 
-            HRN_STORAGE_PUT(storagePgWrite(), "bigish.dat", bigish, .timeModified = 1500000050);
+            HRN_STORAGE_PUT(storagePgWrite(), "bigish.dat", bigish, .timeModified = 1500000001);
 
             // Run backup
             testBackupPqScriptP(PG_VERSION_11, backupTimeStart, .walCompressType = compressTypeGz, .walTotal = 2);
@@ -3058,7 +3051,7 @@ testRun(void)
                 "pg_data/base/1/2={\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\",\"checksum-page\":true,\"size\":24576"
                     ",\"timestamp\":1572400000}\n"
                 "pg_data/bigish.dat={\"checksum\":\"3e5175386be683d2f231f3fa3eab892a799082f7\",\"size\":8191"
-                    ",\"timestamp\":1500000050}\n"
+                    ",\"timestamp\":1500000001}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572400000}\n"
                 "pg_data/pg_wal/0000000105DB8EB000000000={\"size\":1048576,\"timestamp\":1572400002}\n"
                 "pg_data/pg_wal/0000000105DB8EB000000001={\"size\":1048576,\"timestamp\":1572400002}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1696,30 +1696,6 @@ testRun(void)
         TEST_STORAGE_LIST_EMPTY(storageRepo(), STORAGE_REPO_BACKUP, .comment = "check backup path removed");
 
         manifestResume->pub.data.backupOptionCompressType = compressTypeNone;
-
-        // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("cannot resume when bundling");
-
-        argList = strLstNew();
-        hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
-        hrnCfgArgRawZ(argList, cfgOptRepoPath, TEST_PATH "/repo");
-        hrnCfgArgRawZ(argList, cfgOptPgPath, "/pg");
-        hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "1");
-        hrnCfgArgRawStrId(argList, cfgOptType, backupTypeFull);
-        hrnCfgArgRawBool(argList, cfgOptBundle, true);
-        HRN_CFG_LOAD(cfgCmdBackup, argList);
-
-        manifestSave(
-            manifestResume,
-            storageWriteIo(
-                storageNewWriteP(
-                    storageRepoWrite(), STRDEF(STORAGE_REPO_BACKUP "/20191003-105320F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT))));
-
-        TEST_RESULT_PTR(backupResumeFind(manifest, NULL), NULL, "find resumable backup");
-
-        TEST_RESULT_LOG("P00   INFO: backup '20191003-105320F' cannot be resumed: resume is disabled");
-
-        TEST_STORAGE_LIST_EMPTY(storageRepo(), STORAGE_REPO_BACKUP, .comment = "check backup path removed");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
Limit which files can be added to bundles, which allows resume to work reasonably well. On resume, the bundles are removed and any remaining file is eligible to be to be resumed.

Also reduce the bundle-size default to 20MiB. This is pretty arbitrary, but a smaller default seems better.