### PR TITLE
Finalize block incremental feature.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -21,6 +21,9 @@
                         <commit subject="Removing chunking and block numbers from incremental block list.">
                             <github-pull-request id="2029"/>
                         </commit>
+                        <commit subject="Finalize block incremental feature.">
+                            <github-pull-request id="2053"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-contributor id="david.steele"/>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -1580,8 +1580,6 @@
         <section id="block">
             <title>Block Incremental</title>
 
-            <admonition type="important">This feature is in beta release and should not be used in production. The on-disk format will change before the GA release. The <br-option>beta</br-option> option must be enabled to prevent accidental usage of beta features.</admonition>
-
             <p>Block incremental backups save space by only storing the parts of a file that have changed since the prior backup rather than storing the entire file.</p>
 
             <p>The block incremental feature is enabled with the <br-option>repo-block</br-option> option and it works best when enabled for all backup types. File bundling must also be enabled.</p>
@@ -1589,11 +1587,8 @@
             <backrest-config host="{[host-pg1]}" file="{[backrest-config-demo]}">
                 <title>Configure <br-option>repo1-block</br-option></title>
 
-                <backrest-config-option section="global" key="beta">y</backrest-config-option>
                 <backrest-config-option section="global" key="repo1-block">y</backrest-config-option>
             </backrest-config>
-
-            <p>The <br-option>repo-block-size-map</br-option>, <br-option>repo-block-size-super</br-option>, <br-option>repo-block-size-super-full</br-option>, <br-option>repo-block-age-map</br-option>, and <br-option>repo-block-checksum-size-map</br-option> options can be used for tuning, though the defaults should be optimal in most cases. Note that these options may not be be available after the beta since they are primarily intended to allow experimentation to find the optimal values.</p>
         </section>
 
         <!-- =================================================================================================================== -->

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1898,7 +1898,6 @@ option:
     section: global
     group: repo
     type: boolean
-    beta: true
     default: false
     command:
       backup: {}
@@ -1915,7 +1914,7 @@ option:
     group: repo
     type: hash
     required: false
-    beta: true
+    internal: true
     command: repo-block
     command-role:
       main: {}
@@ -1936,7 +1935,7 @@ option:
     type: size
     default: 256KiB
     allow-range: [32KiB, 16MiB]
-    beta: true
+    internal: true
     command: repo-block
     command-role:
       main: {}

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -5115,7 +5115,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                                              // opt/repo-block
         PARSE_RULE_OPTION_NAME("repo-block"),                                                                      // opt/repo-block
         PARSE_RULE_OPTION_TYPE(cfgOptTypeBoolean),                                                                 // opt/repo-block
-        PARSE_RULE_OPTION_BETA(true),                                                                              // opt/repo-block
         PARSE_RULE_OPTION_NEGATE(true),                                                                            // opt/repo-block
         PARSE_RULE_OPTION_RESET(true),                                                                             // opt/repo-block
         PARSE_RULE_OPTION_REQUIRED(true),                                                                          // opt/repo-block
@@ -5151,7 +5150,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                                      // opt/repo-block-age-map
         PARSE_RULE_OPTION_NAME("repo-block-age-map"),                                                      // opt/repo-block-age-map
         PARSE_RULE_OPTION_TYPE(cfgOptTypeHash),                                                            // opt/repo-block-age-map
-        PARSE_RULE_OPTION_BETA(true),                                                                      // opt/repo-block-age-map
         PARSE_RULE_OPTION_RESET(true),                                                                     // opt/repo-block-age-map
         PARSE_RULE_OPTION_REQUIRED(false),                                                                 // opt/repo-block-age-map
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),                                                       // opt/repo-block-age-map
@@ -5181,7 +5179,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                            // opt/repo-block-checksum-size-map
         PARSE_RULE_OPTION_NAME("repo-block-checksum-size-map"),                                  // opt/repo-block-checksum-size-map
         PARSE_RULE_OPTION_TYPE(cfgOptTypeHash),                                                  // opt/repo-block-checksum-size-map
-        PARSE_RULE_OPTION_BETA(true),                                                            // opt/repo-block-checksum-size-map
         PARSE_RULE_OPTION_RESET(true),                                                           // opt/repo-block-checksum-size-map
         PARSE_RULE_OPTION_REQUIRED(false),                                                       // opt/repo-block-checksum-size-map
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),                                             // opt/repo-block-checksum-size-map
@@ -5211,7 +5208,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                                     // opt/repo-block-size-map
         PARSE_RULE_OPTION_NAME("repo-block-size-map"),                                                    // opt/repo-block-size-map
         PARSE_RULE_OPTION_TYPE(cfgOptTypeHash),                                                           // opt/repo-block-size-map
-        PARSE_RULE_OPTION_BETA(true),                                                                     // opt/repo-block-size-map
         PARSE_RULE_OPTION_RESET(true),                                                                    // opt/repo-block-size-map
         PARSE_RULE_OPTION_REQUIRED(false),                                                                // opt/repo-block-size-map
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),                                                      // opt/repo-block-size-map
@@ -5241,7 +5237,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                                   // opt/repo-block-size-super
         PARSE_RULE_OPTION_NAME("repo-block-size-super"),                                                // opt/repo-block-size-super
         PARSE_RULE_OPTION_TYPE(cfgOptTypeSize),                                                         // opt/repo-block-size-super
-        PARSE_RULE_OPTION_BETA(true),                                                                   // opt/repo-block-size-super
         PARSE_RULE_OPTION_RESET(true),                                                                  // opt/repo-block-size-super
         PARSE_RULE_OPTION_REQUIRED(true),                                                               // opt/repo-block-size-super
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),                                                    // opt/repo-block-size-super
@@ -5282,7 +5277,6 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
     (                                                                                              // opt/repo-block-size-super-full
         PARSE_RULE_OPTION_NAME("repo-block-size-super-full"),                                      // opt/repo-block-size-super-full
         PARSE_RULE_OPTION_TYPE(cfgOptTypeSize),                                                    // opt/repo-block-size-super-full
-        PARSE_RULE_OPTION_BETA(true),                                                              // opt/repo-block-size-super-full
         PARSE_RULE_OPTION_RESET(true),                                                             // opt/repo-block-size-super-full
         PARSE_RULE_OPTION_REQUIRED(true),                                                          // opt/repo-block-size-super-full
         PARSE_RULE_OPTION_SECTION(cfgSectionGlobal),                                               // opt/repo-block-size-super-full


### PR DESCRIPTION
Remove beta status and update documentation to remove beta references and warnings.

The repo-block-* sub-options have been marked internal. Most users will be best off with the default behavior and we may still decide to change these options for remove them in the future.