### PR TITLE
Fix unique label generation for diff/incr backup.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -29,6 +29,18 @@
 
                         <p>Skip <file>recovery.signal</file> for <postgres/> &gt;= 12 when recovery <br-option>type=none</br-option>.</p>
                     </release-item>
+
+                    <release-item>
+                        <github-issue id="1873"/>
+                        <github-pull-request id="2104"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="andrey.sokolov"/>
+                            <release-item-reviewer id="david.steele"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix unique label generation for diff/incr backup.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-improvement-list>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -78,20 +78,19 @@ backupLabelCreate(const BackupType type, const String *const backupLabelPrior, c
 
         if (!strLstEmpty(historyYearList))
         {
-            // For full backup find all archives
-            // For other backup types find archives which name begins with the first date of backupLabelLatest and ends with D or I
-            const String *const fileNameRegExp = (type == backupTypeFull) ?
-                                                     backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true) :
-                                                     strNewFmt("^%.*sF\\_" DATE_TIME_REGEX "(D|I)", DATE_TIME_LEN, strZ(backupLabelLatest));
+            // For full backup compare against all backups in the history. For other backup types find backups whose name begins
+            // with full backup part of backupLabelLatest. This prevents label generation from failing when the last full backup is
+            // removed and then an diff/incr is generated from the last remaining full backup.
+            const String *const fileNameRegExp =
+                (type == backupTypeFull) ?
+                    backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true) :
+                    strNewFmt("^%.*sF\\_" DATE_TIME_REGEX "(D|I)", DATE_TIME_LEN, strZ(backupLabelLatest));
 
             const StringList *historyList = strLstSort(
                 storageListP(
                     storageRepo(),
                     strNewFmt(STORAGE_REPO_BACKUP "/" BACKUP_PATH_HISTORY "/%s", strZ(strLstGet(historyYearList, 0))),
-                    .expression = strNewFmt(
-                        "%s\\.manifest\\.%s$",
-                        strZ(fileNameRegExp),
-                        strZ(compressTypeStr(compressTypeGz)))),
+                    .expression = strNewFmt("%s\\.manifest\\.%s$", strZ(fileNameRegExp), strZ(compressTypeStr(compressTypeGz)))),
                 sortOrderDesc);
 
             if (!strLstEmpty(historyList))

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -78,13 +78,19 @@ backupLabelCreate(const BackupType type, const String *const backupLabelPrior, c
 
         if (!strLstEmpty(historyYearList))
         {
+            // For full backup find all archives
+            // For other backup types find archives which name begins with the first date of backupLabelLatest and ends with D or I
+            const String *const fileNameRegExp = (type == backupTypeFull) ?
+                                                     backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true) :
+                                                     strNewFmt("^%.*sF\\_" DATE_TIME_REGEX "(D|I)", DATE_TIME_LEN, strZ(backupLabelLatest));
+
             const StringList *historyList = strLstSort(
                 storageListP(
                     storageRepo(),
                     strNewFmt(STORAGE_REPO_BACKUP "/" BACKUP_PATH_HISTORY "/%s", strZ(strLstGet(historyYearList, 0))),
                     .expression = strNewFmt(
                         "%s\\.manifest\\.%s$",
-                        strZ(backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true)),
+                        strZ(fileNameRegExp),
                         strZ(compressTypeStr(compressTypeGz)))),
                 sortOrderDesc);
 

--- a/src/command/backup/common.c
+++ b/src/command/backup/common.c
@@ -76,7 +76,7 @@ backupLabelFormat(const BackupType type, const String *const backupLabelPrior, c
     else
     {
         // Get the full backup portion of the prior backup label and append the diff/incr timestamp
-        result = strNewFmt("%.*s_%s%s", DATE_TIME_LEN + 1 /*F*/, strZ(backupLabelPrior), buffer, type == backupTypeDiff ? "D" : "I");
+        result = strNewFmt("%.*s_%s%s", DATE_TIME_LEN + 1, strZ(backupLabelPrior), buffer, type == backupTypeDiff ? "D" : "I");
     }
 
     FUNCTION_LOG_RETURN(STRING, result);

--- a/src/command/backup/common.c
+++ b/src/command/backup/common.c
@@ -13,7 +13,6 @@ Common Functions and Definitions for Backup and Expire Commands
 /***********************************************************************************************************************************
 Constants
 ***********************************************************************************************************************************/
-#define DATE_TIME_REGEX                                             "[0-9]{8}\\-[0-9]{6}"
 #define BACKUP_LINK_LATEST                                          "latest"
 
 /**********************************************************************************************************************************/
@@ -60,7 +59,7 @@ backupLabelFormat(const BackupType type, const String *const backupLabelPrior, c
 
     // Format the timestamp
     struct tm timePart;
-    char buffer[16];
+    char buffer[DATE_TIME_LEN + 1];
 
     THROW_ON_SYS_ERROR(
         strftime(buffer, sizeof(buffer), "%Y%m%d-%H%M%S", localtime_r(&timestamp, &timePart)) == 0, AssertError,
@@ -77,7 +76,7 @@ backupLabelFormat(const BackupType type, const String *const backupLabelPrior, c
     else
     {
         // Get the full backup portion of the prior backup label and append the diff/incr timestamp
-        result = strNewFmt("%.16s_%s%s", strZ(backupLabelPrior), buffer, type == backupTypeDiff ? "D" : "I");
+        result = strNewFmt("%.*s_%s%s", DATE_TIME_LEN + 1 /*F*/, strZ(backupLabelPrior), buffer, type == backupTypeDiff ? "D" : "I");
     }
 
     FUNCTION_LOG_RETURN(STRING, result);

--- a/src/command/backup/common.h
+++ b/src/command/backup/common.h
@@ -17,6 +17,10 @@ Backup constants
 #define BACKUP_PATH_HISTORY                                         "backup.history"
 #define BACKUP_BLOCK_INCR_EXT                                       ".pgbi"
 
+// Date and time must be in the %Y%m%d-%H%M%S format, for example 20220901-193409
+#define DATE_TIME_REGEX                                             "[0-9]{8}\\-[0-9]{6}"
+#define DATE_TIME_LEN                                               (8 + 1 + 6)
+
 /***********************************************************************************************************************************
 Functions
 ***********************************************************************************************************************************/

--- a/src/command/backup/common.h
+++ b/src/command/backup/common.h
@@ -17,7 +17,7 @@ Backup constants
 #define BACKUP_PATH_HISTORY                                         "backup.history"
 #define BACKUP_BLOCK_INCR_EXT                                       ".pgbi"
 
-// Date and time must be in the %Y%m%d-%H%M%S format, for example 20220901-193409
+// Date and time must be in %Y%m%d-%H%M%S format, for example 20220901-193409
 #define DATE_TIME_REGEX                                             "[0-9]{8}\\-[0-9]{6}"
 #define DATE_TIME_LEN                                               (8 + 1 + 6)
 


### PR DESCRIPTION
If there were at least 2 full backups and then the last one was expired, then it was impossible to create either a differential or an incremental backup. The backupLabelCreate function identified this situation as clock skew, because the new backup label was compared with label of the expired full backup. If the new backup is differential or incremental, then its label should be compared with labels of differential or incremental backups related to the same full backup.
Replace numbers with macro.
https://github.com/pgbackrest/pgbackrest/issues/1873