### PR TITLE
Preserve block incremental info in manifest during delta backup.

### DIFF
--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -19,6 +19,19 @@
                 <release-bug-list>
                     <release-item>
                         <github-issue id="2112"/>
+                        <github-pull-request id="2123"/>
+
+                        <release-item-contributor-list>
+                            <release-item-ideator id="francisco.miguel.biete"/>
+                            <release-item-contributor id="david.steele"/>
+                            <release-item-reviewer id="stephen.frost"/>
+                        </release-item-contributor-list>
+
+                        <p>Preserve block incremental info in manifest during delta backup.</p>
+                    </release-item>
+
+                    <release-item>
+                        <github-issue id="2112"/>
                         <github-pull-request id="2120"/>
 
                         <release-item-contributor-list>

--- a/doc/xml/release.xml
+++ b/doc/xml/release.xml
@@ -18,8 +18,11 @@
             <release-core-list>
                 <release-bug-list>
                     <release-item>
-                        <github-issue id="2112"/>
-                        <github-pull-request id="2123"/>
+                        <commit subject="Improve validation of referenced files in command/backup unit test."/>
+                        <commit subject="Preserve block incremental info in manifest during delta backup.">
+                            <github-issue id="2112"/>
+                            <github-pull-request id="2123"/>
+                        </commit>
 
                         <release-item-contributor-list>
                             <release-item-ideator id="francisco.miguel.biete"/>

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -1680,12 +1680,12 @@ manifestBuildIncr(Manifest *this, const Manifest *manifestPrior, BackupType type
                     // for block incr and lose the block incr map or block incr could be disabled. The block incr size needs to be
                     // copied from the prior file because it cannot change within a backup set without invalidating all prior maps.
                     // !!! THIS SHOULD PROBABLY BE REMOVED IN CASE THE PRIOR RESULT IS KEPT
-                    if (file.blockIncrSize > 0)
-                    {
+                    // if (file.blockIncrSize > 0)
+                    // {
                         file.blockIncrSize = filePrior.blockIncrSize;
                         file.blockIncrChecksumSize = filePrior.blockIncrChecksumSize;
                         file.blockIncrMapSize = filePrior.blockIncrMapSize;
-                    }
+                    // }
 
                     // Perform delta if the file size is not zero
                     file.delta = delta && file.size != 0;

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -1675,17 +1675,9 @@ manifestBuildIncr(Manifest *this, const Manifest *manifestPrior, BackupType type
                     file.checksumPageErrorList = filePrior.checksumPageErrorList;
                     file.bundleId = filePrior.bundleId;
                     file.bundleOffset = filePrior.bundleOffset;
-
-                    // Copy block incr info if the file has a block incr size. It is possible for a file to shrink below the limit
-                    // for block incr and lose the block incr map or block incr could be disabled. The block incr size needs to be
-                    // copied from the prior file because it cannot change within a backup set without invalidating all prior maps.
-                    // !!! THIS SHOULD PROBABLY BE REMOVED IN CASE THE PRIOR RESULT IS KEPT
-                    // if (file.blockIncrSize > 0)
-                    // {
-                        file.blockIncrSize = filePrior.blockIncrSize;
-                        file.blockIncrChecksumSize = filePrior.blockIncrChecksumSize;
-                        file.blockIncrMapSize = filePrior.blockIncrMapSize;
-                    // }
+                    file.blockIncrSize = filePrior.blockIncrSize;
+                    file.blockIncrChecksumSize = filePrior.blockIncrChecksumSize;
+                    file.blockIncrMapSize = filePrior.blockIncrMapSize;
 
                     // Perform delta if the file size is not zero
                     file.delta = delta && file.size != 0;

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -1679,6 +1679,7 @@ manifestBuildIncr(Manifest *this, const Manifest *manifestPrior, BackupType type
                     // Copy block incr info if the file has a block incr size. It is possible for a file to shrink below the limit
                     // for block incr and lose the block incr map or block incr could be disabled. The block incr size needs to be
                     // copied from the prior file because it cannot change within a backup set without invalidating all prior maps.
+                    // !!! THIS SHOULD PROBABLY BE REMOVED IN CASE THE PRIOR RESULT IS KEPT
                     if (file.blockIncrSize > 0)
                     {
                         file.blockIncrSize = filePrior.blockIncrSize;

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -4184,6 +4184,13 @@ testRun(void)
 
             HRN_STORAGE_TIME(storagePgWrite(), "block-incr-grow", backupTimeStart);
 
+            // Reduce file with block multiplier
+            Buffer *file = bufNew(8192);
+            memset(bufPtr(file), 0, bufSize(file));
+            bufUsedSet(file, bufSize(file));
+
+            HRN_STORAGE_PUT(storagePgWrite(), "block-age-multiplier", file, .timeModified = backupTimeStart);
+
             // Run backup
             hrnBackupPqScriptP(
                 PG_VERSION_11, backupTimeStart, .walCompressType = compressTypeNone, .cipherType = cipherTypeAes256Cbc,
@@ -4196,11 +4203,10 @@ testRun(void)
                 "P00   INFO: backup start archive = 0000000105DC9B4000000000, lsn = 5dc9b40/0\n"
                 "P00   INFO: check archive for segment 0000000105DC9B4000000000\n"
                 "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/PG_VERSION (2B, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-age-multiplier (32KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/0, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-incr-grow (48KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-age-multiplier (bundle 1/88, 8KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191108-080000F\n"
-                "P00 DETAIL: reference pg_data/block-age-multiplier to 20191108-080000F_20191110-153320D\n"
                 "P00 DETAIL: reference pg_data/block-incr-grow to 20191108-080000F_20191110-153320D\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC9B4000000000, lsn = 5dc9b40/100000\n"
@@ -4216,6 +4222,7 @@ testRun(void)
                     .cipherPass = TEST_CIPHER_PASS),
                 ". {link, d=20191108-080000F_20191111-192000I}\n"
                 "bundle {path}\n"
+                "bundle/1/pg_data/block-age-multiplier {file, s=8192}\n"
                 "bundle/1/pg_data/global/pg_control {file, s=8192}\n"
                 "pg_data {path}\n"
                 "pg_data/backup_label.gz {file, s=17}\n"
@@ -4229,9 +4236,8 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573500002}\n"
-                "pg_data/block-age-multiplier={\"bi\":2,\"bic\":16,\"bim\":56"
-                ",\"checksum\":\"5188431849b4613152fd7bdba6a3ff0a4fd6424b\",\"reference\":\"20191108-080000F_20191110-153320D\""
-                ",\"size\":32768,\"timestamp\":1573313600}\n"
+                "pg_data/block-age-multiplier={\"checksum\":\"0631457264ff7f8d5fb1edc2c0211992a67c73e6\",\"size\":8192"
+                ",\"timestamp\":1573500000}\n"
                 "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
                 ",\"reference\":\"20191108-080000F_20191110-153320D\",\"size\":49152,\"timestamp\":1573500000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573500000}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -260,13 +260,14 @@ testBackupValidateFile(
 static String *
 testBackupValidateList(
     const Storage *const storage, const String *const path, Manifest *const manifest, const ManifestData *const manifestData,
-    const CipherType cipherType, const String *const cipherPass, String *const result)
+    StringList *const manifestFileList, const CipherType cipherType, const String *const cipherPass, String *const result)
 {
     FUNCTION_HARNESS_BEGIN();
         FUNCTION_HARNESS_PARAM(STORAGE, storage);
         FUNCTION_HARNESS_PARAM(STRING, path);
         FUNCTION_HARNESS_PARAM(MANIFEST, manifest);
         FUNCTION_HARNESS_PARAM_P(VOID, manifestData);
+        FUNCTION_HARNESS_PARAM(STRING_LIST, manifestFileList);
         FUNCTION_HARNESS_PARAM(STRING_ID, cipherType);
         FUNCTION_HARNESS_PARAM(STRING, cipherPass);
         FUNCTION_HARNESS_PARAM(STRING, result);
@@ -351,11 +352,16 @@ testBackupValidateList(
                 // -----------------------------------------------------------------------------------------------------------------
                 for (unsigned int fileIdx = 0; fileIdx < lstSize(fileList); fileIdx++)
                 {
+                    // Remove this file from manifest file list to track what has been updated
+                    ManifestFilePack **const filePack = *(ManifestFilePack ***)lstGet(fileList, fileIdx);
+                    const unsigned int manifestFileIdx = strLstFindIdxP(
+                        manifestFileList, (String *const)*filePack, .required = true);
+                    strLstRemoveIdx(manifestFileList, manifestFileIdx);
+
                     strCat(
                         result,
                         testBackupValidateFile(
-                            storage, path, manifest, manifestData, info.name, info.size,
-                            *(ManifestFilePack ***)lstGet(fileList, fileIdx), cipherType, cipherPass));
+                            storage, path, manifest, manifestData, info.name, info.size, filePack, cipherType, cipherPass));
                 }
 
                 break;
@@ -394,30 +400,6 @@ testBackupValidateList(
         }
     }
 
-    // Check all files in manifest. Since the scan above maps from files to the manifest, any referenced files will not be checked.
-    // -----------------------------------------------------------------------------------------------------------------------------
-    for (unsigned int fileIdx = 0; fileIdx < manifestFileTotal(manifest); fileIdx++)
-    {
-        ManifestFilePack **const filePack = lstGet(manifest->pub.fileList, fileIdx);
-        ManifestFile file = manifestFileUnpack(manifest, *filePack);
-
-        // If compressed or block incremental then set the repo-size to size so it will not be in test output. Even the same
-        // compression algorithm can give slightly different results based on the version so repo-size is not deterministic for
-        // compression. Block incremental maps increase repo-size in a non-obvious way.
-        if (manifestData->backupOptionCompressType != compressTypeNone || file.blockIncrMapSize != 0)
-            file.sizeRepo = file.size;
-
-        // Bundle id/offset are too noisy so remove them. They are verified against size/checksum and listed with the files.
-        file.bundleId = 0;
-        file.bundleOffset = 0;
-
-        // Remove repo checksum since it has been validated
-        file.checksumRepoSha1 = NULL;
-
-        // Update changes to manifest file
-        manifestFilePackUpdate(manifest, filePack, &file);
-    }
-
     FUNCTION_HARNESS_RETURN(STRING, result);
 }
 
@@ -453,13 +435,50 @@ testBackupValidate(const Storage *const storage, const String *const path, TestB
         const InfoBackup *const infoBackup = infoBackupLoadFile(
             storageRepo(), INFO_BACKUP_PATH_FILE_STR, param.cipherType == 0 ? cipherTypeNone : param.cipherType,
             param.cipherPass == NULL ? NULL : STR(param.cipherPass));
-
         Manifest *manifest = manifestLoadFile(
             storage, strNewFmt("%s/" BACKUP_MANIFEST_FILE, strZ(path)), param.cipherType == 0 ? cipherTypeNone : param.cipherType,
             param.cipherPass == NULL ? NULL : infoBackupCipherPass(infoBackup));
-        testBackupValidateList(
-            storage, path, manifest, manifestData(manifest), param.cipherType == 0 ? cipherTypeNone : param.cipherType,
-            param.cipherPass == NULL ? NULL : manifestCipherSubPass(manifest), result);
+
+        // Build list of files in the manifest
+        StringList *const manifestFileList = strLstNew();
+
+        for (unsigned int fileIdx = 0; fileIdx < manifestFileTotal(manifest); fileIdx++)
+            strLstAdd(manifestFileList, manifestFileUnpack(manifest, manifestFilePackGet(manifest, fileIdx)).name);
+
+        // Validate files on disk against the manifest
+        const CipherType cipherType = param.cipherType == 0 ? cipherTypeNone : param.cipherType;
+        const String *const cipherPass = param.cipherPass == NULL ? NULL : manifestCipherSubPass(manifest);
+
+        testBackupValidateList(storage, path, manifest, manifestData(manifest), manifestFileList, cipherType, cipherPass, result);
+
+        // Check remaining files in the manifest -- these should all be references
+        for (unsigned int manifestFileIdx = 0; manifestFileIdx < strLstSize(manifestFileList); manifestFileIdx++)
+        {
+            ManifestFilePack **const filePack = manifestFilePackFindInternal(
+                manifest, strLstGet(manifestFileList, manifestFileIdx));
+            const ManifestFile file = manifestFileUnpack(manifest, *filePack);
+
+            // No need to check zero-length files in bundled backups
+            if (manifestData(manifest)->bundle && file.size == 0)
+                continue;
+
+            // Error if reference is NULL
+            if (file.reference == NULL)
+                THROW_FMT(AssertError, "manifest file '%s' not in backup but does not have a reference", strZ(file.name));
+
+            strCat(
+                result,
+                testBackupValidateFile(
+                    storage, strPath(path), manifest, manifestData(manifest),
+                    strSub(
+                        backupFileRepoPathP(
+                                file.reference,
+                                .manifestName = file.name, .bundleId = file.bundleId,
+                                .compressType = manifestData(manifest)->backupOptionCompressType,
+                                .blockIncr = file.blockIncrMapSize != 0),
+                        sizeof(STORAGE_REPO_BACKUP)),
+                    file.sizeRepo, filePack, cipherType, cipherPass));
+        }
 
         // Make sure both backup.manifest files exist since we skipped them in the callback above
         if (!storageExistsP(storage, strNewFmt("%s/" BACKUP_MANIFEST_FILE, strZ(path))))
@@ -467,6 +486,30 @@ testBackupValidate(const Storage *const storage, const String *const path, TestB
 
         if (!storageExistsP(storage, strNewFmt("%s/" BACKUP_MANIFEST_FILE INFO_COPY_EXT, strZ(path))))
             THROW(AssertError, BACKUP_MANIFEST_FILE INFO_COPY_EXT " is missing");
+
+        // Update manifest to make the output a bit simpler
+        // -------------------------------------------------------------------------------------------------------------------------
+        for (unsigned int fileIdx = 0; fileIdx < manifestFileTotal(manifest); fileIdx++)
+        {
+            ManifestFilePack **const filePack = lstGet(manifest->pub.fileList, fileIdx);
+            ManifestFile file = manifestFileUnpack(manifest, *filePack);
+
+            // If compressed or block incremental then set the repo-size to size so it will not be in test output. Even the same
+            // compression algorithm can give slightly different results based on the version so repo-size is not deterministic for
+            // compression. Block incremental maps increase repo-size in a non-obvious way.
+            if (manifestData(manifest)->backupOptionCompressType != compressTypeNone || file.blockIncrMapSize != 0)
+                file.sizeRepo = file.size;
+
+            // Bundle id/offset are too noisy so remove them. They are verified against size/checksum and listed with the files.
+            file.bundleId = 0;
+            file.bundleOffset = 0;
+
+            // Remove repo checksum since it has been validated
+            file.checksumRepoSha1 = NULL;
+
+            // Update changes to manifest file
+            manifestFilePackUpdate(manifest, filePack, &file);
+        }
 
         // Output the manifest to a string and exclude sections that don't need validation. Note that each of these sections should
         // be considered from automatic validation but adding them to the output will make the tests too noisy. One good technique
@@ -3730,6 +3773,7 @@ testRun(void)
                 "pg_data {path}\n"
                 "pg_data/backup_label.gz {file, s=17}\n"
                 "pg_data/tablespace_map.gz {file, s=19}\n"
+                "20191030-014640F/bundle/1/pg_data/PG_VERSION {file, s=2}\n"
                 "--------\n"
                 "[backup:target]\n"
                 "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n"
@@ -3956,6 +4000,7 @@ testRun(void)
                 "pg_data/block-incr-grow.pgbi {file, m=0:{0},1:{0},0:{2},1:{1,2,3,4,5,6,7,8,9,10,11,12,13}, s=131072}\n"
                 "pg_data/block-incr-larger.pgbi {file, m=1:{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15},1:{0,1,2,3,4,5,6}, s=1507328}\n"
                 "pg_data/tablespace_map {file, s=19}\n"
+                "20191103-165320F/bundle/1/pg_data/PG_VERSION {file, s=2}\n"
                 "--------\n"
                 "[backup:target]\n"
                 "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n"
@@ -4162,6 +4207,7 @@ testRun(void)
                 "pg_data {path}\n"
                 "pg_data/backup_label.gz {file, s=17}\n"
                 "pg_data/tablespace_map.gz {file, s=19}\n"
+                "20191108-080000F/bundle/1/pg_data/PG_VERSION {file, s=2}\n"
                 "--------\n"
                 "[backup:target]\n"
                 "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n"
@@ -4244,6 +4290,9 @@ testRun(void)
                 "pg_data {path}\n"
                 "pg_data/backup_label.gz {file, s=17}\n"
                 "pg_data/tablespace_map.gz {file, s=19}\n"
+                "20191108-080000F/bundle/1/pg_data/PG_VERSION {file, s=2}\n"
+                "20191108-080000F_20191110-153320D/bundle/1/pg_data/block-age-multiplier {file, m=1:{0,1}, s=32768}\n"
+                "20191108-080000F_20191110-153320D/bundle/1/pg_data/block-incr-grow {file, m=0:{0,1},1:{0,1,2,3}, s=49152}\n"
                 "--------\n"
                 "[backup:target]\n"
                 "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -4182,14 +4182,7 @@ testRun(void)
             hrnCfgEnvRawZ(cfgOptRepoCipherPass, TEST_CIPHER_PASS);
             HRN_CFG_LOAD(cfgCmdBackup, argList);
 
-            HRN_STORAGE_TIME(storagePgWrite(), "block-incr-grow", backupTimeStart);
-
-            // Reduce file with block multiplier
-            Buffer *file = bufNew(8192);
-            memset(bufPtr(file), 0, bufSize(file));
-            bufUsedSet(file, bufSize(file));
-
-            HRN_STORAGE_PUT(storagePgWrite(), "block-age-multiplier", file, .timeModified = backupTimeStart);
+            HRN_STORAGE_TIME(storagePgWrite(), "block-incr-grow", backupTimeStart - 29 * SEC_PER_DAY);
 
             // Run backup
             hrnBackupPqScriptP(
@@ -4202,11 +4195,12 @@ testRun(void)
                 "P00   INFO: execute non-exclusive backup start: backup begins after the next regular checkpoint completes\n"
                 "P00   INFO: backup start archive = 0000000105DC9B4000000000, lsn = 5dc9b40/0\n"
                 "P00   INFO: check archive for segment 0000000105DC9B4000000000\n"
-                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/PG_VERSION (2B, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/0, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-incr-grow (48KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-age-multiplier (bundle 1/88, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/PG_VERSION (2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-age-multiplier (32KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/0, 8KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191108-080000F\n"
+                "P00 DETAIL: reference pg_data/block-age-multiplier to 20191108-080000F_20191110-153320D\n"
                 "P00 DETAIL: reference pg_data/block-incr-grow to 20191108-080000F_20191110-153320D\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC9B4000000000, lsn = 5dc9b40/100000\n"
@@ -4222,7 +4216,6 @@ testRun(void)
                     .cipherPass = TEST_CIPHER_PASS),
                 ". {link, d=20191108-080000F_20191111-192000I}\n"
                 "bundle {path}\n"
-                "bundle/1/pg_data/block-age-multiplier {file, s=8192}\n"
                 "bundle/1/pg_data/global/pg_control {file, s=8192}\n"
                 "pg_data {path}\n"
                 "pg_data/backup_label.gz {file, s=17}\n"
@@ -4236,10 +4229,11 @@ testRun(void)
                 ",\"size\":2,\"timestamp\":1572800000}\n"
                 "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
                 ",\"timestamp\":1573500002}\n"
-                "pg_data/block-age-multiplier={\"checksum\":\"0631457264ff7f8d5fb1edc2c0211992a67c73e6\",\"size\":8192"
-                ",\"timestamp\":1573500000}\n"
-                "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
-                ",\"reference\":\"20191108-080000F_20191110-153320D\",\"size\":49152,\"timestamp\":1573500000}\n"
+                "pg_data/block-age-multiplier={\"bi\":2,\"bic\":16,\"bim\":56"
+                ",\"checksum\":\"5188431849b4613152fd7bdba6a3ff0a4fd6424b\",\"reference\":\"20191108-080000F_20191110-153320D\""
+                ",\"size\":32768,\"timestamp\":1573313600}\n"
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\","
+                "\"reference\":\"20191108-080000F_20191110-153320D\",\"size\":49152,\"timestamp\":1570994400}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573500000}\n"
                 "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
                 ",\"timestamp\":1573500002}\n"

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -4160,6 +4160,89 @@ testRun(void)
                 "pg_data/global={}\n",
                 "compare file list");
         }
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("online 11 incr backup with comp/enc and delta");
+
+        backupTimeStart = BACKUP_EPOCH + 3500000;
+
+        {
+            // Load options
+            StringList *argList = strLstNew();
+            hrnCfgArgRawZ(argList, cfgOptStanza, "test1");
+            hrnCfgArgRaw(argList, cfgOptRepoPath, repoPath);
+            hrnCfgArgRaw(argList, cfgOptPgPath, pg1Path);
+            hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "1");
+            hrnCfgArgRawStrId(argList, cfgOptType, backupTypeIncr);
+            hrnCfgArgRawBool(argList, cfgOptRepoBundle, true);
+            hrnCfgArgRawZ(argList, cfgOptRepoBundleLimit, "4MiB");
+            hrnCfgArgRawBool(argList, cfgOptRepoBlock, true);
+            hrnCfgArgRawBool(argList, cfgOptDelta, true);
+            hrnCfgArgRawZ(argList, cfgOptRepoCipherType, "aes-256-cbc");
+            hrnCfgEnvRawZ(cfgOptRepoCipherPass, TEST_CIPHER_PASS);
+            HRN_CFG_LOAD(cfgCmdBackup, argList);
+
+            HRN_STORAGE_TIME(storagePgWrite(), "block-incr-grow", backupTimeStart);
+
+            // Run backup
+            hrnBackupPqScriptP(
+                PG_VERSION_11, backupTimeStart, .walCompressType = compressTypeNone, .cipherType = cipherTypeAes256Cbc,
+                .cipherPass = TEST_CIPHER_PASS, .walTotal = 1);
+            TEST_RESULT_VOID(hrnCmdBackup(), "backup");
+
+            TEST_RESULT_LOG(
+                "P00   INFO: last backup label = 20191108-080000F_20191110-153320D, version = " PROJECT_VERSION "\n"
+                "P00   INFO: execute non-exclusive backup start: backup begins after the next regular checkpoint completes\n"
+                "P00   INFO: backup start archive = 0000000105DC9B4000000000, lsn = 5dc9b40/0\n"
+                "P00   INFO: check archive for segment 0000000105DC9B4000000000\n"
+                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/PG_VERSION (2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-age-multiplier (32KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/0, 8KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: match file from prior backup " TEST_PATH "/pg1/block-incr-grow (48KB, [PCT]) checksum [SHA1]\n"
+                "P00 DETAIL: reference pg_data/PG_VERSION to 20191108-080000F\n"
+                "P00 DETAIL: reference pg_data/block-age-multiplier to 20191108-080000F_20191110-153320D\n"
+                "P00 DETAIL: reference pg_data/block-incr-grow to 20191108-080000F_20191110-153320D\n"
+                "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
+                "P00   INFO: backup stop archive = 0000000105DC9B4000000000, lsn = 5dc9b40/100000\n"
+                "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
+                "P00 DETAIL: wrote 'tablespace_map' file returned from backup stop function\n"
+                "P00   INFO: check archive for segment(s) 0000000105DC9B4000000000:0000000105DC9B4000000000\n"
+                "P00   INFO: new backup label = 20191108-080000F_20191111-192000I\n"
+                "P00   INFO: incr backup size = [SIZE], file total = 6");
+
+            TEST_RESULT_STR_Z(
+                testBackupValidateP(
+                    storageRepo(), STRDEF(STORAGE_REPO_BACKUP "/latest"), .cipherType = cipherTypeAes256Cbc,
+                    .cipherPass = TEST_CIPHER_PASS),
+                ". {link, d=20191108-080000F_20191111-192000I}\n"
+                "bundle {path}\n"
+                "bundle/1/pg_data/global/pg_control {file, s=8192}\n"
+                "pg_data {path}\n"
+                "pg_data/backup_label.gz {file, s=17}\n"
+                "pg_data/tablespace_map.gz {file, s=19}\n"
+                "--------\n"
+                "[backup:target]\n"
+                "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n"
+                "\n"
+                "[target:file]\n"
+                "pg_data/PG_VERSION={\"checksum\":\"17ba0791499db908433b80f37c5fbc89b870084b\",\"reference\":\"20191108-080000F\""
+                ",\"size\":2,\"timestamp\":1572800000}\n"
+                "pg_data/backup_label={\"checksum\":\"8e6f41ac87a7514be96260d65bacbffb11be77dc\",\"size\":17"
+                ",\"timestamp\":1573500002}\n"
+                "pg_data/block-age-multiplier={\"bi\":2,\"bic\":16,\"bim\":56"
+                ",\"checksum\":\"5188431849b4613152fd7bdba6a3ff0a4fd6424b\",\"reference\":\"20191108-080000F_20191110-153320D\""
+                ",\"size\":32768,\"timestamp\":1573313600}\n"
+                "pg_data/block-incr-grow={\"bi\":1,\"bim\":72,\"checksum\":\"bd4716c88f38d2540e3024b54308b0b95f34a0cc\""
+                ",\"reference\":\"20191108-080000F_20191110-153320D\",\"size\":49152,\"timestamp\":1573500000}\n"
+                "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573500000}\n"
+                "pg_data/tablespace_map={\"checksum\":\"87fe624d7976c2144e10afcb7a9a49b071f35e9c\",\"size\":19"
+                ",\"timestamp\":1573500002}\n"
+                "\n"
+                "[target:path]\n"
+                "pg_data={}\n"
+                "pg_data/global={}\n",
+                "compare file list");
+        }
     }
 
     FUNCTION_HARNESS_RETURN_VOID();


### PR DESCRIPTION
It was possible for block incremental info to be lost if a file had been modified in such a way that block incremental would be disabled if the file were new, e.g. if the file shrank below the block incremental limit or the file timestamp regressed far enough into the past. In those cases the block incremental info would not be copied in  manifestBuildIncr().

Instead always copy the block incremental info in case the file ends up being referenced to a prior backup.

The validation tests were not robust enough to catch this issue so they were improved in 1d42aed1.

In the particular case that exposed this bug, a file had a timestamp that was almost four weeks in the past at full backup time. A few days later a fail over occurred and the next incremental ran on the new primary (old standby) in delta mode. The same file had a timestamp just a few hours older than in the full backup, but now four weeks older than the current backup. Block incremental was disabled for the file on initial manifest build because of its age, which meant the block incremental info was not copied into the new manifest. The delta then determined the file had not changed and referenced it to the full backup. On restore, the file appeared to be a normal file stored in a bundle but could not be decompressed because it was in fact a block incremental.