### PR TITLE
Allow case-insensitive matching of HTTP connection header values.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -33,6 +33,19 @@
 
                         <p>Retry errors in S3 batch file delete.</p>
                     </release-item>
+
+                    <release-item>
+                        <github-issue id="1638"/>
+                        <github-pull-request id="1675"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="remi.vidier"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="reid.thompson"/>
+                        </release-item-contributor-list>
+
+                        <p>Allow case-insensitive matching of <proper>HTTP</proper> <id>connection</id> header values.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-feature-list>
@@ -11308,6 +11321,11 @@
         <contributor id="rakshitha.br">
             <contributor-name-display>Rakshitha-BR</contributor-name-display>
             <contributor-id type="github">Rakshitha-BR</contributor-id>
+        </contributor>
+
+        <contributor id="remi.vidier">
+            <contributor-name-display>R&amp;eacute;mi Vidier</contributor-name-display>
+            <contributor-id type="github">vidierr</contributor-id>
         </contributor>
 
         <contributor id="rohit.raveendran">

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -275,8 +275,6 @@ httpResponseNew(HttpSession *session, const String *verb, bool contentCache)
                 String *headerKey = strLower(strTrim(strSubN(header, 0, (size_t)colonPos)));
                 String *headerValue = strTrim(strSub(header, (size_t)colonPos + 1));
 
-                httpHeaderAdd(this->pub.header, headerKey, headerValue);
-
                 // Read transfer encoding (only chunked is supported)
                 if (strEq(headerKey, HTTP_HEADER_TRANSFER_ENCODING_STR))
                 {
@@ -300,8 +298,11 @@ httpResponseNew(HttpSession *session, const String *verb, bool contentCache)
 
                 // If the server notified of a closed connection then close the client connection after reading content.  This
                 // prevents doing a retry on the next request when using the closed connection.
-                if (strEq(headerKey, HTTP_HEADER_CONNECTION_STR) && strEq(headerValue, HTTP_VALUE_CONNECTION_CLOSE_STR))
+                if (strEq(headerKey, HTTP_HEADER_CONNECTION_STR) && strEq(strLower(headerValue), HTTP_VALUE_CONNECTION_CLOSE_STR))
                     this->closeOnContentEof = true;
+
+                // Add after header checks in case the value was modified
+                httpHeaderAdd(this->pub.header, headerKey, headerValue);
             }
             while (1);
 

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -653,7 +653,7 @@ testRun(void)
                             .content = BUFSTRDEF("012345678901234567890123456789")), true),
                     "request");
                 TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpResponseHeader(response)), "{connection: 'close'}", "check response headers");
+                    httpHeaderToLog(httpResponseHeader(response)), "{connection: 'ClosE'}", "check response headers");
                 TEST_RESULT_STR_Z(strNewBuf(httpResponseContent(response)), "01234567890123456789012345678901", "check response");
                 TEST_RESULT_UINT(httpResponseRead(response, bufNew(1), true), 0, "call internal read to check eof");
 

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -653,7 +653,7 @@ testRun(void)
                             .content = BUFSTRDEF("012345678901234567890123456789")), true),
                     "request");
                 TEST_RESULT_STR_Z(
-                    httpHeaderToLog(httpResponseHeader(response)), "{connection: 'ClosE'}", "check response headers");
+                    httpHeaderToLog(httpResponseHeader(response)), "{connection: 'close'}", "check response headers");
                 TEST_RESULT_STR_Z(strNewBuf(httpResponseContent(response)), "01234567890123456789012345678901", "check response");
                 TEST_RESULT_UINT(httpResponseRead(response, bufNew(1), true), 0, "call internal read to check eof");
 

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -638,7 +638,7 @@ testRun(void)
                 hrnServerScriptExpectZ(
                     http, "GET /path/file%201.txt HTTP/1.1\r\n" TEST_USER_AGENT "content-length:30\r\n\r\n"
                         "012345678901234567890123456789");
-                hrnServerScriptReplyZ(http, "HTTP/1.1 200 OK\r\nConnection:close\r\n\r\n01234567890123456789012345678901");
+                hrnServerScriptReplyZ(http, "HTTP/1.1 200 OK\r\nConnection:ClosE\r\n\r\n01234567890123456789012345678901");
 
                 hrnServerScriptClose(http);
 


### PR DESCRIPTION
The specification allows values for the connection header to be case-insensitive. See https://www.rfc-editor.org/rfc/rfc7230#section-6.1.