### PR TITLE
Suppress existing WAL warning when archive-mode-check is disabled.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -33,6 +33,17 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1711"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="reid.thompson"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Suppress existing WAL warning when <br-option>archive-mode-check</br-option> is disabled.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="1685"/>
                         <github-pull-request id="1691"/>
 

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1072,6 +1072,7 @@ option:
     type: boolean
     default: true
     command:
+      archive-push: {}
       backup:
         depend:
           option: online
@@ -1080,6 +1081,7 @@ option:
             - true
       check: {}
     command-role:
+      async: {}
       main: {}
 
   archive-copy:
@@ -1101,9 +1103,11 @@ option:
     type: boolean
     default: true
     command:
+      archive-push: {}
       backup: {}
       check: {}
     command-role:
+      async: {}
       main: {}
     depend:
       option: archive-check

--- a/src/command/archive/push/file.c
+++ b/src/command/archive/push/file.c
@@ -94,13 +94,14 @@ archivePushFileIo(ArchivePushFileIoType type, IoWrite *write, const Buffer *buff
 /**********************************************************************************************************************************/
 ArchivePushFileResult
 archivePushFile(
-    const String *walSource, const bool headerCheck, const unsigned int pgVersion, const uint64_t pgSystemId,
+    const String *walSource, const bool headerCheck, const bool modeCheck, const unsigned int pgVersion, const uint64_t pgSystemId,
     const String *archiveFile, CompressType compressType, const int compressLevel, const List *const repoList,
-    const StringList *const priorErrorList, const bool modeCheck)
+    const StringList *const priorErrorList)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(STRING, walSource);
         FUNCTION_LOG_PARAM(BOOL, headerCheck);
+        FUNCTION_LOG_PARAM(BOOL, modeCheck);
         FUNCTION_LOG_PARAM(UINT, pgVersion);
         FUNCTION_LOG_PARAM(UINT64, pgSystemId);
         FUNCTION_LOG_PARAM(STRING, archiveFile);
@@ -108,7 +109,6 @@ archivePushFile(
         FUNCTION_LOG_PARAM(INT, compressLevel);
         FUNCTION_LOG_PARAM_P(VOID, repoList);
         FUNCTION_LOG_PARAM(STRING_LIST, priorErrorList);
-        FUNCTION_LOG_PARAM(BOOL, modeCheck);
     FUNCTION_LOG_END();
 
     ASSERT(walSource != NULL);

--- a/src/command/archive/push/file.c
+++ b/src/command/archive/push/file.c
@@ -94,9 +94,9 @@ archivePushFileIo(ArchivePushFileIoType type, IoWrite *write, const Buffer *buff
 /**********************************************************************************************************************************/
 ArchivePushFileResult
 archivePushFile(
-    const String *walSource, const bool headerCheck, const bool modeCheck, const unsigned int pgVersion, const uint64_t pgSystemId,
-    const String *archiveFile, CompressType compressType, const int compressLevel, const List *const repoList,
-    const StringList *const priorErrorList)
+    const String *const walSource, const bool headerCheck, const bool modeCheck, const unsigned int pgVersion,
+    const uint64_t pgSystemId, const String *const archiveFile, const CompressType compressType, const int compressLevel,
+    const List *const repoList, const StringList *const priorErrorList)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(STRING, walSource);

--- a/src/command/archive/push/file.h
+++ b/src/command/archive/push/file.h
@@ -32,6 +32,7 @@ typedef struct ArchivePushFileResult
 // Copy a file from the source to the archive
 ArchivePushFileResult archivePushFile(
     const String *walSource, bool headerCheck, unsigned int pgVersion, uint64_t pgSystemId, const String *archiveFile,
-    CompressType compressType, int compressLevel, const List *const repoList, const StringList *const priorErrorList);
+    CompressType compressType, int compressLevel, const List *const repoList, const StringList *const priorErrorList,
+    bool modeCheck);
 
 #endif

--- a/src/command/archive/push/file.h
+++ b/src/command/archive/push/file.h
@@ -32,7 +32,7 @@ typedef struct ArchivePushFileResult
 // Copy a file from the source to the archive
 ArchivePushFileResult archivePushFile(
     const String *walSource, bool headerCheck, bool modeCheck, unsigned int pgVersion, uint64_t pgSystemId,
-    const String *archiveFile, CompressType compressType, int compressLevel, const List *const repoList,
-    const StringList *const priorErrorList);
+    const String *archiveFile, CompressType compressType, int compressLevel, const List *repoList,
+    const StringList *priorErrorList);
 
 #endif

--- a/src/command/archive/push/file.h
+++ b/src/command/archive/push/file.h
@@ -31,8 +31,8 @@ typedef struct ArchivePushFileResult
 
 // Copy a file from the source to the archive
 ArchivePushFileResult archivePushFile(
-    const String *walSource, bool headerCheck, unsigned int pgVersion, uint64_t pgSystemId, const String *archiveFile,
-    CompressType compressType, int compressLevel, const List *const repoList, const StringList *const priorErrorList,
-    bool modeCheck);
+    const String *walSource, bool headerCheck, bool modeCheck, unsigned int pgVersion, uint64_t pgSystemId,
+    const String *archiveFile, CompressType compressType, int compressLevel, const List *const repoList,
+    const StringList *const priorErrorList);
 
 #endif

--- a/src/command/archive/push/protocol.c
+++ b/src/command/archive/push/protocol.c
@@ -29,6 +29,7 @@ archivePushFileProtocol(PackRead *const param, ProtocolServer *const server)
         // Read parameters
         const String *const walSource = pckReadStrP(param);
         const bool headerCheck = pckReadBoolP(param);
+        const bool modeCheck = pckReadBoolP(param);
         const unsigned int pgVersion = pckReadU32P(param);
         const uint64_t pgSystemId = pckReadU64P(param);
         const String *const archiveFile = pckReadStrP(param);
@@ -58,7 +59,8 @@ archivePushFileProtocol(PackRead *const param, ProtocolServer *const server)
 
         // Push file
         const ArchivePushFileResult fileResult = archivePushFile(
-            walSource, headerCheck, pgVersion, pgSystemId, archiveFile, compressType, compressLevel, repoList, priorErrorList);
+            walSource, headerCheck, pgVersion, pgSystemId, archiveFile, compressType, compressLevel, repoList, priorErrorList,
+            modeCheck);
 
         // Return result
         protocolServerDataPut(server, pckWriteStrLstP(protocolPackNew(), fileResult.warnList));

--- a/src/command/archive/push/protocol.c
+++ b/src/command/archive/push/protocol.c
@@ -59,8 +59,8 @@ archivePushFileProtocol(PackRead *const param, ProtocolServer *const server)
 
         // Push file
         const ArchivePushFileResult fileResult = archivePushFile(
-            walSource, headerCheck, pgVersion, pgSystemId, archiveFile, compressType, compressLevel, repoList, priorErrorList,
-            modeCheck);
+            walSource, headerCheck, modeCheck, pgVersion, pgSystemId, archiveFile, compressType, compressLevel, repoList,
+            priorErrorList);
 
         // Return result
         protocolServerDataPut(server, pckWriteStrLstP(protocolPackNew(), fileResult.warnList));

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -413,7 +413,7 @@ cmdArchivePush(void)
                 ArchivePushFileResult fileResult = archivePushFile(
                     walFile, cfgOptionBool(cfgOptArchiveHeaderCheck), archiveInfo.pgVersion, archiveInfo.pgSystemId, archiveFile,
                     compressTypeEnum(cfgOptionStrId(cfgOptCompressType)), cfgOptionInt(cfgOptCompressLevel), archiveInfo.repoList,
-                    archiveInfo.errorList);
+                    archiveInfo.errorList, cfgOptionBool(cfgOptArchiveModeCheck));
 
                 // If a warning was returned then log it
                 for (unsigned int warnIdx = 0; warnIdx < strLstSize(fileResult.warnList); warnIdx++)
@@ -468,6 +468,7 @@ archivePushAsyncCallback(void *data, unsigned int clientIdx)
 
             pckWriteStrP(param, strNewFmt("%s/%s", strZ(jobData->walPath), strZ(walFile)));
             pckWriteBoolP(param, cfgOptionBool(cfgOptArchiveHeaderCheck));
+            pckWriteBoolP(param, cfgOptionBool(cfgOptArchiveModeCheck));
             pckWriteU32P(param, jobData->archiveInfo.pgVersion);
             pckWriteU64P(param, jobData->archiveInfo.pgSystemId);
             pckWriteStrP(param, walFile);

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -411,9 +411,9 @@ cmdArchivePush(void)
 
                 // Push the file to the archive
                 ArchivePushFileResult fileResult = archivePushFile(
-                    walFile, cfgOptionBool(cfgOptArchiveHeaderCheck), archiveInfo.pgVersion, archiveInfo.pgSystemId, archiveFile,
-                    compressTypeEnum(cfgOptionStrId(cfgOptCompressType)), cfgOptionInt(cfgOptCompressLevel), archiveInfo.repoList,
-                    archiveInfo.errorList, cfgOptionBool(cfgOptArchiveModeCheck));
+                    walFile, cfgOptionBool(cfgOptArchiveHeaderCheck), cfgOptionBool(cfgOptArchiveModeCheck), archiveInfo.pgVersion,
+                    archiveInfo.pgSystemId, archiveFile, compressTypeEnum(cfgOptionStrId(cfgOptCompressType)),
+                    cfgOptionInt(cfgOptCompressLevel), archiveInfo.repoList, archiveInfo.errorList);
 
                 // If a warning was returned then log it
                 for (unsigned int warnIdx = 0; warnIdx < strLstSize(fileResult.warnList); warnIdx++)

--- a/src/config/parse.auto.c
+++ b/src/config/parse.auto.c
@@ -745,8 +745,14 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
 
         PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
+            PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
+        ),
+
+        PARSE_RULE_OPTION_COMMAND_ROLE_ASYNC_VALID_LIST
+        (
+            PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
         ),
 
         PARSE_RULE_OPTIONAL
@@ -970,8 +976,14 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
 
         PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST
         (
+            PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
             PARSE_RULE_OPTION_COMMAND(cfgCmdBackup)
             PARSE_RULE_OPTION_COMMAND(cfgCmdCheck)
+        ),
+
+        PARSE_RULE_OPTION_COMMAND_ROLE_ASYNC_VALID_LIST
+        (
+            PARSE_RULE_OPTION_COMMAND(cfgCmdArchivePush)
         ),
 
         PARSE_RULE_OPTIONAL

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -339,9 +339,10 @@ testRun(void)
             .remove = true, .comment = "check repo for WAL file, then remove");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("generate valid WAL and push them");
+        TEST_TITLE("generate valid WAL and push them, with parameter --no-archive-mode-check to suppress duplicate WAL warning");
 
         argListTemp = strLstDup(argList);
+        hrnCfgArgRawNegate(argListTemp, cfgOptArchiveModeCheck);
         strLstAddZ(argListTemp, "pg_wal/000000010000000100000001");
         HRN_CFG_LOAD(cfgCmdArchivePush, argListTemp);
 
@@ -363,10 +364,9 @@ testRun(void)
             storageRepoIdxWrite(0), strZ(strNewFmt(STORAGE_REPO_ARCHIVE "/11-1/000000010000000100000001-%s.gz", walBuffer1Sha1)),
             .comment = "check repo for WAL file");
 
+        // No warning emitted re WAL file already existing with the same checksum due to --no-archive-mode-check
         TEST_RESULT_VOID(cmdArchivePush(), "push the WAL segment again");
         TEST_RESULT_LOG(
-            "P00   WARN: WAL file '000000010000000100000001' already exists in the repo1 archive with the same checksum\n"
-            "            HINT: this is valid in some recovery scenarios but may also indicate a problem.\n"
             "P00   INFO: pushed WAL file '000000010000000100000001' to the archive");
 
         // Now create a new WAL buffer with a different checksum to test checksum errors


### PR DESCRIPTION
Do not emit duplicate WAL warning from archive-push command when archive-mode-check is disabled.

See card
https://github.com/pgbackrest/pgbackrest/projects/2#card-66266515