### PR TITLE
Add retry to storagePosixPathRemove().

### DIFF
--- a/src/storage/posix/storage.c
+++ b/src/storage/posix/storage.c
@@ -433,6 +433,17 @@ storagePosixPathRemoveCallback(void *const callbackData, const StorageInfo *cons
     FUNCTION_TEST_RETURN_VOID();
 }
 
+// Helper to determine if an error code indicates that a path is not empty. This can vary by implementation.
+static bool
+storagePosixErrorIsEmpty(const int error)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(INT, error);
+    FUNCTION_TEST_END();
+
+    FUNCTION_TEST_RETURN(BOOL, error == ENOTEMPTY || error == EEXIST);
+}
+
 static bool
 storagePosixPathRemove(THIS_VOID, const String *path, bool recurse, StorageInterfacePathRemoveParam param)
 {
@@ -466,7 +477,7 @@ storagePosixPathRemove(THIS_VOID, const String *path, bool recurse, StorageInter
                     removed = true;
                 }
                 // Else if not empty but recursion requested then remove all sub paths/files
-                else if (errno == ENOTEMPTY && recurse)
+                else if (storagePosixErrorIsEmpty(errno) && recurse)                                                // {vm_covered}
                 {
                     StoragePosixPathRemoveData data =
                     {
@@ -477,7 +488,7 @@ storagePosixPathRemove(THIS_VOID, const String *path, bool recurse, StorageInter
                     storageInterfaceInfoListP(this, path, storageInfoLevelExists, storagePosixPathRemoveCallback, &data);
                 }
                 // Else error
-                else
+                else                                                                                                // {vm_covered}
                     THROW_SYS_ERROR_FMT(PathRemoveError, STORAGE_ERROR_PATH_REMOVE, strZ(path));                    // {vm_covered}
             }
             // Else path was removed

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -820,16 +820,9 @@ testRun(void)
             STORAGE_ERROR_PATH_REMOVE_FILE ": [13] Permission denied", strZ(fileRemove));
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("path remove without recurse");
+        TEST_TITLE("path remove - path with subpath and file removed");
 
         HRN_SYSTEM_FMT("sudo chmod 777 %s", strZ(pathRemove2));
-
-        TEST_ERROR_FMT(
-            storagePathRemoveP(storageTest, pathRemove1), PathRemoveError,
-            STORAGE_ERROR_PATH_REMOVE ": [39] Directory not empty", strZ(pathRemove1));
-
-        // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("path remove - path with subpath and file removed");
 
         TEST_RESULT_VOID(
             storagePathRemoveP(storageTest, pathRemove1, .recurse = true), "remove path");
@@ -838,9 +831,16 @@ testRun(void)
 #endif // TEST_CONTAINER_REQUIRED
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("path remove - path with subpath removed");
+        TEST_TITLE("path remove without recurse");
 
         HRN_SYSTEM_FMT("mkdir -p %s", strZ(pathRemove2));
+
+        TEST_ERROR_FMT(
+            storagePathRemoveP(storageTest, pathRemove1), PathRemoveError,
+            STORAGE_ERROR_PATH_REMOVE ": [39] Directory not empty", strZ(pathRemove1));
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("path remove - path with subpath removed");
 
         TEST_RESULT_VOID(
             storagePathRemoveP(storageTest, pathRemove1, .recurse = true), "remove path");

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -800,21 +800,20 @@ testRun(void)
             STORAGE_ERROR_PATH_REMOVE ": [13] Permission denied", strZ(pathRemove2));
 
         // -------------------------------------------------------------------------------------------------------------------------
-        // TEST_TITLE("path remove - subpath permission denied");
+        TEST_TITLE("path remove - subpath permission denied");
 
-        HRN_SYSTEM_FMT("sudo chmod 777 %s", strZ(pathRemove1));
+        String *fileRemove = strNewFmt("%s/remove.txt", strZ(pathRemove2));
 
-        // TEST_ERROR_FMT(
-        //     storagePathRemoveP(storageTest, pathRemove1, .recurse = true), PathOpenError,
-        //     STORAGE_ERROR_LIST_INFO ": [13] Permission denied", strZ(pathRemove2));
+        HRN_SYSTEM_FMT("sudo chmod 777 %s && sudo touch %s", strZ(pathRemove1), strZ(fileRemove));
+
+        TEST_ERROR_FMT(
+            storagePathRemoveP(storageTest, pathRemove1, .recurse = true), PathOpenError,
+            STORAGE_ERROR_LIST_INFO ": [13] Permission denied", strZ(pathRemove2));
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("path remove - file in subpath, permission denied");
 
-        String *fileRemove = strNewFmt("%s/remove.txt", strZ(pathRemove2));
-
-        HRN_SYSTEM_FMT(
-            "sudo chmod 755 %s && sudo touch %s && sudo chmod 777 %s", strZ(pathRemove2), strZ(fileRemove), strZ(fileRemove));
+        HRN_SYSTEM_FMT("sudo chmod 755 %s && sudo chmod 777 %s", strZ(pathRemove2), strZ(fileRemove));
 
         TEST_ERROR_FMT(
             storagePathRemoveP(storageTest, pathRemove1, .recurse = true), PathRemoveError,

--- a/test/src/module/storage/posixTest.c
+++ b/test/src/module/storage/posixTest.c
@@ -796,17 +796,17 @@ testRun(void)
             storagePathRemoveP(storageTest, pathRemove2), PathRemoveError, STORAGE_ERROR_PATH_REMOVE ": [13] Permission denied",
             strZ(pathRemove2));
         TEST_ERROR_FMT(
-            storagePathRemoveP(storageTest, pathRemove2, .recurse = true), PathOpenError,
-            STORAGE_ERROR_LIST_INFO ": [13] Permission denied", strZ(pathRemove2));
+            storagePathRemoveP(storageTest, pathRemove2, .recurse = true), PathRemoveError,
+            STORAGE_ERROR_PATH_REMOVE ": [13] Permission denied", strZ(pathRemove2));
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("path remove - subpath permission denied");
+        // TEST_TITLE("path remove - subpath permission denied");
 
         HRN_SYSTEM_FMT("sudo chmod 777 %s", strZ(pathRemove1));
 
-        TEST_ERROR_FMT(
-            storagePathRemoveP(storageTest, pathRemove2, .recurse = true), PathOpenError,
-            STORAGE_ERROR_LIST_INFO ": [13] Permission denied", strZ(pathRemove2));
+        // TEST_ERROR_FMT(
+        //     storagePathRemoveP(storageTest, pathRemove1, .recurse = true), PathOpenError,
+        //     STORAGE_ERROR_LIST_INFO ": [13] Permission denied", strZ(pathRemove2));
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("path remove - file in subpath, permission denied");
@@ -821,9 +821,16 @@ testRun(void)
             STORAGE_ERROR_PATH_REMOVE_FILE ": [13] Permission denied", strZ(fileRemove));
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("path remove - path with subpath and file removed");
+        TEST_TITLE("path remove without recurse");
 
         HRN_SYSTEM_FMT("sudo chmod 777 %s", strZ(pathRemove2));
+
+        TEST_ERROR_FMT(
+            storagePathRemoveP(storageTest, pathRemove1), PathRemoveError,
+            STORAGE_ERROR_PATH_REMOVE ": [39] Directory not empty", strZ(pathRemove1));
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("path remove - path with subpath and file removed");
 
         TEST_RESULT_VOID(
             storagePathRemoveP(storageTest, pathRemove1, .recurse = true), "remove path");


### PR DESCRIPTION
Add a retries to handle the case where readdir() skips over existing files when files are simultaneously being deleted.

This is a bit of a band aid. There are lots of other places where this readdir() issue could bite us.

NOTE: this could use better testing. There is 100% coverage because of the way to code is written, but a regression of the retry would likely not be detected.