### PR TITLE
Fix issues in improved path validation for repo-* commands.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -188,7 +188,12 @@
                     </release-item>
 
                     <release-item>
-                        <github-pull-request id="1697"/>
+                        <commit subject="Improve path validation for repo-* commands.">
+                            <github-pull-request id="1697"/>
+                        </commit>
+                        <commit subject="Fix issues in improved path validation for repo-* commands.">
+                            <github-pull-request id="1751"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="reid.thompson"/>

--- a/src/command/repo/common.c
+++ b/src/command/repo/common.c
@@ -32,21 +32,34 @@ repoPathIsValid(const String *path)
         // Validate absolute paths
         if (strBeginsWith(path, FSLASH_STR))
         {
-            // Check that the file path begins with the repo path
-            if (!strBeginsWith(path, cfgOptionStr(cfgOptRepoPath)))
+            // If the path is exactly equal to the repo path then the relative path is empty
+            if (strEq(path, cfgOptionStr(cfgOptRepoPath)))
             {
-                THROW_FMT(
-                    ParamInvalidError, "absolute path '%s' is not in base path '%s'", strZ(path),
-                    strZ(cfgOptionDisplay(cfgOptRepoPath)));
+                MEM_CONTEXT_PRIOR_BEGIN()
+                {
+                    result = strNew();
+                }
+                MEM_CONTEXT_PRIOR_END();
             }
+            // Else check that the file path begins with the repo path
+            else
+            {
+                if (!strEq(cfgOptionStr(cfgOptRepoPath), FSLASH_STR) &&
+                    !strBeginsWith(path, strNewFmt("%s/", strZ(cfgOptionStr(cfgOptRepoPath)))))
+                {
+                    THROW_FMT(
+                        ParamInvalidError, "absolute path '%s' is not in base path '%s'", strZ(path),
+                        strZ(cfgOptionDisplay(cfgOptRepoPath)));
+                }
 
-            MEM_CONTEXT_PRIOR_BEGIN()
-            {
-                // Get the relative part of the file
-                result = strSub(
-                    path, strEq(cfgOptionStr(cfgOptRepoPath), FSLASH_STR) ? 1 : strSize(cfgOptionStr(cfgOptRepoPath)) + 1);
+                MEM_CONTEXT_PRIOR_BEGIN()
+                {
+                    // Get the relative part of the path/file
+                    result = strSub(
+                        path, strEq(cfgOptionStr(cfgOptRepoPath), FSLASH_STR) ? 1 : strSize(cfgOptionStr(cfgOptRepoPath)) + 1);
+                }
+                MEM_CONTEXT_PRIOR_END();
             }
-            MEM_CONTEXT_PRIOR_END();
         }
         else
         {

--- a/test/src/module/command/repoTest.c
+++ b/test/src/module/command/repoTest.c
@@ -97,6 +97,18 @@ testRun(void)
         cfgOptionSet(cfgOptFilter, cfgSourceParam, NULL);
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("exact repo path");
+
+        StringList *argListTmp = strLstDup(argList);
+        strLstAddZ(argListTmp, TEST_PATH "/repo");
+        HRN_CFG_LOAD(cfgCmdRepoLs, argListTmp);
+
+        output = bufNew(0);
+        cfgOptionSet(cfgOptOutput, cfgSourceParam, VARUINT64(CFGOPTVAL_OUTPUT_TEXT));
+        TEST_RESULT_VOID(storageListRender(ioBufferWriteNew(output)), "empty directory (text)");
+        TEST_RESULT_STR_Z(strNewBuf(output), "", "check output");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("add path and file");
 
         cfgOptionSet(cfgOptSort, cfgSourceParam, VARUINT64(CFGOPTVAL_SORT_ASC));
@@ -160,13 +172,24 @@ testRun(void)
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error on /");
 
-        StringList *argListTmp = strLstDup(argList);
+        argListTmp = strLstDup(argList);
         strLstAddZ(argListTmp, "/");
         HRN_CFG_LOAD(cfgCmdRepoLs, argListTmp);
 
         TEST_ERROR(
             storageListRender(ioBufferWriteNew(output)), ParamInvalidError,
             "absolute path '/' is not in base path '" TEST_PATH "/repo'");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("error on path that starts with repo path");
+
+        argListTmp = strLstDup(argList);
+        strLstAddZ(argListTmp, TEST_PATH "/reposub");
+        HRN_CFG_LOAD(cfgCmdRepoLs, argListTmp);
+
+        TEST_ERROR(
+            storageListRender(ioBufferWriteNew(output)), ParamInvalidError,
+            "absolute path '" TEST_PATH "/reposub' is not in base path '" TEST_PATH "/repo'");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error on //");


### PR DESCRIPTION
If the user requested the exact repo path then strSub() would be passed an invalid start value leading to an assertion:

$ pgbackrest --stanza=test repo-ls /var/lib/pgbackrest
ASSERT: [025]: start <= this->pub.size (on dev builds)
ASSERT: [025]: string size must be <= 1073741824 bytes (on prod builds)

Fix this by checking if the requested path exactly equals the repo path and returning an empty relative path in this case.

Another issue was that invalid subpaths were not detected if they started with the repo path. For example, /var/lib/pgbackrestsub would not generate an error if the repo path was /var/lib/pgbackrest. Fix this by explictly checking for a / between the repo path and the subpath. This also requires special handling when the repo path is /.

This is not classified as a bug since the issues were found in an unreleased feature introduced in 5ae84d5e.