### PR TITLE
Force target-timeline=current when restore type=immediate.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -46,6 +46,17 @@
                     </release-item>
 
                     <release-item>
+                        <github-pull-request id="1814"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stephen.frost"/>
+                        </release-item-contributor-list>
+
+                        <p>Force <br-option>target-timeline=current</br-option> when restore <br-option>type=immediate</br-option>.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-pull-request id="1758"/>
 
                         <release-item-contributor-list>

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1599,17 +1599,32 @@ testRun(void)
             "check recovery options");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("recovery target immediate");
+        TEST_TITLE("recovery target immediate, pg < 12");
 
         argList = strLstDup(argBaseList);
         hrnCfgArgRawZ(argList, cfgOptType, "immediate");
         HRN_CFG_LOAD(cfgCmdRestore, argList);
 
         TEST_RESULT_STR_Z(
-            restoreRecoveryConf(PG_VERSION_94, restoreLabel),
+            restoreRecoveryConf(PG_VERSION_11, restoreLabel),
             RECOVERY_SETTING_HEADER
             "restore_command = 'my_restore_command'\n"
             "recovery_target = 'immediate'\n",
+            "check recovery options");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("recovery target immediate, pg >= 12");
+
+        argList = strLstDup(argBaseList);
+        hrnCfgArgRawZ(argList, cfgOptType, "immediate");
+        HRN_CFG_LOAD(cfgCmdRestore, argList);
+
+        TEST_RESULT_STR_Z(
+            restoreRecoveryConf(PG_VERSION_12, restoreLabel),
+            RECOVERY_SETTING_HEADER
+            "restore_command = 'my_restore_command'\n"
+            "recovery_target = 'immediate'\n"
+            "recovery_target_timeline = 'current'\n",
             "check recovery options");
 
         // -------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
If target-timeline is not current then the recovery may fail if the most recent timeline cannot be recovered to from the backup (current) timeline. This is arguably a bug in PostgreSQL since replay should stop before a timeline switch would need to occur.

In PostgreSQL < 12 the timeline defaults to current so nothing needs to be explicitly set.