### PR TITLE
Do not store block map when timestamp is updated but file is unchanged.

### DIFF
--- a/doc/xml/release/2024/2.50.xml
+++ b/doc/xml/release/2024/2.50.xml
@@ -22,6 +22,20 @@
 
                 <p>Skip files truncated during backup when bundling.</p>
             </release-item>
+
+            <release-item>
+                <commit subject="Add block incremental test where timestamp changes but file is the same."/>
+                <commit subject="Do not store block map when timestamp is updated but file is unchanged.">
+                    <github-pull-request id="2246"/>
+                </commit>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stephen.frost"/>
+                </release-item-contributor-list>
+
+                <p>Do not store block map when timestamp is updated but file is unchanged.</p>
+            </release-item>
         </release-improvement-list>
     </release-core-list>
 </release>

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -47,6 +47,7 @@ typedef struct BlockIncr
     const BlockMap *blockMapPrior;                                  // Prior block map
     BlockMap *blockMapOut;                                          // Output block map
     uint64_t blockMapOutSize;                                       // Output block map size (if any)
+    bool blockMapWrite;                                             // Write block map (at least one new/changed block)
 
     size_t inputOffset;                                             // Input offset
     bool inputSame;                                                 // Input the same data
@@ -175,7 +176,7 @@ blockIncrProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
 
                     memcpy(blockMapItem.checksum, bufPtrConst(checksum), bufUsed(checksum));
 
-                    unsigned int blockMapItemIdx = blockMapSize(this->blockMapOut);
+                    const unsigned int blockMapItemIdx = blockMapSize(this->blockMapOut);
                     blockMapAdd(this->blockMapOut, &blockMapItem);
                     lstAdd(this->blockOutList, &blockMapItemIdx);
 
@@ -226,10 +227,13 @@ blockIncrProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
             // Reset block out size and super block no
             this->blockOutSize = 0;
             this->superBlockNo = 0;
+
+            // Block map must be written since there are new/changed blocks
+            this->blockMapWrite = true;
         }
 
         // Write the block map if done processing and at least one block was written
-        if (this->done && this->blockOutOffset == 0 && this->blockOutList != NULL)
+        if (this->done && this->blockOutOffset == 0 && this->blockMapWrite)
         {
             MEM_CONTEXT_TEMP_BEGIN()
             {

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -232,7 +232,7 @@ blockIncrProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
             this->blockMapWrite = true;
         }
 
-        // Write the block map if done processing and at least one block was written
+        // Write the block map if done processing and there are new/changed blocks
         if (this->done && this->blockOutOffset == 0 && this->blockMapWrite)
         {
             MEM_CONTEXT_TEMP_BEGIN()

--- a/src/command/backup/blockIncr.c
+++ b/src/command/backup/blockIncr.c
@@ -229,7 +229,7 @@ blockIncrProcess(THIS_VOID, const Buffer *const input, Buffer *const output)
         }
 
         // Write the block map if done processing and at least one block was written
-        if (this->done && this->blockOutOffset == 0 && this->blockNo > 0)
+        if (this->done && this->blockOutOffset == 0 && this->blockOutList != NULL)
         {
             MEM_CONTEXT_TEMP_BEGIN()
             {

--- a/src/command/backup/file.c
+++ b/src/command/backup/file.c
@@ -380,6 +380,14 @@ backupFile(
                                 {
                                     fileResult->blockIncrMapSize = pckReadU64P(
                                         ioFilterGroupResultP(ioReadFilterGroup(readIo), BLOCK_INCR_FILTER_TYPE));
+                                    ASSERT(fileResult->blockIncrMapSize > 0 || fileResult->repoSize == 0);
+
+                                    // If no map was written then the file did not change
+                                    if (fileResult->blockIncrMapSize == 0)
+                                    {
+                                        ASSERT(file->blockIncrMapPriorFile != NULL);
+                                        fileResult->backupCopyResult = backupCopyResultNoOp;
+                                    }
                                 }
 
                                 // Get repo checksum

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -3450,6 +3450,13 @@ testRun(void)
 
             HRN_STORAGE_PUT(storagePgWrite(), "block-incr-shrink", file, .timeModified = backupTimeStart);
 
+            // File that remains the same between backups
+            file = bufNew(BLOCK_MIN_FILE_SIZE);
+            memset(bufPtr(file), 33, bufSize(file));
+            bufUsedSet(file, bufSize(file));
+
+            HRN_STORAGE_PUT(storagePgWrite(), "block-incr-same", file, .timeModified = backupTimeStart);
+
             // File that grows above the limit
             file = bufNew(BLOCK_MIN_FILE_SIZE - 1);
             memset(bufPtr(file), 77, bufSize(file));
@@ -3490,20 +3497,22 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16.0KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16383, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24575, 16KB, [PCT]) checksum [SHA1]\n"
-                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/40989, 2B, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-same (bundle 1/40989, 16KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (bundle 1/57395, 2B, [PCT]) checksum [SHA1]\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DBF06000000001, lsn = 5dbf060/300000\n"
                 "P00 DETAIL: wrote 'backup_label' file returned from backup stop function\n"
                 "P00 DETAIL: wrote 'tablespace_map' file returned from backup stop function\n"
                 "P00   INFO: check archive for segment(s) 0000000105DBF06000000000:0000000105DBF06000000001\n"
                 "P00   INFO: new backup label = 20191103-165320F\n"
-                "P00   INFO: full backup size = [SIZE], file total = 7");
+                "P00   INFO: full backup size = [SIZE], file total = 8");
 
             TEST_RESULT_STR_Z(
                 testBackupValidateP(storageRepo(), STRDEF(STORAGE_REPO_BACKUP "/latest")),
                 ". {link, d=20191103-165320F}\n"
                 "bundle {path}\n"
                 "bundle/1/pg_data/PG_VERSION {file, s=2}\n"
+                "bundle/1/pg_data/block-incr-same {file, m=0:{0,1}, s=16384}\n"
                 "bundle/1/pg_data/block-incr-shrink {file, m=0:{0,1,2}, s=16385}\n"
                 "bundle/1/pg_data/global/pg_control {file, s=8192}\n"
                 "bundle/1/pg_data/grow-to-block-incr {file, s=16383}\n"
@@ -3522,6 +3531,8 @@ testRun(void)
                 ",\"timestamp\":1572800002}\n"
                 "pg_data/block-incr-grow={\"bi\":1,\"bim\":24,\"checksum\":\"ebdd38b69cd5b9f2d00d273c981e16960fbbb4f7\""
                 ",\"size\":24576,\"timestamp\":1572800000}\n"
+                "pg_data/block-incr-same={\"bi\":1,\"bim\":22,\"checksum\":\"5d389611c12c8b8d2c28d4e590799c016b9375be\""
+                ",\"size\":16384,\"timestamp\":1572800000}\n"
                 "pg_data/block-incr-shrink={\"bi\":1,\"bim\":29,\"checksum\":\"ce5f8864058b1bb274244b512cb9641355987134\""
                 ",\"size\":16385,\"timestamp\":1572800000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1572800000}\n"
@@ -3582,6 +3593,9 @@ testRun(void)
 
             HRN_STORAGE_PUT(storagePgWrite(), "block-incr-shrink", file, .timeModified = backupTimeStart);
 
+            // Update timestamp without changing contents of the file
+            HRN_STORAGE_TIME(storagePgWrite(), "block-incr-same", backupTimeStart);
+
             // Grow file above the limit
             file = bufNew(BLOCK_MIN_FILE_SIZE + 1);
             memset(bufPtr(file), 77, bufSize(file));
@@ -3612,6 +3626,7 @@ testRun(void)
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/global/pg_control (bundle 1/16411, 8KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-shrink (bundle 1/24603, 16.0KB, [PCT]) checksum [SHA1]\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-same (bundle 1/40986, 16KB, [PCT]) checksum [SHA1]\n"
                 "P00 DETAIL: reference pg_data/PG_VERSION to 20191103-165320F\n"
                 "P00   INFO: execute non-exclusive backup stop and wait for all WAL segments to archive\n"
                 "P00   INFO: backup stop archive = 0000000105DC213000000001, lsn = 5dc2130/300000\n"
@@ -3619,12 +3634,13 @@ testRun(void)
                 "P00 DETAIL: wrote 'tablespace_map' file returned from backup stop function\n"
                 "P00   INFO: check archive for segment(s) 0000000105DC213000000000:0000000105DC213000000001\n"
                 "P00   INFO: new backup label = 20191103-165320F_20191106-002640D\n"
-                "P00   INFO: diff backup size = [SIZE], file total = 9");
+                "P00   INFO: diff backup size = [SIZE], file total = 10");
 
             TEST_RESULT_STR_Z(
                 testBackupValidateP(storageRepo(), STRDEF(STORAGE_REPO_BACKUP "/latest")),
                 ". {link, d=20191103-165320F_20191106-002640D}\n"
                 "bundle {path}\n"
+                "bundle/1/pg_data/block-incr-same {file, m=0:{0,1}, s=16384}\n"
                 "bundle/1/pg_data/block-incr-shrink {file, s=16383}\n"
                 "bundle/1/pg_data/global/pg_control {file, s=8192}\n"
                 "bundle/1/pg_data/grow-to-block-incr {file, m=1:{0,1,2}, s=16385}\n"
@@ -3647,6 +3663,8 @@ testRun(void)
                 ",\"size\":131072,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-larger={\"bi\":8,\"bic\":7,\"bim\":173"
                 ",\"checksum\":\"eec53a6da79c00b3c658a7e09f44b3e9efefd960\",\"size\":1507328,\"timestamp\":1573000000}\n"
+                "pg_data/block-incr-same={\"bi\":1,\"bim\":22,\"checksum\":\"5d389611c12c8b8d2c28d4e590799c016b9375be\""
+                ",\"size\":16384,\"timestamp\":1573000000}\n"
                 "pg_data/block-incr-shrink={\"checksum\":\"1c6a17f67562d8b3f64f1b5f2ee592a4c2809b3b\",\"size\":16383"
                 ",\"timestamp\":1573000000}\n"
                 "pg_data/global/pg_control={\"size\":8192,\"timestamp\":1573000000}\n"
@@ -3663,6 +3681,7 @@ testRun(void)
 
             HRN_STORAGE_REMOVE(storagePgWrite(), "block-incr-grow");
             HRN_STORAGE_REMOVE(storagePgWrite(), "block-incr-larger");
+            HRN_STORAGE_REMOVE(storagePgWrite(), "block-incr-same");
             HRN_STORAGE_REMOVE(storagePgWrite(), "block-incr-shrink");
             HRN_STORAGE_REMOVE(storagePgWrite(), "grow-to-block-incr");
             HRN_STORAGE_REMOVE(storagePgWrite(), "truncate-to-zero");


### PR DESCRIPTION
If backup delta is not enabled, then the timestamp is used to determine if a file has changed. If the timestamp changes but the file is the same then the prior map would be stored unchanged in the new backup. This is not quite as bad as storing the entire file but obviously not ideal.

Instead detect if there are no new/changed blocks and simply reference the prior backup in this case.

In passing add a missing const keyword.