### PR TITLE
Fix incorrect time expiration being used for non-default repositories.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -16,6 +16,21 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.41dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <github-issue id="1852"/>
+                        <github-pull-request id="1854"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="adam.brusselback"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix incorrect time expiration being used for non-default repos.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-feature-list>
                     <release-item>
                         <github-issue id="1709"/>

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -1044,7 +1044,8 @@ cmdExpire(void)
                         if (cfgOptionIdxTest(cfgOptRepoRetentionFull, repoIdx))
                         {
                             expireTimeBasedBackup(
-                                infoBackup, time(NULL) - (time_t)(cfgOptionUInt(cfgOptRepoRetentionFull) * SEC_PER_DAY), repoIdx);
+                                infoBackup, time(NULL) - (time_t)(cfgOptionIdxUInt(cfgOptRepoRetentionFull, repoIdx) * SEC_PER_DAY),
+                                repoIdx);
                         }
                     }
                     else


### PR DESCRIPTION
If a repo is not specified for the expire command then the lowest repo becomes the default. In one place we were querying the default rather than a specific repo which led to an incorrect expiration begin applied. Fix it and add a test.

It would be better if the default repo could not be queried in this case but it is not clear how to do that since the repo option is valid for expire (unlike, e.g., archive-push).

