### PR TITLE
Add explicit instructions for upgrading between 2.x versions.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -36,6 +36,17 @@
             <release-doc-list>
                 <release-improvement-list>
                     <release-item>
+                        <github-pull-request id="1993"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="christophe.courtois"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Add explicit instructions for upgrading between <id>2.x</id> versions.</p>
+                    </release-item>
+
+                    <release-item>
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>
                         </release-item-contributor-list>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -36,6 +36,7 @@
             <release-doc-list>
                 <release-improvement-list>
                     <release-item>
+                        <github-issue id="1774"/>
                         <github-pull-request id="1993"/>
 
                         <release-item-contributor-list>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -866,6 +866,14 @@
 
             <p><postgres/> and repository options must be indexed when using the new names introduced in <proper>v2</proper>, e.g. <br-option>pg1-host</br-option>, <br-option>pg1-path</br-option>, <br-option>repo1-path</br-option>, <br-option>repo1-type</br-option>, etc.</p>
         </section>
+
+        <!-- =================================================================================================================== -->
+        <section id="v2.x">
+            <title>Upgrading {[project]} from v2.x to v2.y</title>
+
+            <p>Upgrading from <proper>v2.x</proper> to another <proper>v2.y</proper> is straight-forward.  The repository format does not change, so for most installations it is simply a matter of installing the binaries of the new version.  You can even downgrade as long as you don't use a new feature. </p>
+
+        </section>
     </section>
 
     <!-- ======================================================================================================================= -->

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -871,8 +871,7 @@
         <section id="v2.x">
             <title>Upgrading {[project]} from v2.x to v2.y</title>
 
-            <p>Upgrading from <proper>v2.x</proper> to another <proper>v2.y</proper> is straight-forward.  The repository format does not change, so for most installations it is simply a matter of installing the binaries of the new version.  You can even downgrade as long as you don't use a new feature. </p>
-
+            <p>Upgrading from <proper>v2.x</proper> to <proper>v2.y</proper> is straight-forward. The repository format has not changed, so for most installations it is simply a matter of installing binaries for the new version. It is also possible to downgrade if you have not used new features that are unsupported by the older version.</p>
         </section>
     </section>
 


### PR DESCRIPTION
Following https://github.com/pgbackrest/pgbackrest/issues/1774, simply add the statement that there is nothing special to do when upgrading between two 2.x versions. That's better when it is explicit.

I've left in the previous paragraph the bit about the default location that changed between 2.00 and 2.02, as it is more a matter of transitioning from 1.x to 2.x.