### PR TITLE
Strip extensions from history manifest before showing in error message.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -185,6 +185,17 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1738"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Strip extensions from history manifest before showing in error message.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="1722"/>
 
                         <release-item-contributor-list>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -88,10 +88,14 @@ backupLabelCreate(BackupType type, const String *backupLabelPrior, time_t timest
 
             if (!strLstEmpty(historyList))
             {
-                const String *historyLabelLatest = strLstGet(historyList, 0);
+                const String *const historyLabelLatest = strLstGet(historyList, 0);
 
                 if (backupLabelLatest == NULL || strCmp(historyLabelLatest, backupLabelLatest) > 0)
-                    backupLabelLatest = historyLabelLatest;
+                {
+                    // Strip off the compression and manifest extensions in case this ends up in an error message
+                    backupLabelLatest = compressExtStrip(historyLabelLatest, compressTypeFromName(historyLabelLatest));
+                    backupLabelLatest = strSubN(backupLabelLatest, 0, strSize(backupLabelLatest) - sizeof(BACKUP_MANIFEST_EXT) + 1);
+                }
             }
         }
 

--- a/src/info/manifest.h
+++ b/src/info/manifest.h
@@ -13,7 +13,8 @@ nothing is missing or corrupt.  It is also useful for reporting, e.g. size of ba
 /***********************************************************************************************************************************
 Constants
 ***********************************************************************************************************************************/
-#define BACKUP_MANIFEST_FILE                                        "backup.manifest"
+#define BACKUP_MANIFEST_EXT                                         ".manifest"
+#define BACKUP_MANIFEST_FILE                                        "backup" BACKUP_MANIFEST_EXT
     STRING_DECLARE(BACKUP_MANIFEST_FILE_STR);
 
 #define MANIFEST_PATH_BUNDLE                                        "bundle"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1462,6 +1462,20 @@ testRun(void)
             "new backup label '20191203-193413F' is not later than latest backup label '20191203-193413F'\n"
             "HINT: has the timezone changed?\n"
             "HINT: is there clock skew?");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("error when new label is in the past even with advanced time (from history)");
+
+        HRN_STORAGE_PUT_EMPTY(
+            storageRepoWrite(), strZ(
+                strNewFmt(STORAGE_REPO_BACKUP "/backup.history/2019/%s.manifest.gz",
+                strZ(backupLabelFormat(backupTypeFull, NULL, timestamp + 3600)))));
+
+        TEST_ERROR(
+            backupLabelCreate(backupTypeFull, NULL, timestamp), FormatError,
+            "new backup label '20191203-193413F' is not later than latest backup label '20191203-203412F'\n"
+            "HINT: has the timezone changed?\n"
+            "HINT: is there clock skew?");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
In cases where clock skew or timezone issues are preventing backup label generation the user could see an error like this:

new backup label '20220504-152308F' is not later than latest backup label '20220504-222042F_20220504-222141I.manifest.gz'

This will happen if the most recent label is drawn from the history. It is cleaner (and probably less confusing) to strip off the extensions so the user sees:

new backup label '20220504-152308F' is not later than latest backup label '20220504-222042F_20220504-222141I'