### PR TITLE
Block incremental map fixes and improvements.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -53,6 +53,7 @@
                         <commit subject="Rename BlockHash to BlockChecksum."/>
                         <commit subject="Update default block size and super block values based on testing."/>
                         <commit subject="Ensure no continuations when block size equals super block size."/>
+                        <commit subject="Write block totals instead of a block list in super blocks."/>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -52,6 +52,7 @@
                         <commit subject="Exclude backup set size from info for block incremental backups."/>
                         <commit subject="Rename BlockHash to BlockChecksum."/>
                         <commit subject="Update default block size and super block values based on testing."/>
+                        <commit subject="Ensure no continuations when block size equals super block size."/>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -54,6 +54,9 @@
                         <commit subject="Update default block size and super block values based on testing."/>
                         <commit subject="Ensure no continuations when block size equals super block size."/>
                         <commit subject="Fix typo in blockIncrProcess()."/>
+                        <commit subject="Block incremental map fixes and improvements.">
+                            <github-pull-request id="2026"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -271,20 +271,19 @@ backupInit(const InfoBackup *infoBackup)
 Build block incremental maps
 ***********************************************************************************************************************************/
 // Size map. Block size is increased when the block map would be larger than a single block. The break can be calculated with this
-// formula: [block size in KiB] / (1024 / [block size in KiB] * [checksum size + 1]) * 1073741824.
+// formula: [block size in KiB] / (1024 / [block size in KiB] * [checksum size]) * 1073741824.
 static const ManifestBlockIncrSizeMap manifestBlockIncrSizeMapDefault[] =
 {
-    {.fileSize = 968 * 1024 * 1024, .blockSize = 96 * 1024},
-    {.fileSize = 800 * 1024 * 1024, .blockSize = 88 * 1024},
-    {.fileSize = 648 * 1024 * 1024, .blockSize = 80 * 1024},
-    {.fileSize = 512 * 1024 * 1024, .blockSize = 72 * 1024},
-    {.fileSize = 392 * 1024 * 1024, .blockSize = 64 * 1024},
-    {.fileSize = 288 * 1024 * 1024, .blockSize = 56 * 1024},
-    {.fileSize = 200 * 1024 * 1024, .blockSize = 48 * 1024},
-    {.fileSize = 128 * 1024 * 1024, .blockSize = 40 * 1024},
-    {.fileSize = 84256 * 1024, .blockSize = 32 * 1024},             // These do not come out evenly because the map record size is 7
-    {.fileSize = 37448 * 1024, .blockSize = 24 * 1024},             // instead of 8 in the rows above
-    {.fileSize = 9360 * 1024, .blockSize = 16 * 1024},
+    {.fileSize = 914 * 1024 * 1024, .blockSize = 88 * 1024},
+    {.fileSize = 740 * 1024 * 1024, .blockSize = 80 * 1024},
+    {.fileSize = 585 * 1024 * 1024, .blockSize = 72 * 1024},
+    {.fileSize = 448 * 1024 * 1024, .blockSize = 64 * 1024},
+    {.fileSize = 329 * 1024 * 1024, .blockSize = 56 * 1024},
+    {.fileSize = 228 * 1024 * 1024, .blockSize = 48 * 1024},
+    {.fileSize = 146 * 1024 * 1024, .blockSize = 40 * 1024},
+    {.fileSize = 96 * 1024 * 1024, .blockSize = 32 * 1024},
+    {.fileSize = 43 * 1024 * 1024, .blockSize = 24 * 1024},
+    {.fileSize = 11 * 1024 * 1024, .blockSize = 16 * 1024},
     {.fileSize = 16 * 1024, .blockSize = 8 * 1024},
 };
 

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -448,7 +448,7 @@ blockIncrNew(
 
                 MEM_CONTEXT_PRIOR_BEGIN()
                 {
-                    driver->blockMapPrior = blockMapNewRead(read, checksumSize);
+                    driver->blockMapPrior = blockMapNewRead(read, blockSize, checksumSize);
                 }
                 MEM_CONTEXT_PRIOR_END();
             }

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -234,14 +234,17 @@ blockIncrProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
             // Close write
             ioWriteClose(this->blockOutWrite);
 
-            // Update size for items already added to the block map
+            // Update size and super block size for items already added to the block map
             const uint64_t blockOutSize = pckReadU64P(
                 ioFilterGroupResultP(ioWriteFilterGroup(this->blockOutWrite), SIZE_FILTER_TYPE));
 
             for (unsigned int blockMapIdx = 0; blockMapIdx < lstSize(this->blockOutList); blockMapIdx++)
             {
-                blockMapGet(
-                    this->blockMapOut, *(unsigned int *)lstGet(this->blockOutList, blockMapIdx))->size = blockOutSize;
+                BlockMapItem *const blockMapItem = blockMapGet(
+                    this->blockMapOut, *(unsigned int *)lstGet(this->blockOutList, blockMapIdx));
+
+                blockMapItem->size = blockOutSize;
+                blockMapItem->superBlockSize = this->blockOutSize;
             }
 
             lstFree(this->blockOutList);

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -399,7 +399,7 @@ blockIncrNew(
         *driver = (BlockIncr)
         {
             .memContext = memContextCurrent(),
-            .superBlockSize = superBlockSize,
+            .superBlockSize = (superBlockSize / blockSize + (superBlockSize % blockSize == 0 ? 0 : 1)) * blockSize,
             .blockSize = blockSize,
             .checksumSize = checksumSize,
             .reference = reference,
@@ -409,15 +409,6 @@ blockIncrNew(
             .blockOut = bufNew(0),
             .blockMapOut = blockMapNew(),
         };
-
-        // If super block size is less than block size then make them equal
-        if (superBlockSize < blockSize)
-        {
-            driver->superBlockSize = blockSize;
-        }
-        // Else make super block size an even number of blocks
-        else if (superBlockSize > blockSize)
-            driver->superBlockSize = (superBlockSize / blockSize + (superBlockSize % blockSize == 0 ? 0 : 1)) * blockSize;
 
         // Duplicate compress filter
         if (compress != NULL)

--- a/src/command/backup/blockIncr.h
+++ b/src/command/backup/blockIncr.h
@@ -20,9 +20,6 @@ consists of the following, compressed and encrypted as required:
   when the block list is being read sequentially, e.g. during verification. If blocks are accessed from the map then the block
   number is already known and the delta can be ignored.
 
-- If the block number above has BLOCK_INCR_FLAG_SIZE set then the block size is different from the default and must be read. This is
-  because it is at the end of the file and so also indicates the end of the super block.
-
 - Block data.
 
 The super block list is followed by the block map, which is encrypted separately when required but not compressed. The return value
@@ -47,12 +44,6 @@ SHA1 file checksum. This will fail the backup, which is not ideal, but better th
 Filter type constant
 ***********************************************************************************************************************************/
 #define BLOCK_INCR_FILTER_TYPE                                      STRID5("blk-incr", 0x90dc9dad820)
-
-/***********************************************************************************************************************************
-Constants needed to read the block number in a super block
-***********************************************************************************************************************************/
-#define BLOCK_INCR_FLAG_SIZE                                        1 // Does the block have a different size than the default?
-#define BLOCK_INCR_BLOCK_SHIFT                                      1 // Shift required to get block number
 
 /***********************************************************************************************************************************
 Constructors

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -459,6 +459,7 @@ blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t bl
 
             sizeLast = (int64_t)superBlock->size;
 
+            // Write block total if the super block does not include all blocks with no block offset
             if (!(superBlockEncoded & BLOCK_MAP_FLAG_SUPER_BLOCK_COMPLETE))
             {
                 // Write total blocks in the super block

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -26,11 +26,6 @@ The block map is stored as a flag and a series of reference, super block, and bl
       - Checksum.
 
 References, super blocks, and blocks are encoded with a bit that indicates when the last one has been reached.
-
-!!! DONE:
-    - Write a block total instead of block list
-    - Working on block equal
-
 ***********************************************************************************************************************************/
 #include "build.auto.h"
 
@@ -65,7 +60,7 @@ typedef struct BlockMapReference
     uint64_t superBlockSize;                                        // Super block size
     uint64_t bundleId;                                              // Bundle id
     uint64_t offset;                                                // Offset
-    uint64_t size;                                                  // Super block size
+    uint64_t size;                                                  // Stored super block size (with compression, etc.)
     uint64_t block;                                                 // Block no
 } BlockMapReference;
 
@@ -271,6 +266,7 @@ blockMapNewRead(IoRead *const map, const size_t blockSize, const size_t checksum
     FUNCTION_LOG_RETURN(BLOCK_MAP, this);
 }
 
+/**********************************************************************************************************************************/
 FN_EXTERN void
 blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t blockSize, const size_t checksumSize)
 {

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -137,6 +137,8 @@ blockMapNewRead(IoRead *const map, size_t checksumSize)
             // If the reference is continued use the prior offset and size values
             if (referenceEncoded & BLOCK_MAP_FLAG_CONTINUE)
             {
+                ASSERT(!blockEqual);
+
                 blockMapItem.offset = referenceData->offset;
                 blockMapItem.size = referenceData->size;
                 referenceContinue = true;
@@ -333,6 +335,8 @@ blockMapWrite(const BlockMap *const this, IoWrite *const output, const bool bloc
             // the last one for the reference.
             if (reference->offset == referenceData->offset)
             {
+                ASSERT(!blockEqual);
+
                 referenceEncoded |= BLOCK_MAP_FLAG_CONTINUE;
                 referenceContinue = true;
             }

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -481,9 +481,9 @@ blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t bl
                     superBlockEncoded |= BLOCK_MAP_FLAG_SUPER_BLOCK_CHANGE;
                 }
 
-                // If this is the first size written then just write the size. !!!Else write the difference from the prior size. This
-                // depends on the expectation that the compressed size of equal-sized blocks will be similar in order to be most
-                // efficient.
+                // If this is the first size written then just write the size. Otherwise write the difference from the prior size.
+                // This depends on the expectation that the compressed size of equal-sized blocks will be similar in order to be
+                // most efficient.
                 ioWriteVarIntU64(
                     output,
                     superBlockEncoded |

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -363,6 +363,7 @@ blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t bl
         else
         {
             ASSERT(reference->reference == referenceData->reference);
+            ASSERT(reference->superBlockSize == referenceData->superBlockSize);
             ASSERT(reference->bundleId == referenceData->bundleId);
             ASSERT(reference->offset >= referenceData->offset);
 

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -216,7 +216,10 @@ blockMapNewRead(IoRead *const map, const size_t blockSize, const size_t checksum
 
                 // If the super block size has changed then read it
                 if (superBlockEncoded & BLOCK_MAP_FLAG_LAST && superBlockEncoded & BLOCK_MAP_FLAG_SUPER_BLOCK_CHANGE)
+                {
                     blockMapItem.superBlockSize = blockMapReadSuperBlockSize(map, blockSize);
+                    referenceData->superBlockSize = blockMapItem.superBlockSize;
+                }
 
                 // Set offset, size, and block for the super block
                 if (superBlockFirst)
@@ -492,7 +495,10 @@ blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t bl
 
                 // If the super block size has changed then write it
                 if (superBlockEncoded & BLOCK_MAP_FLAG_SUPER_BLOCK_CHANGE)
+                {
                     blockMapWriteSuperBlockSize(output, superBlock->superBlockSize, blockSize);
+                    referenceData->superBlockSize = superBlock->superBlockSize;
+                }
 
                 // Set offset, size, and block for the super block
                 referenceData->offset = superBlock->offset;

--- a/src/command/backup/blockMap.c
+++ b/src/command/backup/blockMap.c
@@ -262,8 +262,7 @@ blockMapNewRead(IoRead *const map, const size_t blockSize, const size_t checksum
 
 /**********************************************************************************************************************************/
 FN_EXTERN void
-blockMapWrite(
-    const BlockMap *const this, IoWrite *const output, const size_t blockSize, const size_t checksumSize)
+blockMapWrite(const BlockMap *const this, IoWrite *const output, const size_t blockSize, const size_t checksumSize)
 {
     FUNCTION_LOG_BEGIN(logLevelTrace);
         FUNCTION_LOG_PARAM(BLOCK_MAP, this);

--- a/src/command/backup/blockMap.h
+++ b/src/command/backup/blockMap.h
@@ -39,7 +39,7 @@ blockMapNew(void)
 }
 
 // New block map from IO
-FN_EXTERN BlockMap *blockMapNewRead(IoRead *map, size_t checksumSize);
+FN_EXTERN BlockMap *blockMapNewRead(IoRead *map, size_t blockSize, size_t checksumSize);
 
 /***********************************************************************************************************************************
 Functions

--- a/src/command/backup/blockMap.h
+++ b/src/command/backup/blockMap.h
@@ -20,6 +20,7 @@ typedef struct BlockMap BlockMap;
 typedef struct BlockMapItem
 {
     unsigned int reference;                                         // Reference to backup where the block is stored
+    uint64_t superBlockSize;                                        // Size for all super blocks in the reference
     uint64_t bundleId;                                              // Bundle where the block is stored (0 if not bundled)
     uint64_t offset;                                                // Offset of super block into the bundle
     uint64_t size;                                                  // Size of the super block (including compression, etc.)
@@ -52,7 +53,7 @@ blockMapAdd(BlockMap *const this, const BlockMapItem *const item)
 }
 
 // Write map to IO
-FN_EXTERN void blockMapWrite(const BlockMap *this, IoWrite *output, bool blockEqual, size_t checksumSize);
+FN_EXTERN void blockMapWrite(const BlockMap *this, IoWrite *output, size_t blockSize, size_t checksumSize);
 
 /***********************************************************************************************************************************
 Getters/Setters

--- a/src/command/backup/blockMap.h
+++ b/src/command/backup/blockMap.h
@@ -20,10 +20,10 @@ typedef struct BlockMap BlockMap;
 typedef struct BlockMapItem
 {
     unsigned int reference;                                         // Reference to backup where the block is stored
-    uint64_t superBlockSize;                                        // Size for all super blocks in the reference
+    uint64_t superBlockSize;                                        // Super block size
     uint64_t bundleId;                                              // Bundle where the block is stored (0 if not bundled)
     uint64_t offset;                                                // Offset of super block into the bundle
-    uint64_t size;                                                  // Size of the super block (including compression, etc.)
+    uint64_t size;                                                  // Stored super block size (with compression, etc.)
     uint64_t block;                                                 // Block no inside of super block
     unsigned char checksum[XX_HASH_SIZE_MAX];                       // Checksum of the block
 } BlockMapItem;

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -312,6 +312,9 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
     // If no result then the super blocks have been read. Reset for the next read.
     if (result == NULL)
     {
+        ASSERT(this->superBlockIdx == lstSize(readDelta->superBlockList));
+        ASSERT(this->blockIdx == this->blockTotal);
+
         this->superBlockData = NULL;
         this->superBlockIdx = 0;
     }

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -15,8 +15,8 @@ Object type
 ***********************************************************************************************************************************/
 typedef struct BlockDeltaSuperBlock
 {
-    uint64_t size;                                                  // Stored size of superblock (with compression, etc.)
     uint64_t superBlockSize;                                        // Super block size
+    uint64_t size;                                                  // Stored size of superblock (with compression, etc.)
     List *blockList;                                                // Block list
 } BlockDeltaSuperBlock;
 

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -38,10 +38,11 @@ struct BlockDelta
 
     const BlockDeltaSuperBlock *superBlockData;                     // Current super block data
     unsigned int superBlockIdx;                                     // Current super block index
-    unsigned int blockNo;                                           // Block number in current super block
     IoRead *chunkedRead;                                            // Chunked read for current super block
     const BlockDeltaBlock *blockData;                               // Current block data
     unsigned int blockIdx;                                          // Current block index
+    unsigned int blockTotal;                                        // Block total for super block
+    unsigned int blockFindIdx;                                      // Index of the block to find in the super block
 
     BlockDeltaWrite write;                                          // Block/offset to be returned for write
 };
@@ -255,79 +256,56 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
 
             // Set block info
             this->blockIdx = 0;
-            this->blockNo = 0;
-            this->blockData = lstGet(this->superBlockData->blockList, this->blockIdx);
+            this->blockFindIdx = 0;
+            this->blockTotal =
+                (unsigned int)(this->superBlockData->max / this->blockSize) +
+                (this->superBlockData->max % this->blockSize == 0 ? 0 : 1);
+            this->blockData = lstGet(this->superBlockData->blockList, this->blockFindIdx);
         }
 
-        // Read encoded info about the block
-        uint64_t blockEncoded = ioReadVarIntU64(this->chunkedRead);
-
-        // Loop through blocks in the super block until a match with the map is found
-        do
+        while (this->blockIdx < this->blockTotal)
         {
-            // Break out if encoded block info is zero and this is not the first block. This means the super block has ended when
-            // all blocks are equal size.
-            if (this->blockNo != 0 && blockEncoded == 0)
-            {
-                this->superBlockData = NULL;
-                this->superBlockIdx++;
-                break;
-            }
+            // Read encoded info about the block (NOT USED !!!)
+            ioReadVarIntU64(this->chunkedRead);
 
             // Apply block size limit if required and read the block
             bufUsedSet(this->write.block, 0);
 
-            if (blockEncoded & BLOCK_INCR_FLAG_SIZE)
-            {
-                size_t size = (size_t)ioReadVarIntU64(this->chunkedRead);
-                bufLimitSet(this->write.block, size);
-            }
+            if (this->blockIdx == this->blockTotal - 1 && this->superBlockData->max % this->blockSize != 0)
+                bufLimitSet(this->write.block, this->superBlockData->max % this->blockSize);
             else
                 bufLimitClear(this->write.block);
 
             ioRead(this->chunkedRead, this->write.block);
 
             // If the block matches the block we are expecting
-            if (this->blockNo == this->blockData->no)
+            if (this->blockIdx == this->blockData->no)
             {
                 this->write.offset = this->blockData->offset;
                 result = &this->write;
-                this->blockIdx++;
+                this->blockFindIdx++;
 
                 // Get the next block if there are any more to read
-                if (this->blockIdx < lstSize(this->superBlockData->blockList))
-                {
-                    this->blockData = lstGet(this->superBlockData->blockList, this->blockIdx);
-                }
-                // Else stop processing if this is the last super block. This is only works for the last super block because
-                // otherwise the blocks must be read sequentially.
-                else if (this->superBlockIdx >= lstSize(readDelta->superBlockList) - 1)
-                {
-                    this->superBlockData = NULL;
-                    this->superBlockIdx++;
-                }
+                if (this->blockFindIdx < lstSize(this->superBlockData->blockList))
+                    this->blockData = lstGet(this->superBlockData->blockList, this->blockFindIdx);
+                // else !!! NEED A SOLUTION HERE
+                //     ioReadDrain(this->chunkedRead);
             }
 
-            // If the size was set (meaning this is the last block in the super block) it must also be the last block we are looking
-            // for in the read. Partial blocks cannot happen in the middle of a read and there is code above to cut out early on the
-            // last super block of a read when possible.
-            ASSERT(blockEncoded ^ BLOCK_INCR_FLAG_SIZE || this->superBlockIdx >= lstSize(readDelta->superBlockList) - 1);
-
             // Increment the block to read in the super block
-            this->blockNo++;
+            this->blockIdx++;
 
             // Break if there is a result
             if (result != NULL)
                 break;
-
-            // Read encoded info about the block
-            blockEncoded = ioReadVarIntU64(this->chunkedRead);
         }
-        while (true);
 
         // Break if there is a result
         if (result != NULL)
             break;
+
+        this->superBlockData = NULL;
+        this->superBlockIdx++;
     }
 
     // If no result then the super blocks have been read. Reset for the next read.

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -15,8 +15,8 @@ Object type
 ***********************************************************************************************************************************/
 typedef struct BlockDeltaSuperBlock
 {
-    uint64_t size;                                                  // Size of super block
-    uint64_t max;                                                   // Max size of super block
+    uint64_t size;                                                  // Stored size of superblock (with compression, etc.)
+    uint64_t superBlockSize;                                        // Super block size
     List *blockList;                                                // Block list
 } BlockDeltaSuperBlock;
 
@@ -175,7 +175,7 @@ blockDeltaNew(
                         {
                             BlockDeltaSuperBlock blockDeltaSuperBlockNew =
                             {
-                                .max = blockMapItem->superBlockSize,
+                                .superBlockSize = blockMapItem->superBlockSize,
                                 .size = blockMapItem->size,
                                 .blockList = lstNewP(sizeof(BlockDeltaBlock)),
                             };
@@ -258,8 +258,8 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
             this->blockIdx = 0;
             this->blockFindIdx = 0;
             this->blockTotal =
-                (unsigned int)(this->superBlockData->max / this->blockSize) +
-                (this->superBlockData->max % this->blockSize == 0 ? 0 : 1);
+                (unsigned int)(this->superBlockData->superBlockSize / this->blockSize) +
+                (this->superBlockData->superBlockSize % this->blockSize == 0 ? 0 : 1);
             this->blockData = lstGet(this->superBlockData->blockList, this->blockFindIdx);
         }
 
@@ -272,8 +272,8 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
             // Apply block size limit if required and read the block
             bufUsedSet(this->write.block, 0);
 
-            if (this->blockIdx == this->blockTotal - 1 && this->superBlockData->max % this->blockSize != 0)
-                bufLimitSet(this->write.block, (size_t)(this->superBlockData->max % this->blockSize));
+            if (this->blockIdx == this->blockTotal - 1 && this->superBlockData->superBlockSize % this->blockSize != 0)
+                bufLimitSet(this->write.block, (size_t)(this->superBlockData->superBlockSize % this->blockSize));
             else
                 bufLimitClear(this->write.block);
 

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -263,16 +263,17 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
             this->blockData = lstGet(this->superBlockData->blockList, this->blockFindIdx);
         }
 
+        // Find required blocks in the super block
         while (this->blockIdx < this->blockTotal)
         {
-            // Read encoded info about the block (NOT USED !!!)
+            // Read encoded info about the block, which is not used here
             ioReadVarIntU64(this->chunkedRead);
 
             // Apply block size limit if required and read the block
             bufUsedSet(this->write.block, 0);
 
             if (this->blockIdx == this->blockTotal - 1 && this->superBlockData->max % this->blockSize != 0)
-                bufLimitSet(this->write.block, this->superBlockData->max % this->blockSize);
+                bufLimitSet(this->write.block, (size_t)(this->superBlockData->max % this->blockSize));
             else
                 bufLimitClear(this->write.block);
 
@@ -281,6 +282,8 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
             // If the block matches the block we are expecting
             if (this->blockIdx == this->blockData->no)
             {
+                ASSERT(result == NULL);
+
                 this->write.offset = this->blockData->offset;
                 result = &this->write;
                 this->blockFindIdx++;
@@ -288,8 +291,6 @@ blockDeltaNext(BlockDelta *const this, const BlockDeltaRead *const readDelta, Io
                 // Get the next block if there are any more to read
                 if (this->blockFindIdx < lstSize(this->superBlockData->blockList))
                     this->blockData = lstGet(this->superBlockData->blockList, this->blockFindIdx);
-                // else !!! NEED A SOLUTION HERE
-                //     ioReadDrain(this->chunkedRead);
             }
 
             // Increment the block to read in the super block

--- a/src/command/restore/blockDelta.c
+++ b/src/command/restore/blockDelta.c
@@ -16,6 +16,7 @@ Object type
 typedef struct BlockDeltaSuperBlock
 {
     uint64_t size;                                                  // Size of super block
+    uint64_t max;                                                   // Max size of super block
     List *blockList;                                                // Block list
 } BlockDeltaSuperBlock;
 
@@ -173,6 +174,7 @@ blockDeltaNew(
                         {
                             BlockDeltaSuperBlock blockDeltaSuperBlockNew =
                             {
+                                .max = blockMapItem->superBlockSize,
                                 .size = blockMapItem->size,
                                 .blockList = lstNewP(sizeof(BlockDeltaBlock)),
                             };

--- a/src/command/restore/file.c
+++ b/src/command/restore/file.c
@@ -295,7 +295,8 @@ restoreFile(
 
                         // Read block map. This will be compared to the block checksum list already created to determine which
                         // blocks need to be fetched from the repository. If we got here there must be at least one block to fetch.
-                        const BlockMap *const blockMap = blockMapNewRead(storageReadIo(repoFileRead), file->blockIncrChecksumSize);
+                        const BlockMap *const blockMap = blockMapNewRead(
+                            storageReadIo(repoFileRead), file->blockIncrSize, file->blockIncrChecksumSize);
 
                         // The repo file needs to be closed so that block lists can be read from the remote protocol
                         ioReadClose(storageReadIo(repoFileRead));

--- a/src/command/restore/file.c
+++ b/src/command/restore/file.c
@@ -343,6 +343,8 @@ restoreFile(
 
                                 deltaWrite = blockDeltaNext(blockDelta, read, storageReadIo(superBlockRead));
                             }
+
+                            storageReadFree(superBlockRead);
                         }
 
                         // Close the file to complete the update

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -768,28 +768,28 @@ testRun(void)
             "00"                                        // Version 0
 
             "8008"                                      // reference 128
-            "1c"                                        // size 3
+            "18"                                        // size 3
             "eeee01ffff"                                // checksum
-            "25"                                        // size
+            "21"                                        // size
             "eeee02ffff"                                // checksum
 
             "06"                                        // reference 0
             "01"                                        // bundle 1
             "01"                                        // offset 1
-            "05"                                        // size 1
+            "01"                                        // size 1
             "eeee03ffff"                                // checksum
 
             "8008"                                      // reference 128
-            "e50b"                                      // size 99
+            "e10b"                                      // size 99
             "eeee04ffff"                                // checksum
 
             "04"                                        // reference 0
             "01"                                        // offset 7
-            "05"                                        // size 99
+            "01"                                        // size 99
             "eeee05ffff"                                // checksum
 
             "21"                                        // reference 0
-            "ad0b"                                      // size 8
+            "a90b"                                      // size 8
             "eeee88ffff",                               // checksum
             "compare");
 
@@ -952,17 +952,17 @@ testRun(void)
             "00"                                        // Blocks are unequal
 
             "00"                                        // reference 0
-            "26"                                        // size 4
+            "22"                                        // size 4
             "04"                                        // super block size 6
             "eeee01000000ffff"                          // checksum
             "eeee02000000ffff"                          // checksum
 
-            "11"                                        // size 5
+            "15"                                        // size 5
             "00"                                        // block total 1
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
-            "e50b"                                      // size 99
+            "e10b"                                      // size 99
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
@@ -971,7 +971,7 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
-            "3f01"                                      // size 1
+            "3b01"                                      // size 1
             "02"                                        // super block size 2
             "eeee06000000ffff"                          // checksum
 
@@ -980,11 +980,15 @@ testRun(void)
             "01"                                        // block 5
             "eeee07000000ffff"                          // checksum
 
-            "17"                                        // size 6
+            "13"                                        // size 6
             "0102"                                      // size 2
             "eeee08000000ffff"                          // checksum
 
-            "09490101eeee09000000ffff",
+            "09"                                        // reference 1
+            "4d"                                        // size 1
+            "01"                                        // block total 1
+            "01"                                        // block 1
+            "eeee09000000ffff",                         // checksum
             "compare");
 
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -869,7 +869,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 1,
-            .superBlockSize = 6,
+            .superBlockSize = 3,
             .offset = 0,
             .size = 99,
             .block = 0,
@@ -893,7 +893,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 2,
-            .superBlockSize = 6,
+            .superBlockSize = 3,
             .offset = 0,
             .size = 1,
             .block = 0,
@@ -950,9 +950,8 @@ testRun(void)
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
-            "01"                                        // super block size 6
+            "00"                                        // super block size 3
             "f902"                                      // size 99
-            "00"                                        // block total 1
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
@@ -961,9 +960,8 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
-            "01"                                        // super block size 6
+            "00"                                        // super block size 3
             "0f"                                        // size 1
-            "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
 
             "03"                                        // reference 0

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -764,31 +764,37 @@ testRun(void)
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, buffer),
-            "02"                                        // Blocks are equal
+            "00"                                        // Version 0
 
             "8008"                                      // reference 128
-            "06"                                        // super block size 3
+            "0c"                                        // size 3
+            "00"                                        // block total 1
             "eeee01ffff"                                // checksum
-            "11"                                        // super block size 5
+            "11"                                        // size
+            "00"                                        // block total 1
             "eeee02ffff"                                // checksum
 
             "06"                                        // reference 0
             "01"                                        // bundle 1
             "01"                                        // offset 1
-            "01"                                        // super block size 5
+            "01"                                        // size 1
+            "00"                                        // block total 1
             "eeee03ffff"                                // checksum
 
             "8008"                                      // reference 128
-            "f105"                                      // super block size 99
+            "f105"                                      // size 99
+            "00"                                        // block total 1
             "eeee04ffff"                                // checksum
 
             "04"                                        // reference 0
             "01"                                        // offset 7
-            "01"                                        // super block size 99
+            "01"                                        // size 99
+            "00"                                        // block total 1
             "eeee05ffff"                                // checksum
 
             "21"                                        // reference 0
-            "d505"                                      // super block size 8
+            "d505"                                      // size 8
+            "00"                                        // block total 1
             "eeee88ffff",                               // checksum
             "compare");
 
@@ -939,8 +945,8 @@ testRun(void)
             "00"                                        // Blocks are unequal
 
             "00"                                        // reference 0
+            "12"                                        // size 4
             "04"                                        // super block size 6
-            "08"                                        // size 4
             "02"                                        // block total 2
             "eeee01000000ffff"                          // checksum
             "eeee02000000ffff"                          // checksum
@@ -950,8 +956,8 @@ testRun(void)
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
-            "02"                                        // super block size 3
             "f105"                                      // size 99
+            "00"                                        // block total 1
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
@@ -960,8 +966,8 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
+            "1f"                                        // size 1
             "0102"                                      // super block size 2
-            "1d"                                        // size 1
             "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
 
@@ -1093,7 +1099,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 31, "map size");
+        TEST_RESULT_UINT(mapSize, 34, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1133,7 +1139,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 46, "map size");
+        TEST_RESULT_UINT(mapSize, 48, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -50,7 +50,8 @@ testBlockDelta(const BlockMap *const blockMap, const size_t blockSize, const siz
         {
             const BlockDeltaSuperBlock *const superBlock = lstGet(read->superBlockList, superBlockIdx);
 
-            strCatFmt(result, "  super block {max: %" PRIu64 ", size: %" PRIu64 "}\n", superBlock->max, superBlock->size);
+            strCatFmt(
+                result, "  super block {max: %" PRIu64 ", size: %" PRIu64 "}\n", superBlock->superBlockSize, superBlock->size);
 
             for (unsigned int blockIdx = 0; blockIdx < lstSize(superBlock->blockList); blockIdx++)
             {

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -682,6 +682,7 @@ testRun(void)
         BlockMapItem blockMapItem =
         {
             .reference = 128,
+            .superBlockSize = 1,
             .bundleId = 0,
             .offset = 0,
             .size = 3,
@@ -694,6 +695,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 128,
+            .superBlockSize = 1,
             .bundleId = 0,
             .offset = 3,
             .size = 5,
@@ -705,6 +707,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 1,
             .bundleId = 1,
             .offset = 1,
             .size = 5,
@@ -716,6 +719,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 128,
+            .superBlockSize = 1,
             .bundleId = 0,
             .offset = 8,
             .size = 99,
@@ -727,6 +731,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 1,
             .bundleId = 1,
             .offset = 7,
             .size = 99,
@@ -739,6 +744,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 4,
+            .superBlockSize = 1,
             .bundleId = 0,
             .offset = 0,
             .size = 8,
@@ -752,12 +758,13 @@ testRun(void)
 
         Buffer *buffer = bufNew(256);
         IoWrite *write = ioBufferWriteNewOpen(buffer);
-        TEST_RESULT_VOID(blockMapWrite(blockMap, write, true, 5), "save");
+        TEST_RESULT_VOID(blockMapWrite(blockMap, write, 1, 5), "save");
         ioWriteClose(write);
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, buffer),
             "02"                                        // Blocks are equal
+            "00"                                        // Block size 1
 
             "8008"                                      // reference 128
             "06"                                        // super block size 3
@@ -790,7 +797,7 @@ testRun(void)
 
         Buffer *bufferCompare = bufNew(256);
         write = ioBufferWriteNewOpen(bufferCompare);
-        TEST_RESULT_VOID(blockMapWrite(blockMapNewRead(ioBufferReadNewOpen(buffer), 5), write, true, 5), "read and save");
+        TEST_RESULT_VOID(blockMapWrite(blockMapNewRead(ioBufferReadNewOpen(buffer), 5), write, 1, 5), "read and save");
         ioWriteClose(write);
 
         TEST_RESULT_STR(strNewEncode(encodingHex, bufferCompare), strNewEncode(encodingHex, buffer), "compare");
@@ -826,6 +833,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 0,
             .size = 4,
             .block = 0,
@@ -837,6 +845,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 0,
             .size = 4,
             .block = 1,
@@ -848,6 +857,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 4,
             .size = 5,
             .block = 0,
@@ -859,6 +869,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 1,
+            .superBlockSize = 6,
             .offset = 0,
             .size = 99,
             .block = 0,
@@ -870,6 +881,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 4,
             .size = 5,
             .block = 3,
@@ -881,6 +893,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 2,
+            .superBlockSize = 6,
             .offset = 0,
             .size = 1,
             .block = 0,
@@ -892,6 +905,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 4,
             .size = 5,
             .block = 5,
@@ -903,6 +917,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
+            .superBlockSize = 6,
             .offset = 9,
             .size = 6,
             .block = 0,
@@ -916,14 +931,16 @@ testRun(void)
 
         buffer = bufNew(256);
         write = ioBufferWriteNewOpen(buffer);
-        TEST_RESULT_VOID(blockMapWrite(blockMap, write, false, 8), "save");
+        TEST_RESULT_VOID(blockMapWrite(blockMap, write, 3, 8), "save");
         ioWriteClose(write);
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, buffer),
             "00"                                        // Blocks are unequal
+            "02"                                        // Block size 3
 
             "00"                                        // reference 0
+            "01"                                        // super block size 6
             "08"                                        // size 4
             "02"                                        // block total 2
             "eeee01000000ffff"                          // checksum
@@ -934,6 +951,7 @@ testRun(void)
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
+            "01"                                        // super block size 6
             "f902"                                      // size 99
             "00"                                        // block total 1
             "eeee04000000ffff"                          // checksum
@@ -944,6 +962,7 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
+            "01"                                        // super block size 6
             "0f"                                        // size 1
             "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
@@ -962,7 +981,7 @@ testRun(void)
 
         bufferCompare = bufNew(256);
         write = ioBufferWriteNewOpen(bufferCompare);
-        TEST_RESULT_VOID(blockMapWrite(blockMapNewRead(ioBufferReadNewOpen(buffer), 8), write, false, 8), "read and save");
+        TEST_RESULT_VOID(blockMapWrite(blockMapNewRead(ioBufferReadNewOpen(buffer), 8), write, 3, 8), "read and save");
         ioWriteClose(write);
 
         TEST_RESULT_STR(strNewEncode(encodingHex, bufferCompare), strNewEncode(encodingHex, buffer), "compare");
@@ -1042,7 +1061,7 @@ testRun(void)
 
         uint64_t mapSize;
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 11, "map size");
+        TEST_RESULT_UINT(mapSize, 12, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1068,14 +1087,14 @@ testRun(void)
         TEST_RESULT_VOID(
             ioFilterGroupAdd(
                 ioWriteFilterGroup(write),
-                blockIncrNewPack(ioFilterParamList(blockIncrNew(5, 3, 8, 2, 4, 5, NULL, NULL, NULL)))),
+                blockIncrNewPack(ioFilterParamList(blockIncrNew(2, 3, 8, 2, 4, 5, NULL, NULL, NULL)))),
             "block incr");
         TEST_RESULT_VOID(ioWriteOpen(write), "open");
         TEST_RESULT_VOID(ioWrite(write, source), "write");
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 31, "map size");
+        TEST_RESULT_UINT(mapSize, 32, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1115,7 +1134,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 42, "map size");
+        TEST_RESULT_UINT(mapSize, 43, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1157,7 +1176,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 32, "map size");
+        TEST_RESULT_UINT(mapSize, 34, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -3653,7 +3672,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40996, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40998, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
@@ -3683,9 +3702,9 @@ testRun(void)
                 ",\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1572800002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":24,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":26,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
-                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":28,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
+                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":30,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572800000}\n"
                 "pg_data/grow-to-block-incr={\"checksum\":\"f5a5c308cf5fcb52bccebe2365f8ed56acbcc41d\",\"size\":16383"
@@ -3764,8 +3783,8 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16418, 8KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24610, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16420, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24612, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"
@@ -3796,14 +3815,14 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573000002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":112,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":115,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
-                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":173"
+                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":175"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573000000}\n"
-                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":25,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
+                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":27,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
                 "\"size\":16385,\"timestamp\":1573000000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
                 ",\"timestamp\":1573000002}\n"
@@ -4004,7 +4023,7 @@ testRun(void)
                 ",\"timestamp\":1573400002}\n"
                 "pg_data/block-age-multiplier={\"bi\":2,\"bic\":16,\"bim\":56"
                 ",\"checksum\":\"5188431849b4613152fd7bdba6a3ff0a4fd6424b\",\"size\":32768,\"timestamp\":1573313600}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":56,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
                 ",\"size\":49152,\"timestamp\":1573400000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573400000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -767,34 +767,28 @@ testRun(void)
             "00"                                        // Version 0
 
             "8008"                                      // reference 128
-            "0c"                                        // size 3
-            "00"                                        // block total 1
+            "1c"                                        // size 3
             "eeee01ffff"                                // checksum
-            "11"                                        // size
-            "00"                                        // block total 1
+            "25"                                        // size
             "eeee02ffff"                                // checksum
 
             "06"                                        // reference 0
             "01"                                        // bundle 1
             "01"                                        // offset 1
-            "01"                                        // size 1
-            "00"                                        // block total 1
+            "05"                                        // size 1
             "eeee03ffff"                                // checksum
 
             "8008"                                      // reference 128
-            "f105"                                      // size 99
-            "00"                                        // block total 1
+            "e50b"                                      // size 99
             "eeee04ffff"                                // checksum
 
             "04"                                        // reference 0
             "01"                                        // offset 7
-            "01"                                        // size 99
-            "00"                                        // block total 1
+            "05"                                        // size 99
             "eeee05ffff"                                // checksum
 
             "21"                                        // reference 0
-            "d505"                                      // size 8
-            "00"                                        // block total 1
+            "ad0b"                                      // size 8
             "eeee88ffff",                               // checksum
             "compare");
 
@@ -932,6 +926,18 @@ testRun(void)
 
         TEST_RESULT_VOID(blockMapAdd(blockMap, &blockMapItem), "add");
 
+        blockMapItem = (BlockMapItem)
+        {
+            .reference = 1,
+            .superBlockSize = 3,
+            .offset = 99,
+            .size = 1,
+            .block = 1,
+            .checksum = {0xee, 0xee, 0x09, 0, 0, 0, 0xff, 0xff},
+        };
+
+        TEST_RESULT_VOID(blockMapAdd(blockMap, &blockMapItem), "add");
+
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("write unequal block map");
 
@@ -945,19 +951,17 @@ testRun(void)
             "00"                                        // Blocks are unequal
 
             "00"                                        // reference 0
-            "12"                                        // size 4
+            "26"                                        // size 4
             "04"                                        // super block size 6
-            "02"                                        // block total 2
             "eeee01000000ffff"                          // checksum
             "eeee02000000ffff"                          // checksum
 
-            "09"                                        // size 5
+            "11"                                        // size 5
             "00"                                        // block total 1
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
-            "f105"                                      // size 99
-            "00"                                        // block total 1
+            "e50b"                                      // size 99
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
@@ -966,19 +970,20 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
-            "1f"                                        // size 1
-            "0102"                                      // super block size 2
-            "00"                                        // block total 1
+            "3f01"                                      // size 1
+            "02"                                        // super block size 2
             "eeee06000000ffff"                          // checksum
 
-            "03"                                        // reference 0
+            "02"                                        // reference 0
             "01"                                        // block total 1
             "01"                                        // block 5
             "eeee07000000ffff"                          // checksum
-            "0b"                                        // size 6
-            "0102"                                      // super block size 2
-            "00"                                        // block total 1
-            "eeee08000000ffff",                         // checksum
+
+            "17"                                        // size 6
+            "0102"                                      // size 2
+            "eeee08000000ffff"                          // checksum
+
+            "09490101eeee09000000ffff",
             "compare");
 
         // -------------------------------------------------------------------------------------------------------------------------
@@ -999,9 +1004,11 @@ testRun(void)
             "read {reference: 2, bundleId: 0, offset: 0, size: 1}\n"
             "  super block {max: 2, size: 1}\n"
             "    block {no: 0, offset: 15}\n"
-            "read {reference: 1, bundleId: 0, offset: 0, size: 99}\n"
+            "read {reference: 1, bundleId: 0, offset: 0, size: 100}\n"
             "  super block {max: 3, size: 99}\n"
             "    block {no: 0, offset: 9}\n"
+            "  super block {max: 3, size: 1}\n"
+            "    block {no: 1, offset: 24}\n"
             "read {reference: 0, bundleId: 0, offset: 0, size: 15}\n"
             "  super block {max: 6, size: 4}\n"
             "    block {no: 0, offset: 0}\n"
@@ -1066,7 +1073,7 @@ testRun(void)
 
         uint64_t mapSize;
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 14, "map size");
+        TEST_RESULT_UINT(mapSize, 13, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1099,7 +1106,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 34, "map size");
+        TEST_RESULT_UINT(mapSize, 31, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1139,7 +1146,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 48, "map size");
+        TEST_RESULT_UINT(mapSize, 44, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1181,7 +1188,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 34, "map size");
+        TEST_RESULT_UINT(mapSize, 32, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -3677,7 +3684,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40997, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40996, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
@@ -3707,9 +3714,9 @@ testRun(void)
                 ",\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1572800002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":25,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":24,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
-                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":30,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
+                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":29,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572800000}\n"
                 "pg_data/grow-to-block-incr={\"checksum\":\"f5a5c308cf5fcb52bccebe2365f8ed56acbcc41d\",\"size\":16383"
@@ -3788,8 +3795,8 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16419, 8KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24611, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16418, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24610, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"
@@ -3822,12 +3829,12 @@ testRun(void)
                 ",\"timestamp\":1573000002}\n"
                 "pg_data/block-incr-grow={\"bi\":1,\"bim\":114,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
-                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":175"
+                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":173"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573000000}\n"
-                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":27,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
+                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":26,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
                 "\"size\":16385,\"timestamp\":1573000000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
                 ",\"timestamp\":1573000002}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -50,7 +50,7 @@ testBlockDelta(const BlockMap *const blockMap, const size_t blockSize, const siz
         {
             const BlockDeltaSuperBlock *const superBlock = lstGet(read->superBlockList, superBlockIdx);
 
-            strCatFmt(result, "  super block {size: %" PRIu64 "}\n", superBlock->size);
+            strCatFmt(result, "  super block {max: %" PRIu64 ", size: %" PRIu64 "}\n", superBlock->max, superBlock->size);
 
             for (unsigned int blockIdx = 0; blockIdx < lstSize(superBlock->blockList); blockIdx++)
             {
@@ -769,7 +769,7 @@ testRun(void)
             "8008"                                      // reference 128
             "06"                                        // super block size 3
             "eeee01ffff"                                // checksum
-            "09"                                        // super block size 5
+            "11"                                        // super block size 5
             "eeee02ffff"                                // checksum
 
             "06"                                        // reference 0
@@ -779,7 +779,7 @@ testRun(void)
             "eeee03ffff"                                // checksum
 
             "8008"                                      // reference 128
-            "f902"                                      // super block size 99
+            "f105"                                      // super block size 99
             "eeee04ffff"                                // checksum
 
             "04"                                        // reference 0
@@ -788,7 +788,7 @@ testRun(void)
             "eeee05ffff"                                // checksum
 
             "21"                                        // reference 0
-            "eb02"                                      // super block size 8
+            "d505"                                      // super block size 8
             "eeee88ffff",                               // checksum
             "compare");
 
@@ -808,20 +808,20 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(buffer), 1, 5), 1, 5),
             "read {reference: 128, bundleId: 0, offset: 0, size: 107}\n"
-            "  super block {size: 3}\n"
+            "  super block {max: 1, size: 3}\n"
             "    block {no: 0, offset: 0}\n"
-            "  super block {size: 5}\n"
+            "  super block {max: 1, size: 5}\n"
             "    block {no: 0, offset: 1}\n"
-            "  super block {size: 99}\n"
+            "  super block {max: 1, size: 99}\n"
             "    block {no: 0, offset: 3}\n"
             "read {reference: 4, bundleId: 0, offset: 0, size: 8}\n"
-            "  super block {size: 8}\n"
+            "  super block {max: 1, size: 8}\n"
             "    block {no: 0, offset: 5}\n"
             "read {reference: 0, bundleId: 1, offset: 1, size: 5}\n"
-            "  super block {size: 5}\n"
+            "  super block {max: 1, size: 5}\n"
             "    block {no: 0, offset: 2}\n"
             "read {reference: 0, bundleId: 1, offset: 7, size: 99}\n"
-            "  super block {size: 99}\n"
+            "  super block {max: 1, size: 99}\n"
             "    block {no: 0, offset: 4}\n",
             "check delta");
 
@@ -917,7 +917,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 0,
-            .superBlockSize = 6,
+            .superBlockSize = 2,
             .offset = 9,
             .size = 6,
             .block = 0,
@@ -945,13 +945,13 @@ testRun(void)
             "eeee01000000ffff"                          // checksum
             "eeee02000000ffff"                          // checksum
 
-            "05"                                        // size 5
+            "09"                                        // size 5
             "00"                                        // block total 1
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
             "02"                                        // super block size 3
-            "f902"                                      // size 99
+            "f105"                                      // size 99
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
@@ -961,7 +961,7 @@ testRun(void)
 
             "10"                                        // reference 2
             "0102"                                      // super block size 2
-            "0f"                                        // size 1
+            "1d"                                        // size 1
             "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
 
@@ -969,7 +969,8 @@ testRun(void)
             "01"                                        // block total 1
             "01"                                        // block 5
             "eeee07000000ffff"                          // checksum
-            "05"                                        // size 6
+            "0b"                                        // size 6
+            "0102"                                      // super block size 2
             "00"                                        // block total 1
             "eeee08000000ffff",                         // checksum
             "compare");
@@ -990,20 +991,20 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(buffer), 3, 8), 3, 8),
             "read {reference: 2, bundleId: 0, offset: 0, size: 1}\n"
-            "  super block {size: 1}\n"
+            "  super block {max: 2, size: 1}\n"
             "    block {no: 0, offset: 15}\n"
             "read {reference: 1, bundleId: 0, offset: 0, size: 99}\n"
-            "  super block {size: 99}\n"
+            "  super block {max: 3, size: 99}\n"
             "    block {no: 0, offset: 9}\n"
             "read {reference: 0, bundleId: 0, offset: 0, size: 15}\n"
-            "  super block {size: 4}\n"
+            "  super block {max: 6, size: 4}\n"
             "    block {no: 0, offset: 0}\n"
             "    block {no: 1, offset: 3}\n"
-            "  super block {size: 5}\n"
+            "  super block {max: 6, size: 5}\n"
             "    block {no: 0, offset: 6}\n"
             "    block {no: 3, offset: 12}\n"
             "    block {no: 5, offset: 18}\n"
-            "  super block {size: 6}\n"
+            "  super block {max: 2, size: 6}\n"
             "    block {no: 0, offset: 21}\n",
             "check delta");
     }
@@ -1059,7 +1060,7 @@ testRun(void)
 
         uint64_t mapSize;
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 11, "map size");
+        TEST_RESULT_UINT(mapSize, 14, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1071,7 +1072,7 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
             "read {reference: 0, bundleId: 0, offset: 0, size: 7}\n"
-            "  super block {size: 7}\n"
+            "  super block {max: 2, size: 7}\n"
             "    block {no: 0, offset: 0}\n",
             "check delta");
 
@@ -1106,11 +1107,11 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
             "read {reference: 2, bundleId: 4, offset: 5, size: 27}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 0}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 3}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -1132,7 +1133,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 42, "map size");
+        TEST_RESULT_UINT(mapSize, 46, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1145,14 +1146,14 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
             "read {reference: 3, bundleId: 0, offset: 0, size: 13}\n"
-            "  super block {size: 8}\n"
+            "  super block {max: 3, size: 8}\n"
             "    block {no: 0, offset: 0}\n"
-            "  super block {size: 5}\n"
+            "  super block {max: 1, size: 5}\n"
             "    block {no: 0, offset: 9}\n"
             "read {reference: 2, bundleId: 4, offset: 14, size: 18}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 3}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -1174,7 +1175,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 33, "map size");
+        TEST_RESULT_UINT(mapSize, 34, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -1188,10 +1189,10 @@ testRun(void)
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
             "read {reference: 2, bundleId: 4, offset: 5, size: 24}\n"
-            "  super block {size: 15}\n"
+            "  super block {max: 6, size: 15}\n"
             "    block {no: 0, offset: 0}\n"
             "    block {no: 1, offset: 3}\n"
-            "  super block {size: 9}\n"
+            "  super block {max: 3, size: 9}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -3700,7 +3701,7 @@ testRun(void)
                 ",\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1572800002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":26,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":25,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
                 "pg_data/block-incr-shrink={\"bi\":1,\"bim\":30,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
@@ -3813,9 +3814,9 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573000002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":116,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":114,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
-                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":174"
+                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":175"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -925,35 +925,35 @@ testRun(void)
 
             "00"                                        // reference 0
             "08"                                        // size 4
-            "00"                                        // block 0
+            "02"                                        // block total 2
             "eeee01000000ffff"                          // checksum
-
-            "03"                                        // block 1
             "eeee02000000ffff"                          // checksum
 
             "05"                                        // size 5
-            "01"                                        // block 0
+            "00"                                        // block total 1
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
             "f902"                                      // size 99
-            "01"                                        // block 0
+            "00"                                        // block total 1
             "eeee04000000ffff"                          // checksum
 
             "06"                                        // reference 0
-            "07"                                        // block 3
+            "01"                                        // block total 1
+            "02"                                        // block 3
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
             "0f"                                        // size 1
-            "01"                                        // block 0
+            "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
 
             "03"                                        // reference 0
-            "05"                                        // size 5
+            "01"                                        // block total 1
+            "01"                                        // block 5
             "eeee07000000ffff"                          // checksum
             "05"                                        // size 6
-            "01"                                        // block
+            "00"                                        // block total 1
             "eeee08000000ffff",                         // checksum
             "compare");
 
@@ -1157,7 +1157,7 @@ testRun(void)
         TEST_RESULT_VOID(ioWriteClose(write), "close");
 
         TEST_ASSIGN(mapSize, pckReadU64P(ioFilterGroupResultP(ioWriteFilterGroup(write), BLOCK_INCR_FILTER_TYPE)), "map size");
-        TEST_RESULT_UINT(mapSize, 33, "map size");
+        TEST_RESULT_UINT(mapSize, 32, "map size");
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
@@ -3653,7 +3653,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40998, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40996, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
@@ -3683,9 +3683,9 @@ testRun(void)
                 ",\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1572800002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":26,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":24,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
-                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":30,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
+                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":28,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572800000}\n"
                 "pg_data/grow-to-block-incr={\"checksum\":\"f5a5c308cf5fcb52bccebe2365f8ed56acbcc41d\",\"size\":16383"
@@ -3764,8 +3764,8 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16420, 8KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24612, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16418, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24610, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"
@@ -3796,14 +3796,14 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573000002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":123,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":112,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
-                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":194"
+                "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":173"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573000000}\n"
-                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":27,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
+                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":25,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
                 "\"size\":16385,\"timestamp\":1573000000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
                 ",\"timestamp\":1573000002}\n"
@@ -4004,7 +4004,7 @@ testRun(void)
                 ",\"timestamp\":1573400002}\n"
                 "pg_data/block-age-multiplier={\"bi\":2,\"bic\":16,\"bim\":56"
                 ",\"checksum\":\"5188431849b4613152fd7bdba6a3ff0a4fd6424b\",\"size\":32768,\"timestamp\":1573313600}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":56,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
                 ",\"size\":49152,\"timestamp\":1573400000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573400000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -893,7 +893,7 @@ testRun(void)
         blockMapItem = (BlockMapItem)
         {
             .reference = 2,
-            .superBlockSize = 3,
+            .superBlockSize = 2,
             .offset = 0,
             .size = 1,
             .block = 0,
@@ -939,7 +939,7 @@ testRun(void)
             "00"                                        // Blocks are unequal
 
             "00"                                        // reference 0
-            "01"                                        // super block size 6
+            "04"                                        // super block size 6
             "08"                                        // size 4
             "02"                                        // block total 2
             "eeee01000000ffff"                          // checksum
@@ -950,7 +950,7 @@ testRun(void)
             "eeee03000000ffff"                          // checksum
 
             "08"                                        // reference 1
-            "00"                                        // super block size 3
+            "02"                                        // super block size 3
             "f902"                                      // size 99
             "eeee04000000ffff"                          // checksum
 
@@ -960,8 +960,9 @@ testRun(void)
             "eeee05000000ffff"                          // checksum
 
             "10"                                        // reference 2
-            "00"                                        // super block size 3
+            "0102"                                      // super block size 2
             "0f"                                        // size 1
+            "00"                                        // block total 1
             "eeee06000000ffff"                          // checksum
 
             "03"                                        // reference 0
@@ -3669,7 +3670,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40997, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40998, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
@@ -3699,9 +3700,9 @@ testRun(void)
                 ",\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1572800002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":25,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":26,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
-                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":29,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
+                "pg_data/block-incr-shrink={\"bi\":1,\"bim\":30,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572800000}\n"
                 "pg_data/grow-to-block-incr={\"checksum\":\"f5a5c308cf5fcb52bccebe2365f8ed56acbcc41d\",\"size\":16383"
@@ -3780,8 +3781,8 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16419, 8KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24611, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16420, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24612, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"
@@ -3812,14 +3813,14 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573000002}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":114,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":116,\"checksum\":\"1ddde8db92dd9019be0819ae4f9ad9cea2fae399\""
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":174"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573000000}\n"
-                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":26,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
+                "pg_data/grow-to-block-incr={\"bi\":1,\"bim\":27,\"checksum\":\"4f560611d9dc9212432970e5c4bec15d876c226e\","
                 "\"size\":16385,\"timestamp\":1573000000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
                 ",\"timestamp\":1573000002}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1064,15 +1064,15 @@ testRun(void)
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
-            "02010201313200",                           // block 0
+            "020031023200",                             // block 0
             "block list");
 
         const Buffer *map = BUF(bufPtr(destination) + (bufUsed(destination) - (size_t)mapSize), (size_t)mapSize);
 
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
-            "read {reference: 0, bundleId: 0, offset: 0, size: 7}\n"
-            "  super block {max: 2, size: 7}\n"
+            "read {reference: 0, bundleId: 0, offset: 0, size: 6}\n"
+            "  super block {max: 2, size: 6}\n"
             "    block {no: 0, offset: 0}\n",
             "check delta");
 
@@ -1097,21 +1097,21 @@ testRun(void)
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
-            "020041014243020000"                          // block 0
-            "02025801595a020000"                          // block 1
-            "020231013233020000",                         // block 2
+            "02004101424300"                              // block 0
+            "02015801595a00"                              // block 1
+            "02013101323300",                             // block 2
             "block list");
 
         map = BUF(bufPtr(destination) + (bufUsed(destination) - (size_t)mapSize), (size_t)mapSize);
 
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
-            "read {reference: 2, bundleId: 4, offset: 5, size: 27}\n"
-            "  super block {max: 3, size: 9}\n"
+            "read {reference: 2, bundleId: 4, offset: 5, size: 21}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 0}\n"
-            "  super block {max: 3, size: 9}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 3}\n"
-            "  super block {max: 3, size: 9}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -1137,23 +1137,23 @@ testRun(void)
 
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
-            "0300414302430000"                          // block 0
-            "0307014000",                               // block 3
+            "03004143044300"                            // block 0
+            "02034000",                                 // block 3
             "block list");
 
         map = BUF(bufPtr(destination) + (bufUsed(destination) - (size_t)mapSize), (size_t)mapSize);
 
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
-            "read {reference: 3, bundleId: 0, offset: 0, size: 13}\n"
-            "  super block {max: 3, size: 8}\n"
+            "read {reference: 3, bundleId: 0, offset: 0, size: 11}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 0}\n"
-            "  super block {max: 1, size: 5}\n"
+            "  super block {max: 1, size: 4}\n"
             "    block {no: 0, offset: 9}\n"
-            "read {reference: 2, bundleId: 4, offset: 14, size: 18}\n"
-            "  super block {max: 3, size: 9}\n"
+            "read {reference: 2, bundleId: 4, offset: 12, size: 14}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 3}\n"
-            "  super block {max: 3, size: 9}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -1180,19 +1180,19 @@ testRun(void)
         TEST_RESULT_STR_Z(
             strNewEncode(encodingHex, BUF(bufPtr(destination), bufUsed(destination) - (size_t)mapSize)),
             "020041014243"                              // super block 0 / block 0
-            "01025801595a020000"                        // super block 0 / block 1
-            "020231013233020000",                       // block 2
+            "01015801595a00"                            // super block 0 / block 1
+            "02013101323300",                           // block 2
             "block list");
 
         map = BUF(bufPtr(destination) + (bufUsed(destination) - (size_t)mapSize), (size_t)mapSize);
 
         TEST_RESULT_STR_Z(
             testBlockDelta(blockMapNewRead(ioBufferReadNewOpen(map), 3, 8), 3, 8),
-            "read {reference: 2, bundleId: 4, offset: 5, size: 24}\n"
-            "  super block {max: 6, size: 15}\n"
+            "read {reference: 2, bundleId: 4, offset: 5, size: 20}\n"
+            "  super block {max: 6, size: 13}\n"
             "    block {no: 0, offset: 0}\n"
             "    block {no: 1, offset: 3}\n"
-            "  super block {max: 3, size: 9}\n"
+            "  super block {max: 3, size: 7}\n"
             "    block {no: 0, offset: 6}\n",
             "check delta");
 
@@ -3671,7 +3671,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40998, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40997, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
@@ -3782,8 +3782,8 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16420, 8KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24612, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16419, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24611, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"


### PR DESCRIPTION
Bug Fixes:

* Remove the distinction between maps where super block size is equal to block size and maps where they are not. In practice, maps with equal blocks are now rare and most of the optimizations can be applied directly to superblocks where the blocks are equal. This fixes a bug where a map that was created with equal size blocks and then converted to differing block sizes would generate an invalid map.

* Free reads during restore to avoid running out of file handles.

Improvements:

* Store super block sizes in the block map. This allows the final block size to be removed from the block list and provides a more optimal restore and better potential for analysis.

* Always round the super block size up to the next block size. This makes the number of blocks per super block more predictable.

* Allow super block sizes to be changed at will in the map. The first case for this is to store the reduced super block size required when the last super block is short but it could be used to dynamically change the super block size to optimize compression.

* Store a block count rather than a list of blocks in a super block. Blocks must always be sequential, though there may be an offset to the first block in a superblock. This saves 11-14% on space for checksum sizes 6-7.

* In the case that all the blocks for a super block are present, and there is no offset, the block size is omitted.