### PR TITLE
Fix missing reference in diff/incr backup.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -16,6 +16,23 @@
     <release-list>
         <release date="XXXX-XX-XX" version="2.43dev" title="UNDER DEVELOPMENT">
             <release-core-list>
+                <release-bug-list>
+                    <release-item>
+                        <github-issue id="1933"/>
+                        <github-pull-request id="1935"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="marcel.borger"/>
+                            <release-item-ideator id="ulfedf"/>
+                            <release-item-ideator id="jaymefSO"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix missing reference in diff/incr backup.</p>
+                    </release-item>
+                </release-bug-list>
+
                 <release-improvement-list>
                     <release-item>
                         <github-issue id="1925"/>
@@ -12090,6 +12107,11 @@
             <contributor-id type="github">javierwilson</contributor-id>
         </contributor>
 
+        <contributor id="jaymefSO">
+            <contributor-name-display>jaymefSO</contributor-name-display>
+            <contributor-id type="github">jaymefSO</contributor-id>
+        </contributor>
+
         <contributor id="jeff.mccormick">
             <contributor-name-display>Jeff McCormick</contributor-name-display>
             <contributor-id type="github">jmccormick2001</contributor-id>
@@ -12251,6 +12273,11 @@
         <contributor id="marc.cousin">
             <contributor-name-display>Marc Cousin</contributor-name-display>
             <contributor-id type="github">marco44</contributor-id>
+        </contributor>
+
+        <contributor id="marcel.borger">
+            <contributor-name-display>Marcel Borger</contributor-name-display>
+            <contributor-id type="github">m-borger</contributor-id>
         </contributor>
 
         <contributor id="marco.montagna">
@@ -12515,6 +12542,11 @@
 
         <contributor id="ugo.bellavance">
             <contributor-name-display>Ugo Bellavance</contributor-name-display>
+        </contributor>
+
+        <contributor id="ulfedf">
+            <contributor-name-display>ulfedf</contributor-name-display>
+            <contributor-id type="github">ulfedf</contributor-id>
         </contributor>
 
         <contributor id="urs.kramer">

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -451,6 +451,11 @@ infoBackupDataAdd(const InfoBackup *this, const Manifest *manifest)
                 // since it will always be the current backup. Technically the current backup is always referenced but this is not
                 // useful information for the user.
                 infoBackupData.backupReference = strLstSort(strLstDup(manifestReferenceList(manifest)), sortOrderAsc);
+
+                ASSERT(
+                    strEq(
+                        strLstGet(infoBackupData.backupReference, strLstSize(infoBackupData.backupReference) - 1),
+                        infoBackupData.backupLabel));
                 strLstRemoveIdx(infoBackupData.backupReference, strLstSize(infoBackupData.backupReference) - 1);
 
                 infoBackupData.backupPrior = strDup(manData->backupLabelPrior);

--- a/src/info/infoBackup.c
+++ b/src/info/infoBackup.c
@@ -447,8 +447,12 @@ infoBackupDataAdd(const InfoBackup *this, const Manifest *manifest)
 
             if (manData->backupType != backupTypeFull)
             {
-                // This list may not be sorted for manifests created before the reference list was added
+                // This list may not be sorted for manifests created before the reference list was added. Remove the last reference
+                // since it will always be the current backup. Technically the current backup is always referenced but this is not
+                // useful information for the user.
                 infoBackupData.backupReference = strLstSort(strLstDup(manifestReferenceList(manifest)), sortOrderAsc);
+                strLstRemoveIdx(infoBackupData.backupReference, strLstSize(infoBackupData.backupReference) - 1);
+
                 infoBackupData.backupPrior = strDup(manData->backupLabelPrior);
             }
 

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -2064,7 +2064,12 @@ manifestLoadCallback(void *callbackData, const String *const section, const Stri
             else if (strEqZ(key, MANIFEST_KEY_BACKUP_BUNDLE))
                 manifest->pub.data.bundle = varBool(jsonToVar(value));
             else if (strEqZ(key, MANIFEST_KEY_BACKUP_LABEL))
+            {
                 manifest->pub.data.backupLabel = varStr(jsonToVar(value));
+
+                // !!!
+                strLstAddIfMissing(manifest->pub.referenceList, manifest->pub.data.backupLabel);
+            }
             else if (strEqZ(key, MANIFEST_KEY_BACKUP_LSN_START))
                 manifest->pub.data.lsnStart = varStr(jsonToVar(value));
             else if (strEqZ(key, MANIFEST_KEY_BACKUP_LSN_STOP))

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -2067,7 +2067,9 @@ manifestLoadCallback(void *callbackData, const String *const section, const Stri
             {
                 manifest->pub.data.backupLabel = varStr(jsonToVar(value));
 
-                // !!!
+                // Add the label to the reference list in case the manifest was created before 2.42 when the explicit reference list
+                // was added. Most references are added when the file list is loaded but the current backup will never be referenced
+                // from a file so it must be added here.
                 strLstAddIfMissing(manifest->pub.referenceList, manifest->pub.data.backupLabel);
             }
             else if (strEqZ(key, MANIFEST_KEY_BACKUP_LSN_START))

--- a/test/src/module/info/infoBackupTest.c
+++ b/test/src/module/info/infoBackupTest.c
@@ -442,8 +442,7 @@ testRun(void)
         TEST_RESULT_STR_Z(backupData.backupPrior, "20190818-084502F", "backup prior set");
         TEST_RESULT_STRLST_Z(
             backupData.backupReference,
-            "20190818-084502F\n20190818-084502F_20190819-084506D\n20190818-084502F_20190819-084506I\n"
-                "20190818-084502F_20190820-084502I\n",
+            "20190818-084502F\n20190818-084502F_20190819-084506D\n20190818-084502F_20190819-084506I\n",
             "backup reference set and ordered");
         TEST_RESULT_BOOL(backupData.optionArchiveCheck, true, "option archive check");
         TEST_RESULT_BOOL(backupData.optionArchiveCopy, true, "option archive copy");

--- a/test/src/module/info/infoBackupTest.c
+++ b/test/src/module/info/infoBackupTest.c
@@ -442,7 +442,8 @@ testRun(void)
         TEST_RESULT_STR_Z(backupData.backupPrior, "20190818-084502F", "backup prior set");
         TEST_RESULT_STRLST_Z(
             backupData.backupReference,
-            "20190818-084502F\n20190818-084502F_20190819-084506D\n20190818-084502F_20190819-084506I\n",
+            "20190818-084502F\n20190818-084502F_20190819-084506D\n20190818-084502F_20190819-084506I\n"
+                "20190818-084502F_20190820-084502I\n",
             "backup reference set and ordered");
         TEST_RESULT_BOOL(backupData.optionArchiveCheck, true, "option archive check");
         TEST_RESULT_BOOL(backupData.optionArchiveCopy, true, "option archive copy");

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -46,6 +46,15 @@ testRun(void)
             "backup-timestamp-stop=0\n"                                                                                            \
             "backup-type=\"full\"\n"
 
+        #define TEST_MANIFEST_HEADER_LABEL                                                                                         \
+            "[backup]\n"                                                                                                           \
+            "backup-label=\"20190818-084502F\"\n"                                                                                  \
+            "backup-reference=\"20190818-084502F\"\n"                                                                              \
+            "backup-timestamp-copy-start=0\n"                                                                                      \
+            "backup-timestamp-start=0\n"                                                                                           \
+            "backup-timestamp-stop=0\n"                                                                                            \
+            "backup-type=\"full\"\n"
+
         #define TEST_MANIFEST_HEADER_BUNDLE                                                                                        \
             "[backup]\n"                                                                                                           \
             "backup-bundle=true\n"                                                                                                 \
@@ -332,6 +341,7 @@ testRun(void)
                 storagePg, PG_VERSION_90, hrnPgCatalogVersion(PG_VERSION_90), false, false, false, NULL,
                 pckWriteResult(tablespaceList)),
             "build manifest");
+        TEST_RESULT_VOID(manifestBackupLabelSet(manifest, STRDEF("20190818-084502F")), "backup label set");
 
         Buffer *contentSave = bufNew(0);
 
@@ -339,7 +349,7 @@ testRun(void)
         TEST_RESULT_STR(
             strNewBuf(contentSave),
             strNewBuf(harnessInfoChecksumZ(
-                TEST_MANIFEST_HEADER
+                TEST_MANIFEST_HEADER_LABEL
                 TEST_MANIFEST_DB_90
                 TEST_MANIFEST_OPTION_ALL
                 "\n"
@@ -1496,7 +1506,7 @@ testRun(void)
             "backup-lsn-start=\"285/89000028\"\n"                                                                                  \
             "backup-lsn-stop=\"285/89001F88\"\n"                                                                                   \
             "backup-prior=\"20190818-084502F\"\n"                                                                                  \
-            "backup-reference=\"20190818-084502F,20190818-084502F_20190819-084506D,20190818-084502F_20190820-084502D\"\n"          \
+            "backup-reference=\"20190818-084502F_20190819-084506D,20190818-084502F,20190818-084502F_20190820-084502D\"\n"          \
             "backup-timestamp-copy-start=1565282141\n"                                                                             \
             "backup-timestamp-start=1565282140\n"                                                                                  \
             "backup-timestamp-stop=1565282142\n"                                                                                   \
@@ -1610,7 +1620,7 @@ testRun(void)
                 "backup-archive-start=\"000000040000028500000089\"\n"
                 "backup-archive-stop=\"000000040000028500000089\"\n"
                 "backup-bundle=true\n"
-                "backup-label=\"20190818-084502F\"\n"
+                "backup-label=\"20190818-084502F_20190820-084502D\"\n"
                 "backup-lsn-start=\"300/89000028\"\n"
                 "backup-lsn-stop=\"300/89001F88\"\n"
                 "backup-prior=\"20190818-084502F\"\n"
@@ -1654,8 +1664,6 @@ testRun(void)
                 TEST_MANIFEST_PATH
                 TEST_MANIFEST_PATH_DEFAULT))),
             "load manifest");
-
-        TEST_RESULT_VOID(manifestBackupLabelSet(manifest, STRDEF("20190818-084502F_20190820-084502D")), "backup label set");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("manifest validation");

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -1496,7 +1496,7 @@ testRun(void)
             "backup-lsn-start=\"285/89000028\"\n"                                                                                  \
             "backup-lsn-stop=\"285/89001F88\"\n"                                                                                   \
             "backup-prior=\"20190818-084502F\"\n"                                                                                  \
-            "backup-reference=\"20190818-084502F_20190819-084506D,20190818-084502F,20190818-084502F_20190820-084502D\"\n"          \
+            "backup-reference=\"20190818-084502F,20190818-084502F_20190819-084506D,20190818-084502F_20190820-084502D\"\n"          \
             "backup-timestamp-copy-start=1565282141\n"                                                                             \
             "backup-timestamp-start=1565282140\n"                                                                                  \
             "backup-timestamp-stop=1565282142\n"                                                                                   \

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -1506,7 +1506,7 @@ testRun(void)
             "backup-lsn-start=\"285/89000028\"\n"                                                                                  \
             "backup-lsn-stop=\"285/89001F88\"\n"                                                                                   \
             "backup-prior=\"20190818-084502F\"\n"                                                                                  \
-            "backup-reference=\"20190818-084502F_20190819-084506D,20190818-084502F\"\n"                                            \
+            "backup-reference=\"20190818-084502F_20190819-084506D,20190818-084502F,20190818-084502F_20190820-084502D\"\n"          \
             "backup-timestamp-copy-start=1565282141\n"                                                                             \
             "backup-timestamp-start=1565282140\n"                                                                                  \
             "backup-timestamp-stop=1565282142\n"                                                                                   \


### PR DESCRIPTION
When loading prior manifests without the new reference list, the code failed to add the current backup to the reference list. Since the current backup can never be referenced, building references from the file list was not sufficient to generate a complete list.