### PR TITLE
Update archive.info timestamps after a successful backup.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -61,6 +61,19 @@
                     </release-item>
 
                     <release-item>
+                        <github-issue id="1853"/>
+                        <github-pull-request id="1855"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="alex.richman"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Update archive.info timestamps after a successful backup.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="1816"/>
                         <github-pull-request id="1819"/>
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -2185,6 +2185,15 @@ backupComplete(InfoBackup *const infoBackup, Manifest *const manifest)
         infoBackupSaveFile(
             infoBackup, storageRepoWrite(), INFO_BACKUP_PATH_FILE_STR, cfgOptionStrId(cfgOptRepoCipherType),
             cfgOptionStrNull(cfgOptRepoCipherPass));
+
+        // Save archive.info/copy so the timestamps will be updated to prevent lifecycle settings from removing the files early
+        // -------------------------------------------------------------------------------------------------------------------------
+        infoArchiveSaveFile(
+            infoArchiveLoadFile(
+                storageRepo(), INFO_ARCHIVE_PATH_FILE_STR, cfgOptionStrId(cfgOptRepoCipherType),
+                cfgOptionStrNull(cfgOptRepoCipherPass)),
+            storageRepoWrite(), INFO_ARCHIVE_PATH_FILE_STR, cfgOptionStrId(cfgOptRepoCipherType),
+            cfgOptionStrNull(cfgOptRepoCipherPass));
     }
     MEM_CONTEXT_TEMP_END();
 


### PR DESCRIPTION
Lifecycle policies can cause the archive.info file and its copy to be removed since they are only updated on a stanza-upgrade. Update the timestamps after a successful backup to prevent this.

This does not mean that lifecycle policies should be used as a replacement for expiration. However, in some cases there may be policies in place that are out of admin control. If the lifecycle expiration is less than pgbackrest expiration then corruption of the earliest backup will occur at the very least and there might be other corruption which would make the repo unrecoverable.