### PR TITLE
Fix compilation error when common/exit test is executed after protocol/protocol

### DIFF
--- a/test/lib/pgBackRestTest/Common/JobTest.pm
+++ b/test/lib/pgBackRestTest/Common/JobTest.pm
@@ -249,6 +249,12 @@ sub run
                 {
                     executeTest("find $self->{strGCovPath} -mindepth 1 -print0 | xargs -0 rm -rf");
                 }
+                # If the $strShimSrcPath directory exists, it must be deleted so that its contents left over from previous tests do
+                # not affect the current one.
+                elsif ($self->{oStorageTest}->pathExists($strShimSrcPath))
+                {
+                    executeTest("rm -rf $strShimSrcPath");
+                }
 
                 # Write build.processing to track processing of this test
                 $self->{oStorageTest}->put($strBuildProcessingFile);


### PR DESCRIPTION
The file protocol/helper.c remains in the $strShimSrcPath directory after executing the "--module=protocol --test=protocol" test. When executing the "--module=common --test=exit" test, the $strShimSrcPath/protocol/helper.c file was compiled instead of $strRepoCopySrcPath/protocol/helper.c. This led to the error, so the $strShimSrcPath directory must be deleted before running a test.

To reproduce the fixed error:
```
[keremet@sl10 pgbackrest_up]$ ./test/test.pl --test-path=/tmp/test --vm=u20 --tz=GMT  --no-coverage --module=protocol --test=protocol
2022-06-02 15:46:48.418 P00   INFO: test begin on x86_64 - log level info
2022-06-02 15:46:48.478 P00   INFO: autogenerate configure
2022-06-02 15:46:48.478 P00   INFO:     autogenerated version in configure.ac script: no changes
2022-06-02 15:46:48.480 P00   INFO:     autogenerated configure script: no changes
2022-06-02 15:46:48.480 P00   INFO: configure build
2022-06-02 15:46:49.485 P00   INFO: autogenerate code
2022-06-02 15:46:51.445 P00   INFO: cleanup old data and containers
2022-06-02 15:46:51.682 P00   INFO: builds required: bin
2022-06-02 15:46:51.705 P00   INFO:     build bin for u20 (/tmp/test/bin/u20)
2022-06-02 15:46:51.908 P00   INFO:         bin dependencies have changed, rebuilding
2022-06-02 15:46:55.725 P00   INFO: 1 test selected
                                        
2022-06-02 15:47:08.619 P00   INFO: P1-T1/1 - vm=u20, module=protocol, test=protocol (12.9s)
2022-06-02 15:47:09.025 P00   INFO: TESTS COMPLETED SUCCESSFULLY (21s)
[keremet@sl10 pgbackrest_up]$ ./test/test.pl --test-path=/tmp/test --vm=u20 --tz=GMT  --no-coverage --module=common --test=exit
2022-06-02 15:47:11.980 P00   INFO: test begin on x86_64 - log level info
2022-06-02 15:47:12.040 P00   INFO: autogenerate configure
2022-06-02 15:47:12.040 P00   INFO:     autogenerated version in configure.ac script: no changes
2022-06-02 15:47:12.042 P00   INFO:     autogenerated configure script: no changes
2022-06-02 15:47:12.042 P00   INFO: autogenerate code
2022-06-02 15:47:12.146 P00   INFO: cleanup old data and containers
2022-06-02 15:47:12.354 P00   INFO: builds required: none
2022-06-02 15:47:12.355 P00   INFO: 1 test selected
                                        
2022-06-02 15:47:15.020 P00  ERROR: [125]: P1-T1/1 - vm=u20, module=common, test=exit (err2-2.67s):
    
    STDOUT:
    /tmp/test/gcov-u20-0/src/protocol/helper.c:187:13: error: 'protocolLocalExec' used but never defined [-Werror]
      187 | static void protocolLocalExec(ProtocolHelperClient *helper, ProtocolStorageType protocolStorageType, unsigned int hostIdx, unsigned int processId); static void
          |             ^~~~~~~~~~~~~~~~~
    compilation terminated due to -Wfatal-errors.
    cc1: all warnings being treated as errors
    make: *** [Makefile:133: .build/protocol/helper.o] Error 1
    make: *** Waiting for unfinished jobs....
    
2022-06-02 15:47:15.426 P00   INFO: TESTS COMPLETED WITH 1 FAILURE(S) (4s)
[keremet@sl10 pgbackrest_up]$ 
```


