### PR TITLE
Add ClockError for unexpected clock skew and timezone changes.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -185,6 +185,19 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1739"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="greg.sabino.mullane"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="greg.sabino.mullane"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Add <code>ClockError</code> for unexpected clock skew and timezone changes.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-pull-request id="1738"/>
 
                         <release-item-contributor-list>

--- a/src/build/error/error.yaml
+++ b/src/build/error/error.yaml
@@ -109,6 +109,9 @@ command: 104
 # Unable to authenticate or authorize
 access: 105
 
+# Unexpected clock skew or timezone change
+clock: 106
+
 # This error should not be thrown directly -- it serves as a parent for the C errors
 runtime: 122
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -108,7 +108,7 @@ backupLabelCreate(BackupType type, const String *backupLabelPrior, time_t timest
             if (strCmp(result, backupLabelLatest) <= 0)
             {
                 THROW_FMT(
-                    FormatError,
+                    ClockError,
                     "new backup label '%s' is not later than latest backup label '%s'\n"
                     "HINT: has the timezone changed?\n"
                     "HINT: is there clock skew?",

--- a/src/common/error.auto.c
+++ b/src/common/error.auto.c
@@ -86,6 +86,7 @@ ERROR_DEFINE(102, ExecuteError, false, RuntimeError);
 ERROR_DEFINE(103, RepoInvalidError, false, RuntimeError);
 ERROR_DEFINE(104, CommandError, false, RuntimeError);
 ERROR_DEFINE(105, AccessError, false, RuntimeError);
+ERROR_DEFINE(106, ClockError, false, RuntimeError);
 ERROR_DEFINE(122, RuntimeError, false, RuntimeError);
 ERROR_DEFINE(123, InvalidError, false, RuntimeError);
 ERROR_DEFINE(124, UnhandledError, false, RuntimeError);
@@ -175,6 +176,7 @@ static const ErrorType *errorTypeList[] =
     &RepoInvalidError,
     &CommandError,
     &AccessError,
+    &ClockError,
     &RuntimeError,
     &InvalidError,
     &UnhandledError,

--- a/src/common/error.auto.h
+++ b/src/common/error.auto.h
@@ -88,6 +88,7 @@ ERROR_DECLARE(ExecuteError);
 ERROR_DECLARE(RepoInvalidError);
 ERROR_DECLARE(CommandError);
 ERROR_DECLARE(AccessError);
+ERROR_DECLARE(ClockError);
 ERROR_DECLARE(RuntimeError);
 ERROR_DECLARE(InvalidError);
 ERROR_DECLARE(UnhandledError);

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1472,7 +1472,7 @@ testRun(void)
                 strZ(backupLabelFormat(backupTypeFull, NULL, timestamp + 3600)))));
 
         TEST_ERROR(
-            backupLabelCreate(backupTypeFull, NULL, timestamp), FormatError,
+            backupLabelCreate(backupTypeFull, NULL, timestamp), ClockError,
             "new backup label '20191203-193413F' is not later than latest backup label '20191203-203412F'\n"
             "HINT: has the timezone changed?\n"
             "HINT: is there clock skew?");

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1458,7 +1458,7 @@ testRun(void)
                 strNewFmt(STORAGE_REPO_BACKUP "/%s", strZ(backupLabelFormat(backupTypeFull, NULL, timestamp + 1)))));
 
         TEST_ERROR(
-            backupLabelCreate(backupTypeFull, NULL, timestamp), FormatError,
+            backupLabelCreate(backupTypeFull, NULL, timestamp), ClockError,
             "new backup label '20191203-193413F' is not later than latest backup label '20191203-193413F'\n"
             "HINT: has the timezone changed?\n"
             "HINT: is there clock skew?");


### PR DESCRIPTION
Having a distinct result code should help with debugging clock skew and timezone issues.