### PR TITLE
Disconnect help.auto.c from build-help in Makefile

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -126,6 +126,17 @@
 
                 <release-development-list>
                     <release-item>
+                        <github-pull-request id="1672"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="daniel.gustafsson"/>
+                            <release-item-contributor id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Disconnect <file>help.auto.c</file> from <id>build-help</id> in <file>Makefile</file>.</p>
+                    </release-item>
+
+                    <release-item>
                         <commit subject="Add read range to all storage drivers."/>
                         <commit subject="Implement restore ownership without updating manifest internals."/>
                         <commit subject="Fix issue with Posix read offset handling after an error."/>

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -249,6 +249,8 @@ OBJS_BUILD_HELP = $(patsubst %.c,$(BUILDDIR)/%.o,$(SRCS_BUILD) $(SRCS_BUILD_HELP
 
 build-help: $(OBJS_BUILD_HELP) build/config/config.yaml build/help/help.xml
 	$(CC) -o build-help $(OBJS_BUILD_HELP) $(LDFLAGS) $(LIBS) $(LIBS_BUILD)
+
+command/help/help.auto.c: build-help
 	./build-help $(VPATH)
 
 ####################################################################################################################################
@@ -284,7 +286,7 @@ clean-all: clean
 # Special per-object flags
 ####################################################################################################################################
 $(BUILDDIR)/postgres/interface/page.o: CFLAGS += @CFLAGS_PAGE_CHECKSUM@
-$(BUILDDIR)/main.o: build-help
+$(BUILDDIR)/main.o: command/help/help.auto.c
 
 ####################################################################################################################################
 # Compile and generate dependencies


### PR DESCRIPTION
When there is an issue with the system library path during building, the `build-help` rule will fail during executing `./build-help` with the effect that `main.c` wont build. Break out `help.auto.c` generation from the `build-help` stage to allow it to be re-executed when the library path has been corrected.

To reproduce:
```
# Set PATH to a non-system build of postgres so that pg_config --libdir picks up something that doesn't resolve
 $ ./configure
 $ make -s
./build-help: error while loading shared libraries: libpq.so.5: cannot open shared object file: No such file or directory
make: *** [Makefile:252: build-help] Error 127
 $ export LD_LIBRARY_PATH=/home/danielg/pghacking/lib
 $ make
gcc   -std=c99 -Wall -Wextra -Wno-missing-field-initializers -Wno-implicit-fallthrough -Wno-clobbered -O2 -D_POSIX_C_SOURCE=200809L -I. -I/home/danielg/pghacking/include -I/usr/include/libxml2 -I. -I. -c -o .build/main.o main.c -MMD -MP -MF .build/main.dep
main.c:54:10: fatal error: command/help/help.auto.c: No such file or directory
 #include "command/help/help.auto.c"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:294: .build/main.o] Error 1
```
With this patch applied, continuing to build after fixing the library path works.

