### PR TITLE
fix: allow pd_upper to be zero in a checksummed page

### DIFF
--- a/src/command/backup/pageChecksum.c
+++ b/src/command/backup/pageChecksum.c
@@ -121,7 +121,7 @@ pageChecksumProcess(THIS_VOID, const Buffer *input)
 
                 // If pd_upper is zero but the checksum field matches we'll consider it all good; this can be the case if the
                 // pd_upper field is an encrypted part of a page so could validly be 0x0000 at this point
-                if (pageHeader->pd_checksum == pgPageChecksum(this->pageBuffer, blockNo))
+                if (pageHeader->pd_checksum == pgPageChecksum(pageHeader, blockNo))
                     continue;
 
                 // On error retry the page

--- a/src/command/backup/pageChecksum.c
+++ b/src/command/backup/pageChecksum.c
@@ -119,16 +119,10 @@ pageChecksumProcess(THIS_VOID, const Buffer *input)
                         continue;
                 }
 
-                // Only validate the checksum if pd_upper is non-zero to avoid an assertion from pg_checksum_page()
-                if (pdUpperValid)
-                {
-                    // Make a copy of the page since it will be modified by the page checksum function
-                    memcpy(this->pageBuffer, pageHeader, PG_PAGE_SIZE_DEFAULT);
-
-                    // Continue if the checksum matches
-                    if (pageHeader->pd_checksum == pgPageChecksum(this->pageBuffer, blockNo))
-                        continue;
-                }
+                // If pd_upper is zero but the checksum field matches we'll consider it all good; this can be the case if the
+                // pd_upper field is an encrypted part of a page so could validly be 0x0000 at this point
+                if (pageHeader->pd_checksum == pgPageChecksum(this->pageBuffer, blockNo))
+                    continue;
 
                 // On error retry the page
                 bool changed = false;

--- a/src/command/backup/pageChecksum.c
+++ b/src/command/backup/pageChecksum.c
@@ -23,8 +23,6 @@ typedef struct PageChecksum
     unsigned int pageNoOffset;                                      // Page number offset for subsequent segments
     const String *fileName;                                         // Used to load the file to retry pages
 
-    unsigned char *pageBuffer;                                      // Buffer to hold a page while verifying the checksum
-
     bool valid;                                                     // Is the relation structure valid?
     bool align;                                                     // Is the relation alignment valid?
     PackWrite *error;                                               // List of checksum errors
@@ -232,7 +230,6 @@ pageChecksumNew(const unsigned int segmentNo, const unsigned int segmentPageTota
             .segmentPageTotal = segmentPageTotal,
             .pageNoOffset = segmentNo * segmentPageTotal,
             .fileName = strDup(fileName),
-            .pageBuffer = bufPtr(bufNew(PG_PAGE_SIZE_DEFAULT)),
             .valid = true,
             .align = true,
         };

--- a/src/command/backup/pageChecksum.c
+++ b/src/command/backup/pageChecksum.c
@@ -119,7 +119,7 @@ pageChecksumProcess(THIS_VOID, const Buffer *input)
 
                 // If pd_upper is zero but the checksum field matches we'll consider it all good; this can be the case if the
                 // pd_upper field is an encrypted part of a page so could validly be 0x0000 at this point
-                if (pageHeader->pd_checksum == pgPageChecksum(pageHeader, blockNo))
+                if (pageHeader->pd_checksum == pgPageChecksum((unsigned char*)pageHeader, blockNo))
                     continue;
 
                 // On error retry the page

--- a/src/command/backup/pageChecksum.c
+++ b/src/command/backup/pageChecksum.c
@@ -119,7 +119,7 @@ pageChecksumProcess(THIS_VOID, const Buffer *input)
 
                 // If pd_upper is zero but the checksum field matches we'll consider it all good; this can be the case if the
                 // pd_upper field is an encrypted part of a page so could validly be 0x0000 at this point
-                if (pageHeader->pd_checksum == pgPageChecksum((unsigned char*)pageHeader, blockNo))
+                if (pageHeader->pd_checksum == pgPageChecksum((unsigned char *)pageHeader, blockNo))
                     continue;
 
                 // On error retry the page

--- a/src/postgres/interface/page.c
+++ b/src/postgres/interface/page.c
@@ -32,7 +32,7 @@ pgPageChecksum(unsigned char *page, uint32_t blockNo)
 	cpage->phdr.pd_checksum = save_checksum;
 
 	/* Mix in the block number to detect transposed pages */
-	checksum ^= blkno;
+	checksum ^= blockNo;
 
 	/*
 	 * Reduce to a uint16 (to fit in the pd_checksum field) with an offset of

--- a/src/postgres/interface/page.c
+++ b/src/postgres/interface/page.c
@@ -16,27 +16,27 @@ Include the page checksum code
 FN_EXTERN uint16_t
 pgPageChecksum(unsigned char *page, uint32_t blockNo)
 {
-	PGChecksummablePage *cpage = (PGChecksummablePage *) page;
-	uint16		save_checksum;
-	uint32		checksum;
+    PGChecksummablePage *cpage = (PGChecksummablePage *) page;
+    uint16 save_checksum;
+    uint32 checksum;
 
-	/*
-	 * Save pd_checksum and temporarily set it to zero, so that the checksum
-	 * calculation isn't affected by the old checksum stored on the page.
-	 * Restore it after, because actually updating the checksum is NOT part of
-	 * the API of this function.
-	 */
-	save_checksum = cpage->phdr.pd_checksum;
-	cpage->phdr.pd_checksum = 0;
-	checksum = pg_checksum_block(cpage);
-	cpage->phdr.pd_checksum = save_checksum;
+    /*
+     * Save pd_checksum and temporarily set it to zero, so that the checksum
+     * calculation isn't affected by the old checksum stored on the page.
+     * Restore it after, because actually updating the checksum is NOT part of
+     * the API of this function.
+     */
+    save_checksum = cpage->phdr.pd_checksum;
+    cpage->phdr.pd_checksum = 0;
+    checksum = pg_checksum_block(cpage);
+    cpage->phdr.pd_checksum = save_checksum;
 
-	/* Mix in the block number to detect transposed pages */
-	checksum ^= blockNo;
+    /* Mix in the block number to detect transposed pages */
+    checksum ^= blockNo;
 
-	/*
-	 * Reduce to a uint16 (to fit in the pd_checksum field) with an offset of
-	 * one. That avoids checksums of zero, which seems like a good idea.
-	 */
-	return (uint16) ((checksum % 65535) + 1);
+    /*
+     * Reduce to a uint16 (to fit in the pd_checksum field) with an offset of
+     * one. That avoids checksums of zero, which seems like a good idea.
+     */
+    return (uint16) ((checksum % 65535) + 1);
 }

--- a/src/postgres/interface/page.c
+++ b/src/postgres/interface/page.c
@@ -16,5 +16,27 @@ Include the page checksum code
 FN_EXTERN uint16_t
 pgPageChecksum(unsigned char *page, uint32_t blockNo)
 {
-    return pg_checksum_page((char *)page, blockNo);
+	PGChecksummablePage *cpage = (PGChecksummablePage *) page;
+	uint16		save_checksum;
+	uint32		checksum;
+
+	/*
+	 * Save pd_checksum and temporarily set it to zero, so that the checksum
+	 * calculation isn't affected by the old checksum stored on the page.
+	 * Restore it after, because actually updating the checksum is NOT part of
+	 * the API of this function.
+	 */
+	save_checksum = cpage->phdr.pd_checksum;
+	cpage->phdr.pd_checksum = 0;
+	checksum = pg_checksum_block(cpage);
+	cpage->phdr.pd_checksum = save_checksum;
+
+	/* Mix in the block number to detect transposed pages */
+	checksum ^= blkno;
+
+	/*
+	 * Reduce to a uint16 (to fit in the pd_checksum field) with an offset of
+	 * one. That avoids checksums of zero, which seems like a good idea.
+	 */
+	return (uint16) ((checksum % 65535) + 1);
 }

--- a/src/postgres/interface/pageChecksum.vendor.c.inc
+++ b/src/postgres/interface/pageChecksum.vendor.c.inc
@@ -11,7 +11,7 @@ src/include/storage/checksum_impl.h for each new release.  Only the newest relea
 Modifications need to be made after copying:
 
 1) Remove `#include "storage/bufpage.h"`.
-2) Make pg_checksum_page() static.
+2) Make pg_checksum_page() static inline.
 ***********************************************************************************************************************************/
 
 /*-------------------------------------------------------------------------
@@ -197,7 +197,7 @@ pg_checksum_block(const PGChecksummablePage *page)
  * somehow moved to a different location), the page header (excluding the
  * checksum itself), and the page data.
  */
-static uint16
+static inline uint16
 pg_checksum_page(char *page, BlockNumber blkno)
 {
 	PGChecksummablePage *cpage = (PGChecksummablePage *) page;


### PR DESCRIPTION
When using pgBackRest with pages that utilize an encrypted page format, pgBackRest would on occasionally hit the case where `pd_upper` would be 0x0000 in the encrypted data.  The current code would skip checking the actual checksum to see if it matched and instead mark the block as invalid after the normal storage retry.

This commit changes the checksum calculations to compare against the computed checksum even when pd_upper is zero.

In passing, remove an unneeded copying of the page data, as the new and old routines both restored the original pd_checksum in the page header when they were called, so the comment was inaccurate and this copy did not need to be made.

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
