### PR TITLE
Allow hardlink option to be changed after full backup.

### DIFF
--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -405,17 +405,6 @@ backupBuildIncrPrior(const InfoBackup *infoBackup)
                         cfgOptCompressLevel, cfgSourceParam, VARINT64(varUInt(manifestPriorData->backupOptionCompressLevel)));
                 }
 
-                // Warn if hardlink option changed ??? Doesn't seem like this is needed?  Hardlinks are always to a directory that
-                // is guaranteed to contain a real file -- like references.  Also annoying that if the full backup was not
-                // hardlinked then an diff/incr can't be used because we need more testing.
-                if (cfgOptionBool(cfgOptRepoHardlink) != manifestPriorData->backupOptionHardLink)
-                {
-                    LOG_WARN_FMT(
-                        "%s backup cannot alter hardlink option to '%s', reset to value in %s",
-                        strZ(cfgOptionDisplay(cfgOptType)), strZ(cfgOptionDisplay(cfgOptRepoHardlink)), strZ(backupLabelPrior));
-                    cfgOptionSet(cfgOptRepoHardlink, cfgSourceParam, VARBOOL(manifestPriorData->backupOptionHardLink));
-                }
-
                 // If not defined this backup was done in a version prior to page checksums being introduced.  Just set
                 // checksum-page to false and move on without a warning.  Page checksums will start on the next full backup.
                 if (manifestData(result)->backupOptionChecksumPage == NULL)

--- a/test/expect/mock-all-001.log
+++ b/test/expect/mock-all-001.log
@@ -2208,21 +2208,21 @@ P01 DETAIL: backup file [TEST_PATH]/db-primary/db/base-2/pg_tblspc/2/[TS_PATH-1]
 P00   WARN: page misalignment in file [TEST_PATH]/db-primary/db/base-2/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2c.txt: file size 12 is not divisible by page size 8192
 P01 DETAIL: backup file [TEST_PATH]/db-primary/db/base-2/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt (7B, 100.00%) checksum dc7f76e43c46101b47acc55ae4d593a9e6983578
 P00   WARN: page misalignment in file [TEST_PATH]/db-primary/db/base-2/pg_tblspc/2/[TS_PATH-1]/32768/tablespace2.txt: file size 7 is not divisible by page size 8192
-P00 DETAIL: reference pg_data/PG_VERSION to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/1/12000 to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/32768/33000 to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/32768/33001 to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/32768/44000_init to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/changetime.txt to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/global/pg_control to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/postgresql.conf to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/special-!_.*'()&!@;:+,? to [BACKUP-FULL-2]
-P00 DETAIL: reference pg_data/zero_from_start to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/PG_VERSION to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/1/12000 to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/1/PG_VERSION to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/16384/PG_VERSION to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/32768/33000 to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/32768/33000.32767 to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/32768/33001 to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/32768/44000_init to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/base/32768/PG_VERSION to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/changetime.txt to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/global/pg_control to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/pg_stat/global.stat to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/postgresql.conf to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/special-!_.*'()&!@;:+,? to [BACKUP-FULL-2]
+P00 DETAIL: hardlink pg_data/zero_from_start to [BACKUP-FULL-2]
 P00   INFO: new backup label = [BACKUP-DIFF-3]
 P00   INFO: diff backup size = 37B, file total = 20
 P00   INFO: backup command end: completed successfully
@@ -2293,7 +2293,7 @@ option-compress-level=3
 option-compress-level-network=3
 option-compress-type="none"
 option-delta=true
-option-hardlink=false
+option-hardlink=true
 option-online=false
 option-process-max=1
 
@@ -2379,7 +2379,7 @@ backrest-version="[VERSION-1]"
 [BACKUP-INCR-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-1]","backup-reference":["[BACKUP-FULL-2]","[BACKUP-DIFF-1]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
 [BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-INCR-3]","backup-reference":["[BACKUP-FULL-2]","[BACKUP-DIFF-1]","[BACKUP-INCR-3]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
 [BACKUP-DIFF-2]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
-[BACKUP-DIFF-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
+[BACKUP-DIFF-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":true,"option-online":false}
 
 [db]
 db-catalog-version=201409291
@@ -2577,7 +2577,7 @@ backrest-version="[VERSION-1]"
 [BACKUP-INCR-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-DIFF-1]","backup-reference":["[BACKUP-FULL-2]","[BACKUP-DIFF-1]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
 [BACKUP-INCR-4]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-INCR-3]","backup-reference":["[BACKUP-FULL-2]","[BACKUP-DIFF-1]","[BACKUP-INCR-3]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"incr","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
 [BACKUP-DIFF-2]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
-[BACKUP-DIFF-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":false,"option-online":false}
+[BACKUP-DIFF-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":true,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-prior":"[BACKUP-FULL-2]","backup-reference":["[BACKUP-FULL-2]"],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"diff","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":true,"option-compress":false,"option-hardlink":true,"option-online":false}
 [BACKUP-FULL-3]={"backrest-format":5,"backrest-version":"[VERSION-1]","backup-archive-start":null,"backup-archive-stop":null,"backup-error":false,"backup-info-repo-size":[SIZE],"backup-info-repo-size-delta":[DELTA],"backup-info-size":[SIZE],"backup-info-size-delta":[DELTA],"backup-timestamp-start":[TIMESTAMP],"backup-timestamp-stop":[TIMESTAMP],"backup-type":"full","db-id":1,"option-archive-check":false,"option-archive-copy":true,"option-backup-standby":false,"option-checksum-page":false,"option-compress":true,"option-hardlink":true,"option-online":false}
 
 [db]

--- a/test/expect/mock-all-001.log
+++ b/test/expect/mock-all-001.log
@@ -2187,7 +2187,6 @@ P00   WARN: option 'repo1-retention-full' is not set for 'repo1-retention-full-t
             HINT: to retain full backups indefinitely (without warning), set option 'repo1-retention-full' to the maximum.
 P00   INFO: last backup label = [BACKUP-FULL-2], version = [VERSION-1]
 P00   WARN: diff backup cannot alter compress-type option to 'zst', reset to value in [BACKUP-FULL-2]
-P00   WARN: diff backup cannot alter hardlink option to 'true', reset to value in [BACKUP-FULL-2]
 P00   WARN: diff backup cannot alter 'checksum-page' option to 'false', reset to 'true' from [BACKUP-FULL-2]
 P01 DETAIL: match file from prior backup [TEST_PATH]/db-primary/db/base-2/base/32768/33001 (64KB, 36.35%) checksum 6bf316f11d28c28914ea9be92c00de9bea6d9a6b
 P01 DETAIL: match file from prior backup [TEST_PATH]/db-primary/db/base-2/base/32768/44000_init (32KB, 54.52%) checksum 1d73a0052828531770e7c155aeb22338e017e196

--- a/test/lib/pgBackRestTest/Module/Mock/MockAllTest.pm
+++ b/test/lib/pgBackRestTest/Module/Mock/MockAllTest.pm
@@ -960,10 +960,12 @@ sub run
             $oHostBackup->configUpdate({&CFGDEF_SECTION_GLOBAL => {'compress-type' => $strCompressType}});
         }
 
-        # Enable hardlinks (except for s3) to ensure a warning is raised
+        # Enable hardlinks (except for s3) to show they can be enabled after a full backup
         if ($strStorage eq POSIX)
         {
             $oHostBackup->configUpdate({&CFGDEF_SECTION_GLOBAL => {'repo1-hardlink' => 'y'}});
+            $oManifest{&MANIFEST_SECTION_BACKUP_OPTION}{&MANIFEST_KEY_HARDLINK} = JSON::PP::true;
+            $oHostBackup->{bHardLink} = true;
         }
 
         $oManifest{&MANIFEST_SECTION_BACKUP_OPTION}{&MANIFEST_KEY_PROCESS_MAX} = 1;
@@ -987,15 +989,9 @@ sub run
         #---------------------------------------------------------------------------------------------------------------------------
         $strType = CFGOPTVAL_BACKUP_TYPE_FULL;
 
-        # Now the compression and hardlink changes will take effect
+        # Now the compression changes will take effect
         $oManifest{&MANIFEST_SECTION_BACKUP_OPTION}{&MANIFEST_KEY_COMPRESS} = JSON::PP::true;
         $oManifest{&MANIFEST_SECTION_BACKUP_OPTION}{&MANIFEST_KEY_COMPRESS_TYPE} = $strCompressType;
-
-        if ($strStorage eq POSIX)
-        {
-            $oManifest{&MANIFEST_SECTION_BACKUP_OPTION}{&MANIFEST_KEY_HARDLINK} = JSON::PP::true;
-            $oHostBackup->{bHardLink} = true;
-        }
 
         $oHostDbPrimary->manifestReference(\%oManifest);
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -2266,7 +2266,6 @@ testRun(void)
             hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "1");
             hrnCfgArgRawStrId(argList, cfgOptType, backupTypeFull);
             hrnCfgArgRawBool(argList, cfgOptStopAuto, true);
-            hrnCfgArgRawBool(argList, cfgOptRepoHardlink, true);
             hrnCfgArgRawBool(argList, cfgOptArchiveCopy, true);
             HRN_CFG_LOAD(cfgCmdBackup, argList);
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1978,7 +1978,6 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "1");
         hrnCfgArgRawBool(argList, cfgOptOnline, false);
         hrnCfgArgRawBool(argList, cfgOptCompress, true);
-        hrnCfgArgRawBool(argList, cfgOptRepoHardlink, true);
         hrnCfgArgRawStrId(argList, cfgOptType, backupTypeDiff);
         HRN_CFG_LOAD(cfgCmdBackup, argList);
 
@@ -1986,8 +1985,7 @@ testRun(void)
 
         TEST_RESULT_LOG(
             "P00   INFO: last backup label = [FULL-1], version = " PROJECT_VERSION "\n"
-            "P00   WARN: diff backup cannot alter compress-type option to 'gz', reset to value in [FULL-1]\n"
-            "P00   WARN: diff backup cannot alter hardlink option to 'true', reset to value in [FULL-1]");
+            "P00   WARN: diff backup cannot alter compress-type option to 'gz', reset to value in [FULL-1]");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("offline incr backup to test unresumable backup");


### PR DESCRIPTION
This rule was added because there were not sufficient tests to demonstrate that the `repo-hardlink` option could be changed in a backup set.

Remove the restriction and add/update tests to show that it works.