### PR TITLE
Keep only one all-default group index.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -33,6 +33,19 @@
                         <p>Block-level incremental backup.</p>
                     </release-item>
                 </release-feature-list>
+
+                <release-improvement-list>
+                    <release-item>
+                        <github-pull-request id="2011"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Keep only one all-default group index.</p>
+                    </release-item>
+                </release-improvement-list>
             </release-core-list>
 
             <release-doc-list>

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -2410,8 +2410,8 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
             // Phase 6: Remove any group indexes that have all default values (unless there is only one)
             //
             // It is possible that a group index was created for an option that was later found to not meet dependencies. In this
-            // case all values will be default leading to a phantom group, which can be quite confusing. Removed all group indexes
-            // that are all default (except the last one) and make sure the key for the last all default group index is 1.
+            // case all values will be default leading to a phantom group, which can be quite confusing. Remove all group indexes
+            // that are all default (except the final one) and make sure the key for the final all default group index is 1.
             // ---------------------------------------------------------------------------------------------------------------------
             for (unsigned int optionGroupIdx = 0; optionGroupIdx < CFG_OPTION_GROUP_TOTAL; optionGroupIdx++)
             {

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -2021,7 +2021,7 @@ configParse(const Storage *storage, unsigned int argListSize, const char *argLis
             // Phase 5: validate option definitions and load into configuration
             // ---------------------------------------------------------------------------------------------------------------------
             // Determine whether a group index will be kept based on non-default values
-            bool optionGroupIndexKeep[CFG_OPTION_GROUP_TOTAL][CFG_OPTION_KEY_MAX] = {false};
+            bool optionGroupIndexKeep[CFG_OPTION_GROUP_TOTAL][CFG_OPTION_KEY_MAX] = {{false}};
 
             for (unsigned int optionOrderIdx = 0; optionOrderIdx < CFG_OPTION_TOTAL; optionOrderIdx++)
             {

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -2019,20 +2019,6 @@ testRun(void)
         // TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptPgPath, cfgOptionKeyToIdx(cfgOptPgPath, 8)), "/pg8", "check pg8-path");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("repo key 1 is not required");
-
-        argList = strLstNew();
-        hrnCfgArgRawZ(argList, cfgOptStanza, "test");
-        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 1, "/pg1");
-        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 5, "repo5");
-        hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 112, "/repo112");
-        HRN_CFG_LOAD(cfgCmdCheck, argList);
-
-        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoHost, 0), "repo5", "check repo5-host");
-        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 0), "/var/lib/pgbackrest", "check repo5-path");
-        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 1), "/repo112", "check repo112-path");
-
-        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid pg option");
 
         argList = strLstNew();
@@ -2043,6 +2029,24 @@ testRun(void)
         TEST_ERROR(
             hrnCfgLoadP(cfgCmdBackup, argList, .role = cfgCmdRoleLocal), OptionInvalidValueError,
             "key '4' is not valid for 'pg' option");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("remove groups indexes that do not have a non-default option");
+
+        argList = strLstNew();
+        hrnCfgArgRawZ(argList, cfgOptStanza, "test");
+        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 1, "/pg1");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 5, "repo5");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 112, "/repo112");
+        hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 1, "x1x");
+        hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 3, "x3x");
+        hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 255, "x255x");
+        HRN_CFG_LOAD(cfgCmdCheck, argList);
+
+        TEST_RESULT_UINT(cfgOptionGroupIdxTotal(cfgOptGrpRepo), 2, "check repo group total");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoHost, 0), "repo5", "check repo5-host");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 0), "/var/lib/pgbackrest", "check repo5-path");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 1), "/repo112", "check repo112-path");
     }
 
     // *****************************************************************************************************************************

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -2019,6 +2019,20 @@ testRun(void)
         // TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptPgPath, cfgOptionKeyToIdx(cfgOptPgPath, 8)), "/pg8", "check pg8-path");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("repo key 1 is not required");
+
+        argList = strLstNew();
+        hrnCfgArgRawZ(argList, cfgOptStanza, "test");
+        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 1, "/pg1");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 5, "repo5");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoPath, 112, "/repo112");
+        HRN_CFG_LOAD(cfgCmdCheck, argList);
+
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoHost, 0), "repo5", "check repo5-host");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 0), "/var/lib/pgbackrest", "check repo5-path");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 1), "/repo112", "check repo112-path");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid pg option");
 
         argList = strLstNew();

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -2043,10 +2043,36 @@ testRun(void)
         hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 255, "x255x");
         HRN_CFG_LOAD(cfgCmdCheck, argList);
 
+        hrnCfgEnvKeyRemoveRaw(cfgOptRepoS3Key, 1);
+        hrnCfgEnvKeyRemoveRaw(cfgOptRepoS3Key, 3);
+        hrnCfgEnvKeyRemoveRaw(cfgOptRepoS3Key, 255);
+
         TEST_RESULT_UINT(cfgOptionGroupIdxTotal(cfgOptGrpRepo), 2, "check repo group total");
+        TEST_RESULT_UINT(cfgOptionGroupIdxToKey(cfgOptGrpRepo, 0), 5, "check repo5 key");
+        TEST_RESULT_Z(cfgOptionGroupName(cfgOptGrpRepo, 0), "repo5", "check repo5 name");
         TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoHost, 0), "repo5", "check repo5-host");
         TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 0), "/var/lib/pgbackrest", "check repo5-path");
+        TEST_RESULT_UINT(cfgOptionGroupIdxToKey(cfgOptGrpRepo, 1), 112, "check repo112 key");
+        TEST_RESULT_Z(cfgOptionGroupName(cfgOptGrpRepo, 1), "repo112", "check repo112 name");
         TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 1), "/repo112", "check repo112-path");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("two indexes with default options (first is remapped to repo1)");
+
+        argList = strLstNew();
+        hrnCfgArgRawZ(argList, cfgOptStanza, "test");
+        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 1, "/pg1");
+        hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 4, "x4x");
+        hrnCfgEnvKeyRawZ(cfgOptRepoS3Key, 255, "x255x");
+        HRN_CFG_LOAD(cfgCmdCheck, argList);
+
+        hrnCfgEnvKeyRemoveRaw(cfgOptRepoS3Key, 4);
+        hrnCfgEnvKeyRemoveRaw(cfgOptRepoS3Key, 255);
+
+        TEST_RESULT_UINT(cfgOptionGroupIdxTotal(cfgOptGrpRepo), 1, "check repo group total");
+        TEST_RESULT_UINT(cfgOptionGroupIdxToKey(cfgOptGrpRepo, 0), 1, "check repo1 key");
+        TEST_RESULT_Z(cfgOptionGroupName(cfgOptGrpRepo, 0), "repo1", "check repo1 name");
+        TEST_RESULT_STR_Z(cfgOptionIdxStr(cfgOptRepoPath, 0), "/var/lib/pgbackrest", "check repo1-path");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
It is possible that a group index was created for an option that was later found to not meet dependencies. In this case all values will be default leading to a phantom group, which can be quite confusing. Remove all group indexes that are all default (except the final one) and make sure the key for the final all default group index is 1.