### PR TITLE
Fix common/lock test failing with -Werror=unused-result.

### DIFF
--- a/test/src/module/common/lockTest.c
+++ b/test/src/module/common/lockTest.c
@@ -303,7 +303,7 @@ testRun(void)
             lseek(lockLocal.file[lockTypeBackup].fd, 0, SEEK_SET) == -1, FileOpenError, STORAGE_ERROR_READ_SEEK, (uint64_t)0,
             strZ(lockLocal.file[lockTypeBackup].name));
 
-        TEST_RESULT_BOOL(ftruncate(lockLocal.file[lockTypeBackup].fd, 0), 0, "truncate lockLocal.file[lockTypeBackup].fd");
+        TEST_RESULT_INT(ftruncate(lockLocal.file[lockTypeBackup].fd, 0), 0, "truncate lockLocal.file[lockTypeBackup].fd");
 
         IoWrite *const write = ioFdWriteNewOpen(lockLocal.file[lockTypeBackup].name, lockLocal.file[lockTypeBackup].fd, 0);
 

--- a/test/src/module/common/lockTest.c
+++ b/test/src/module/common/lockTest.c
@@ -303,7 +303,7 @@ testRun(void)
             lseek(lockLocal.file[lockTypeBackup].fd, 0, SEEK_SET) == -1, FileOpenError, STORAGE_ERROR_READ_SEEK, (uint64_t)0,
             strZ(lockLocal.file[lockTypeBackup].name));
 
-        ftruncate(lockLocal.file[lockTypeBackup].fd, 0);
+        TEST_RESULT_BOOL(ftruncate(lockLocal.file[lockTypeBackup].fd, 0), 0, "truncate lockLocal.file[lockTypeBackup].fd");
 
         IoWrite *const write = ioFdWriteNewOpen(lockLocal.file[lockTypeBackup].name, lockLocal.file[lockTypeBackup].fd, 0);
 


### PR DESCRIPTION
Certain test invocations include  [-Werror=unused-result]  which result in a failed compilation of lockTest.c due to a bare call to ftruncate.  Wrap the call in TEST_RESULT_BOOL() to prevent this.

Invoked locally on my development host,
 pgbackrest/test/test.pl   --vm=none

                                       ```In file included from ../test.c:121:
                                        ../../../repo/test/src/module/common/lockTest.c: In function ‘testRun’:
                                        ../../../repo/test/src/module/common/lockTest.c:306:9: error: ignoring return value of ‘ftruncate’, declared with attribute warn_unused_result [-Werror=unused-result]
                                          306 |         ftruncate(lockLocal.file[lockTypeBackup].fd, 0);
                                              |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                        compilation terminated due to -Wfatal-errors.
                                        cc1: all warnings being treated as errors
                                        ninja: build stopped: subcommand failed.
    2023-09-28 14:31:57.612 P00   INFO: test command end: aborted with exception [102]```