### PR TITLE
Read correct type for sizes in lock file

### DIFF
--- a/src/common/lock.c
+++ b/src/common/lock.c
@@ -156,10 +156,10 @@ lockReadFileData(const String *const lockFile, const int fd)
                 result.processId = jsonReadInt(jsonReadKeyRequireStrId(json, LOCK_KEY_PROCESS_ID));
 
                 if (jsonReadKeyExpectStrId(json, LOCK_KEY_SIZE))
-                    result.size = varNewUInt64(jsonReadUInt(json));
+                    result.size = varNewUInt64(jsonReadUInt64(json));
 
                 if (jsonReadKeyExpectStrId(json, LOCK_KEY_SIZE_COMPLETE))
-                    result.sizeComplete = varNewUInt64(jsonReadUInt(json));
+                    result.sizeComplete = varNewUInt64(jsonReadUInt64(json));
             }
             MEM_CONTEXT_PRIOR_END();
         }

--- a/test/src/module/common/lockTest.c
+++ b/test/src/module/common/lockTest.c
@@ -239,15 +239,15 @@ testRun(void)
 
         TEST_RESULT_VOID(
             lockWriteDataP(
-                lockTypeBackup, .percentComplete = VARUINT(8888), .sizeComplete = VARUINT64(2807719), .size = VARUINT64(3159000)),
+                lockTypeBackup, .percentComplete = VARUINT(8888), .sizeComplete = VARUINT64(3223802441008), .size = VARUINT64(6126216975438)),
             "write lock data");
         THROW_ON_SYS_ERROR_FMT(
             lseek(lockLocal.file[lockTypeBackup].fd, 0, SEEK_SET) == -1, FileOpenError, STORAGE_ERROR_READ_SEEK, (uint64_t)0,
             strZ(lockLocal.file[lockTypeBackup].name));
         lockDataResult = lockReadFileData(backupLockFile, lockLocal.file[lockTypeBackup].fd);
         TEST_RESULT_UINT(varUInt(lockDataResult.percentComplete), 8888, "verify percentComplete");
-        TEST_RESULT_UINT(varUInt64(lockDataResult.sizeComplete), 2807719, "verify sizeProgress");
-        TEST_RESULT_UINT(varUInt64(lockDataResult.size), 3159000, "verify sizeTotal");
+        TEST_RESULT_UINT(varUInt64(lockDataResult.sizeComplete), 3223802441008, "verify sizeProgress");
+        TEST_RESULT_UINT(varUInt64(lockDataResult.size), 6126216975438, "verify sizeTotal");
 
         TEST_ERROR(
             lockAcquireP(.returnOnNoLock = true), AssertError,


### PR DESCRIPTION
As per issue #2251 

The writing of the sz and szCplt parameters in the lock file use jsonWriteUInt64 but the reading of these parameters use jsonReadUInt. This causes a silent exception for any backups larger than MAX_UINT and prevents the info command from reporting progress. Correcting this so the reads are symmetric and verified before/after with the test change.