### PR TITLE
Add warning about enabling "hierarchical namespace" on Azure storage.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -132,6 +132,7 @@
                 <release-improvement-list>
                     <release-item>
                         <github-issue id="1770"/>
+                        <github-pull-request id="1980"/>
 
                         <release-item-contributor-list>
                             <release-item-ideator id="vojtech.galda"/>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -139,6 +139,7 @@
                             <release-item-ideator id="Pluggi"/>
                             <release-item-ideator id="asjonos"/>
                             <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
                         </release-item-contributor-list>
 
                         <p>Add warning about enabling <quote>hierarchical namespace</quote> on Azure storage.</p>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -131,6 +131,19 @@
             <release-doc-list>
                 <release-improvement-list>
                     <release-item>
+                        <github-issue id="1770"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="vojtech.galda"/>
+                            <release-item-ideator id="Pluggi"/>
+                            <release-item-ideator id="asjonos"/>
+                            <release-item-contributor id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Add warning about enabling <quote>hierarchical namespace</quote> on Azure storage.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="1910"/>
                         <github-pull-request id="1963"/>
 
@@ -11907,6 +11920,11 @@
             <contributor-id type="github">argdenis</contributor-id>
         </contributor>
 
+        <contributor id="asjonos">
+            <contributor-name-display>asjonos</contributor-name-display>
+            <contributor-id type="github">asjonos</contributor-id>
+        </contributor>
+
         <contributor id="avinash.vallarapu">
             <contributor-name-display>Avinash Vallarapu</contributor-name-display>
             <contributor-id type="github">avinashvallarapu</contributor-id>
@@ -12582,6 +12600,11 @@
             <contributor-id type="github">PierreDucroquet</contributor-id>
         </contributor>
 
+        <contributor id="Pluggi">
+            <contributor-name-display>Pluggi</contributor-name-display>
+            <contributor-id type="github">Pluggi</contributor-id>
+        </contributor>
+
         <contributor id="pritam.barhate">
             <contributor-name-display>Pritam Barhate</contributor-name-display>
             <contributor-id type="github">pritammobisoft</contributor-id>
@@ -12763,6 +12786,11 @@
         <contributor id="virgile.crevon">
             <contributor-name-display>Virgile CREVON</contributor-name-display>
             <contributor-id type="github">collectionneurfou</contributor-id>
+        </contributor>
+
+        <contributor id="vojtech.galda">
+            <contributor-name-display>Vojtech Galda</contributor-name-display>
+            <contributor-id type="github">vojtechDB</contributor-id>
         </contributor>
 
         <contributor id="vthriller">

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -687,6 +687,8 @@
     <block-define id="azure-setup">
         <p><backrest/> supports locating repositories in <proper>Azure-compatible</proper> object stores.  The container used to store the repository must be created in advance &amp;mdash; <backrest/> will not do it automatically.  The repository can be located in the container root (<path>/</path>) but it's usually best to place it in a subpath so object store logs or other data can also be stored in the container without conflicts.</p>
 
+        <admonition type="warning">Do not enable <quote>hierarchical namespace</quote> as this will cause errors during expire.</admonition>
+
         <backrest-config host="{[azure-setup-host]}" file="{[backrest-config-demo]}" owner="{[azure-setup-config-owner]}">
             <title>Configure <proper>Azure</proper></title>
 


### PR DESCRIPTION
If this feature is enabled expire will fail since directories need to be deleted separately.

Ideally we would add support for this feature but for now we'll just document the issue.