### PR TITLE
pg_control version check FAIL in function pgControlFromBuffer() when PG version is 14

### DIFF
--- a/src/postgres/interface/version.vendor.h
+++ b/src/postgres/interface/version.vendor.h
@@ -333,6 +333,16 @@ Types from src/include/catalog/pg_control.h
 // ---------------------------------------------------------------------------------------------------------------------------------
 #if PG_VERSION > PG_VERSION_MAX
 
+#elif PG_VERSION >= PG_VERSION_15
+
+/* Version identifier for this pg_control format */
+#define PG_CONTROL_VERSION	1500
+
+#elif PG_VERSION >= PG_VERSION_14
+
+/* Version identifier for this pg_control format */
+#define PG_CONTROL_VERSION	1400
+
 #elif PG_VERSION >= PG_VERSION_13
 
 /* Version identifier for this pg_control format */


### PR DESCRIPTION
make  function `pgControlFromBuffer()'s` pg_control version check to support PG14 & PG15

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
