### PR TITLE
Fix time-based archive expiration when no backups are expired.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -41,6 +41,18 @@
 
                         <p>Fix unique label generation for diff/incr backup.</p>
                     </release-item>
+
+                    <release-item>
+                        <github-issue id="2103"/>
+                        <github-pull-request id="2109"/>
+
+                        <release-item-contributor-list>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stefan.fercot"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix time-based archive expiration when no backups are expired.</p>
+                    </release-item>
                 </release-bug-list>
 
                 <release-improvement-list>

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -299,45 +299,52 @@ expireTimeBasedBackup(InfoBackup *infoBackup, const time_t minTimestamp, unsigne
         // and D1c, and keep the next full backups (F2 and F3) and all intermediate non-full backups.
         if (backupIdx > 0)
         {
-            const String *lastBackupLabelToKeep = NULL;
+            const String *retentionMetBackupLabel = NULL;
 
             do
             {
                 backupIdx--;
 
                 InfoBackupData *info = infoBackupDataByLabel(infoBackup, strLstGet(currentBackupList, backupIdx));
-                lastBackupLabelToKeep = info->backupLabel;
 
                 // We can start deleting before this backup. This way, we keep one full backup and its dependents.
                 if (info->backupTimestampStop < minTimestamp)
+                {
+                    retentionMetBackupLabel = info->backupLabel;
                     break;
+                }
             }
             while (backupIdx != 0);
 
-            // Count number of full backups being expired
-            unsigned int numFullExpired = 0;
-
-            // Since expireBackup will remove the requested entry from the backup list, we keep checking the first entry which is
-            // always the oldest so if it is not the backup to keep then we can remove it
-            while (!strEq(infoBackupData(infoBackup, 0).backupLabel, lastBackupLabelToKeep))
+            // If retention has not been met there is nothing to expire
+            if (retentionMetBackupLabel != NULL)
             {
-                StringList *backupExpired = expireBackup(infoBackup, infoBackupData(infoBackup, 0).backupLabel, repoIdx);
+                // Count number of full backups being expired
+                unsigned int numFullExpired = 0;
 
-                result += strLstSize(backupExpired);
-                numFullExpired++;
+                // Since expireBackup() will remove the requested entry from the backup list, we keep checking the first entry which
+                // is always the oldest so if it is not the backup to retain then we can remove it
+                while (!strEq(infoBackupData(infoBackup, 0).backupLabel, retentionMetBackupLabel))
+                {
+                    StringList *backupExpired = expireBackup(infoBackup, infoBackupData(infoBackup, 0).backupLabel, repoIdx);
 
-                // Log the expired backups. If there is more than one backup, then prepend "set:"
-                LOG_INFO_FMT(
-                    "%s: expire time-based backup %s%s", cfgOptionGroupName(cfgOptGrpRepo, repoIdx),
-                    (strLstSize(backupExpired) > 1 ? "set " : ""), strZ(strLstJoin(backupExpired, ", ")));
-            }
+                    result += strLstSize(backupExpired);
+                    numFullExpired++;
 
-            if (cfgOptionIdxStrId(cfgOptRepoRetentionArchiveType, repoIdx) == backupTypeFull &&
-                !cfgOptionIdxTest(cfgOptRepoRetentionArchive, repoIdx) && numFullExpired > 0)
-            {
-                cfgOptionIdxSet(
-                    cfgOptRepoRetentionArchive, repoIdx, cfgSourceDefault,
-                    VARINT64(strLstSize(currentBackupList) - numFullExpired));
+                    // Log the expired backups. If there is more than one backup, then prepend "set:"
+                    LOG_INFO_FMT(
+                        "%s: expire time-based backup %s%s", cfgOptionGroupName(cfgOptGrpRepo, repoIdx),
+                        (strLstSize(backupExpired) > 1 ? "set " : ""), strZ(strLstJoin(backupExpired, ", ")));
+                }
+
+                // Set archive retention (if it is not already set) based on the number of full backups retained
+                if (cfgOptionIdxStrId(cfgOptRepoRetentionArchiveType, repoIdx) == backupTypeFull &&
+                    !cfgOptionIdxTest(cfgOptRepoRetentionArchive, repoIdx))
+                {
+                    cfgOptionIdxSet(
+                        cfgOptRepoRetentionArchive, repoIdx, cfgSourceDefault,
+                        VARINT64(strLstSize(currentBackupList) - numFullExpired));
+                }
             }
         }
     }


### PR DESCRIPTION
In the case that no backups were expired but time-based retention was met no archive expiration would occur and the following would be logged:

INFO: time-based archive retention not met - archive logs will not be expired

In most cases this was harmless, but when retention was first met or if retention was increased, it would require one additional backup to expire earlier WAL. After that expiration worked as normal.

Even once expiration was working normally the message would continue to be output, which was pretty misleading since retention had been met, even though there was nothing to do.

Bring this code in line with count-based retention, i.e. always log what should be expired at detail level (even if nothing will be expired) and then log info about what was expired (even if nothing is expired). For example:

DETAIL: repo1: 11-1 archive retention on backup 20181119-152138F, start = 000000010000000000000002
    INFO: repo1: 11-1 no archive to remove