### PR TITLE
Add link to PostgreSQL configuration in repository host section.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -150,6 +150,18 @@
                         <p>Skip internal options in the configuration reference.</p>
                     </release-item>
                 </release-bug-list>
+
+                <release-improvement-list>
+                    <release-item>
+                        <release-item-contributor-list>
+                            <release-item-ideator id="julien.cigar"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Add link to <postgres/> configuration in repository host section.</p>
+                    </release-item>
+                </release-improvement-list>
             </release-doc-list>
 
             <release-test-list>
@@ -11785,6 +11797,11 @@
         <contributor id="julian.zhang">
             <contributor-name-display>Julian Zhang</contributor-name-display>
             <contributor-id type="github">julianzhang98</contributor-id>
+        </contributor>
+
+        <contributor id="julien.cigar">
+            <contributor-name-display>Julien Cigar</contributor-name-display>
+            <contributor-id type="github">silenius</contributor-id>
         </contributor>
 
         <contributor id="jungle-boogie">

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -2477,7 +2477,7 @@
                 <backrest-config-option section="global" key="repo1-path">{[backrest-repo-path]}</backrest-config-option>
             </backrest-config>
 
-            <p>The <host>repository</host> host must be configured with the <host>{[host-pg1]}</host> host/user and database path.  The primary will be configured as <id>pg1</id> to allow a standby to be added later.</p>
+            <p>The <host>repository</host> host must be configured with the <host>{[host-pg1]}</host> host/user and database path. The primary will be configured as <id>pg1</id> to allow a standby to be added later.</p>
 
             <backrest-config host="{[host-repo1]}" owner="{[br-user]}:{[br-group]}" file="{[backrest-config-demo]}">
                 <title>Configure <br-option>pg1-host</br-option>/<br-option>pg1-host-user</br-option> and <br-option>pg1-path</br-option></title>
@@ -2529,6 +2529,8 @@
                 <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
+
+            <p><postgres/> configuration may be found in the <link section="/quickstart/configure-archiving">Configure Archiving</link> section.</p>
 
             <p>Commands are run the same as on a single host configuration except that some commands such as <cmd>backup</cmd> and <cmd>expire</cmd> are run from the <host>repository</host> host instead of the <host>database</host> host.</p>
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -2477,7 +2477,7 @@
                 <backrest-config-option section="global" key="repo1-path">{[backrest-repo-path]}</backrest-config-option>
             </backrest-config>
 
-            <p>The <host>repository</host> host must be configured with the <host>{[host-pg1]}</host> host/user and database path. The primary will be configured as <id>pg1</id> to allow a standby to be added later.</p>
+            <p>The <host>repository</host> host must be configured with the <host>{[host-pg1]}</host> host/user and database path.  The primary will be configured as <id>pg1</id> to allow a standby to be added later.</p>
 
             <backrest-config host="{[host-repo1]}" owner="{[br-user]}:{[br-group]}" file="{[backrest-config-demo]}">
                 <title>Configure <br-option>pg1-host</br-option>/<br-option>pg1-host-user</br-option> and <br-option>pg1-path</br-option></title>


### PR DESCRIPTION
This should make the documentation clearer when starting from this section.