### PR TITLE
Fix block incremental file names in verify command.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -18,6 +18,19 @@
             <release-core-list>
                 <release-bug-list>
                     <release-item>
+                        <github-issue id="2112"/>
+                        <github-pull-request id="2120"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="francisco.miguel.biete"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="reid.thompson"/>
+                        </release-item-contributor-list>
+
+                        <p>Fix block incremental file names in <cmd>verify</cmd> command.</p>
+                    </release-item>
+
+                    <release-item>
                         <github-issue id="2062"/>
                         <github-pull-request id="2070"/>
 
@@ -12520,18 +12533,13 @@
         </contributor>
 
         <contributor id="francisco.miguel.biete">
-            <contributor-name-display>Francisco Miguel Biete</contributor-name-display>
+            <contributor-name-display>Francisco Miguel Biete Banon</contributor-name-display>
             <contributor-id type="github">fmbiete</contributor-id>
         </contributor>
 
         <contributor id="floris.van.nee">
             <contributor-name-display>Floris van Nee</contributor-name-display>
             <contributor-id type="github">fvannee</contributor-id>
-        </contributor>
-
-        <contributor id="francisco.miguel.biete">
-            <contributor-name-display>Francisco Miguel Biete</contributor-name-display>
-            <contributor-id type="github">fmbiete</contributor-id>
         </contributor>
 
         <contributor id="vidhya.gurumoorthi">

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -977,25 +977,21 @@ verifyBackup(VerifyJobData *const jobData)
                             // Set up the job
                             ProtocolCommand *command = protocolCommandNew(PROTOCOL_COMMAND_VERIFY_FILE);
                             PackWrite *const param = protocolCommandParam(command);
+                            const String *const filePathName = backupFileRepoPathP(
+                                fileBackupLabel, .manifestName = fileData.name, .bundleId = fileData.bundleId,
+                                .compressType = manifestData(jobData->manifest)->backupOptionCompressType,
+                                .blockIncr = fileData.blockIncrMapSize != 0);
 
-                            const String *const filePathName = strNewFmt(
-                                STORAGE_REPO_BACKUP "/%s/%s%s", strZ(fileBackupLabel), strZ(fileData.name),
-                                strZ(compressExtStr((manifestData(jobData->manifest))->backupOptionCompressType)));
+                            pckWriteStrP(param, filePathName);
 
                             if (fileData.bundleId != 0)
                             {
-                                pckWriteStrP(
-                                    param,
-                                    strNewFmt(
-                                        STORAGE_REPO_BACKUP "/%s/" MANIFEST_PATH_BUNDLE "/%" PRIu64, strZ(fileBackupLabel),
-                                        fileData.bundleId));
                                 pckWriteBoolP(param, true);
                                 pckWriteU64P(param, fileData.bundleOffset);
                                 pckWriteU64P(param, fileData.sizeRepo);
                             }
                             else
                             {
-                                pckWriteStrP(param, filePathName);
                                 pckWriteBoolP(param, false);
                             }
 

--- a/src/command/verify/verify.c
+++ b/src/command/verify/verify.c
@@ -991,9 +991,7 @@ verifyBackup(VerifyJobData *const jobData)
                                 pckWriteU64P(param, fileData.sizeRepo);
                             }
                             else
-                            {
                                 pckWriteBoolP(param, false);
-                            }
 
                             // Use the repo checksum when present
                             if (fileData.checksumRepoSha1 != NULL)

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -1545,6 +1545,8 @@ testRun(void)
             "[target:file]\n"
             "pg_data/validfile={\"bni\":1,\"bno\":3,\"checksum\":\"%s\",\"size\":%u,\"timestamp\":1565282114}\n"
             "pg_data/zerofile={\"size\":0,\"timestamp\":1565282114}\n"
+            "pg_data/biind={\"bi\":1,\"bim\":3,\"checksum\":\"9865d483bc5a94f2e30056fc256ed3066af54d04\",\"size\":4"
+            ",\"timestamp\":1565282114}\n"
             TEST_MANIFEST_FILE_DEFAULT
             TEST_MANIFEST_LINK
             TEST_MANIFEST_LINK_DEFAULT
@@ -1562,6 +1564,8 @@ testRun(void)
         HRN_STORAGE_PUT_Z(
             storageRepoWrite(), STORAGE_REPO_BACKUP "/20201119-163000F/bundle/1", zNewFmt("XXX%s", fileContents),
             .comment = "valid file");
+        HRN_STORAGE_PUT_Z(
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20201119-163000F/pg_data/biind.pgbi", "ZZZZ", .comment = "pgbi file");
 
         // Create WAL file with just header info and small WAL size
         Buffer *walBuffer = bufNew((size_t)(1024 * 1024));
@@ -1657,14 +1661,16 @@ testRun(void)
         HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE, TEST_BACKUP_INFO);
         HRN_INFO_PUT(storageRepoWrite(), INFO_BACKUP_PATH_FILE INFO_COPY_EXT, TEST_BACKUP_INFO);
 
-        // Create valid full backup for DB1
-        #define TEST_MANIFEST_FULL_DB1                                                                                             \
+        // Create valid full backup for DB2
+        #define TEST_MANIFEST_FULL_DB2                                                                                             \
             TEST_MANIFEST_HEADER                                                                                                   \
             TEST_MANIFEST_DB_94                                                                                                    \
             TEST_MANIFEST_OPTION_ALL                                                                                               \
             TEST_MANIFEST_TARGET                                                                                                   \
             TEST_MANIFEST_DB                                                                                                       \
             TEST_MANIFEST_FILE                                                                                                     \
+            "pg_data/biind={\"bi\":1,\"bim\":3,\"checksum\":\"f0da04b8eb24817a8a920cdbcc00402c0bb85a29\",\"size\":4"               \
+            ",\"timestamp\":1565282114}\n"                                                                                         \
             TEST_MANIFEST_FILE_DEFAULT                                                                                             \
             TEST_MANIFEST_LINK                                                                                                     \
             TEST_MANIFEST_LINK_DEFAULT                                                                                             \
@@ -1673,14 +1679,17 @@ testRun(void)
 
         // Write manifests for full backup
         HRN_INFO_PUT(
-            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/" BACKUP_MANIFEST_FILE, TEST_MANIFEST_FULL_DB1,
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/" BACKUP_MANIFEST_FILE, TEST_MANIFEST_FULL_DB2,
             .comment = "valid manifest - full");
         HRN_INFO_PUT(
-            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT, TEST_MANIFEST_FULL_DB1,
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT, TEST_MANIFEST_FULL_DB2,
             .comment = "valid manifest copy - full");
+        HRN_STORAGE_PUT_Z(
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/pg_data/biind.pgbi", "ZVZV", .comment = "pgbi file");
+        // THROW_FMT(AssertError, "!!! %s", strZ(strNewEncode(encodingHex, cryptoHashOne(hashTypeSha1, BUFSTRDEF("ZVZV")))));
 
-        // Create valid diff backup for DB1
-        #define TEST_MANIFEST_DIFF_DB1                                                                                             \
+        // Create valid diff backup for DB2
+        #define TEST_MANIFEST_DIFF_DB2                                                                                             \
             TEST_MANIFEST_HEADER                                                                                                   \
             TEST_MANIFEST_DB_94                                                                                                    \
             TEST_MANIFEST_OPTION_ALL                                                                                               \
@@ -1690,6 +1699,8 @@ testRun(void)
             "[target:file]\n"                                                                                                      \
             "pg_data/PG_VERSION={\"checksum\":\"184473f470864e067ee3a22e64b47b0a1c356f29\",\"reference\":\"20181119-152900F\""     \
                 ",\"size\":4,\"timestamp\":1565282114}\n"                                                                          \
+            "pg_data/biind={\"bi\":1,\"bim\":3,\"checksum\":\"f0da04b8eb24817a8a920cdbcc00402c0bb85a29\","                         \
+            "\"reference\":\"20181119-152900F\",\"size\":4,\"timestamp\":1565282114}\n"                                            \
             TEST_MANIFEST_FILE_DEFAULT                                                                                             \
             TEST_MANIFEST_LINK                                                                                                     \
             TEST_MANIFEST_LINK_DEFAULT                                                                                             \
@@ -1699,10 +1710,10 @@ testRun(void)
         // Write manifests for diff backup
         HRN_INFO_PUT(
             storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F_20181119-152909D/" BACKUP_MANIFEST_FILE,
-            TEST_MANIFEST_DIFF_DB1, .comment = "valid manifest - diff");
+            TEST_MANIFEST_DIFF_DB2, .comment = "valid manifest - diff");
         HRN_INFO_PUT(
             storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F_20181119-152909D/" BACKUP_MANIFEST_FILE INFO_COPY_EXT,
-            TEST_MANIFEST_DIFF_DB1, .comment = "valid manifest copy - diff");
+            TEST_MANIFEST_DIFF_DB2, .comment = "valid manifest copy - diff");
 
         // Put the file referenced by both backups into the full backup
         HRN_STORAGE_PUT_Z(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/pg_data/PG_VERSION", fileContents);
@@ -1725,22 +1736,22 @@ testRun(void)
             "stanza: db\n"
             "status: error\n"
             "  archiveId: none found\n"
-            "  backup: 20181119-152900F, status: invalid, total files checked: 1, total valid files: 0\n"
-            "    missing: 0, checksum invalid: 1, size invalid: 0, other: 0\n"
-            "  backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 1, total valid files: 0\n"
+            "  backup: 20181119-152900F, status: invalid, total files checked: 2, total valid files: 0\n"
+            "    missing: 0, checksum invalid: 2, size invalid: 0, other: 0\n"
+            "  backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 2, total valid files: 1\n"
             "    missing: 0, checksum invalid: 1, size invalid: 0, other: 0\n", .remove = true);
         // The error for the referenced file is logged twice because it is checked again by the second backup since the first backup
         // verification had not yet completed before the second backup verification began
         TEST_RESULT_LOG(
             "P01   INFO: invalid checksum '20181119-152900F/pg_data/PG_VERSION'\n"
-            "P01   INFO: invalid checksum '20181119-152900F/pg_data/PG_VERSION'\n"
+            "P01   INFO: invalid checksum '20181119-152900F/pg_data/biind.pgbi'\n"
             "P00   INFO: stanza: db\n"
             "            status: error\n"
             "              archiveId: none found\n"
-            "              backup: 20181119-152900F, status: invalid, total files checked: 1, total valid files: 0\n"
-            "                missing: 0, checksum invalid: 1, size invalid: 0, other: 0\n"
-            "              backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 1,"
-            " total valid files: 0\n"
+            "              backup: 20181119-152900F, status: invalid, total files checked: 2, total valid files: 0\n"
+            "                missing: 0, checksum invalid: 2, size invalid: 0, other: 0\n"
+            "              backup: 20181119-152900F_20181119-152909D, status: invalid, total files checked: 2,"
+            " total valid files: 1\n"
             "                missing: 0, checksum invalid: 1, size invalid: 0, other: 0");
     }
 

--- a/test/src/module/command/verifyTest.c
+++ b/test/src/module/command/verifyTest.c
@@ -1698,7 +1698,7 @@ testRun(void)
             "[target:file]\n"                                                                                                      \
             "pg_data/PG_VERSION={\"checksum\":\"184473f470864e067ee3a22e64b47b0a1c356f29\",\"reference\":\"20181119-152900F\""     \
                 ",\"size\":4,\"timestamp\":1565282114}\n"                                                                          \
-            "pg_data/biind={\"bi\":1,\"bim\":3,\"checksum\":\"f0da04b8eb24817a8a920cdbcc00402c0bb85a29\","                         \
+            "pg_data/biind={\"bi\":1,\"bim\":3,\"checksum\":\"ffffffffffffffffffffffffffffffffffffffff\","                         \
             "\"reference\":\"20181119-152900F\",\"size\":4,\"timestamp\":1565282114}\n"                                            \
             TEST_MANIFEST_FILE_DEFAULT                                                                                             \
             TEST_MANIFEST_LINK                                                                                                     \


### PR DESCRIPTION
The verify command was not appending the .pgbi extension instead of the compression extension when verifying block incremental files stored outside a bundle.

Originally the idea was that verify would not need any changes (since it just examines repo-size and checksum) but at some point the new extension was added and broke that assumption.

Use backupFileRepoPathP() to generate the correct filename (Just like backup, restore, etc).