### PR TITLE
Fix hard-coded WAL size assertion in walSegmentNext().

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -99,6 +99,17 @@
 
                         <p>Add <code>FN_NO_RETURN</code> macro.</p>
                     </release-item>
+
+                    <release-item>
+                        <github-pull-request id="1781"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="alexey.gordeev"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix hard-coded WAL size assertion in <code>walSegmentNext()</code>.</p>
+                    </release-item>
                 </release-development-list>
             </release-core-list>
 
@@ -11298,6 +11309,11 @@
         <contributor id="alex.richman">
             <contributor-name-display>Alex Richman</contributor-name-display>
             <contributor-id type="github">alex-richman-onesignal</contributor-id>
+        </contributor>
+
+        <contributor id="alexey.gordeev">
+            <contributor-name-display>Alexey Gordeev</contributor-name-display>
+            <contributor-id type="github">InnerLife0</contributor-id>
         </contributor>
 
         <contributor id="anderson.a.mallmann">

--- a/src/command/archive/common.c
+++ b/src/command/archive/common.c
@@ -489,7 +489,7 @@ walSegmentNext(const String *walSegment, size_t walSegmentSize, unsigned int pgV
     ASSERT(walSegment != NULL);
     ASSERT(strSize(walSegment) == 24);
     ASSERT(UINT32_MAX % walSegmentSize == walSegmentSize - 1);
-    ASSERT(pgVersion >= PG_VERSION_11 || walSegmentSize == 16 * 1024 * 1024);
+    ASSERT(pgVersion >= PG_VERSION_11 || walSegmentSize == PG_WAL_SEGMENT_SIZE_DEFAULT);
 
     // Extract WAL parts
     uint32_t timeline = 0;


### PR DESCRIPTION
We use PG_WAL_SEGMENT_SIZE_DEFAULT to compare and check WAL size on pre-11
installations. However, there is an assertion with hard-coded WAL size value,
which doesn't respect PG_WAL_SEGMENT_SIZE_DEFAULT. This patch fixes this
hard-coded value.