### PR TITLE
Fix progress logging when file size changes during backup.

### DIFF
--- a/doc/xml/release/2024/2.51.xml
+++ b/doc/xml/release/2024/2.51.xml
@@ -31,6 +31,19 @@
 
                 <p>Fix performance regression in storage list.</p>
             </release-item>
+
+            <release-item>
+                <github-issue id="2298"/>
+                <github-pull-request id="2304"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="samkingno"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stephen.frost"/>
+                </release-item-contributor-list>
+
+                <p>Fix progress logging when file size changes during backup.</p>
+            </release-item>
         </release-bug-list>
 
         <release-improvement-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -895,6 +895,11 @@
     <contributor-id type="github">shkshk90</contributor-id>
 </contributor>
 
+<contributor id="samkingno">
+    <contributor-name-display>samkingno</contributor-name-display>
+    <contributor-id type="github">samkingno</contributor-id>
+</contributor>
+
 <contributor id="sarah.conway">
     <contributor-name-display>Sarah Conway</contributor-name-display>
     <contributor-id type="github">xenophenes</contributor-id>

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1442,8 +1442,9 @@ backupJobResult(
                 const Buffer *const repoChecksum = pckReadBinP(jobResult);
                 PackRead *const checksumPageResult = pckReadPackReadP(jobResult);
 
-                // Increment backup copy progress
-                *sizeProgress += copySize;
+                // Increment backup copy progress. Use the original size since the size may have changed during the copy but for the
+                // purpose of reporting progress we need to increment by the original size used to generate the total size.
+                *sizeProgress += file.sizeOriginal;
 
                 // Create log file name
                 const String *const fileName = storagePathP(storagePg, manifestPathPg(file.name));

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -2091,7 +2091,7 @@ testRun(void)
         HRN_STORAGE_PUT_Z(storagePgWrite(), "postgresql.conf", "CONFIGSTUFF2");
         HRN_BACKUP_SCRIPT_SET(
             {.op = hrnBackupScriptOpUpdate, .file = storagePathP(storagePg(), STRDEF("postgresql.conf")),
-                .content = BUFSTRDEF("CONFIG")});
+             .content = BUFSTRDEF("CONFIG")});
 
         unsigned int backupCount = strLstSize(storageListP(storageRepoIdx(1), strNewFmt(STORAGE_PATH_BACKUP "/test1")));
 

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -2087,17 +2087,24 @@ testRun(void)
 
         HRN_STORAGE_PUT_Z(storagePgWrite(), PG_FILE_PGVERSION, "VER");
 
+        // Modify file postgresql.conf during the backup to demonstrate that percent complete will be updated correctly
+        HRN_STORAGE_PUT_Z(storagePgWrite(), "postgresql.conf", "CONFIGSTUFF2");
+        HRN_BACKUP_SCRIPT_SET(
+            {.op = hrnBackupScriptOpUpdate, .file = storagePathP(storagePg(), STRDEF("postgresql.conf")),
+                .content = BUFSTRDEF("CONFIG")});
+
         unsigned int backupCount = strLstSize(storageListP(storageRepoIdx(1), strNewFmt(STORAGE_PATH_BACKUP "/test1")));
 
         TEST_RESULT_VOID(hrnCmdBackup(), "backup");
 
         TEST_RESULT_LOG(
             "P00   INFO: last backup label = [FULL-2], version = " PROJECT_VERSION "\n"
+            "P01 DETAIL: backup file " TEST_PATH "/pg1/postgresql.conf (12B->6B, 80.00%) checksum"
+            " 2fb60054b43a25d7a958d3d19bdb1aa7809577a8\n"
             "P01 DETAIL: backup file " TEST_PATH "/pg1/PG_VERSION (3B, 100.00%) checksum c8663c2525f44b6d9c687fbceb4aafc63ed8b451\n"
             "P00 DETAIL: reference pg_data/global/pg_control to [FULL-2]\n"
-            "P00 DETAIL: reference pg_data/postgresql.conf to [FULL-2]\n"
             "P00   INFO: new backup label = [DIFF-4]\n"
-            "P00   INFO: diff backup size = 3B, file total = 3");
+            "P00   INFO: diff backup size = 9B, file total = 3");
         TEST_RESULT_UINT(
             strLstSize(storageListP(storageRepoIdx(1), strNewFmt(STORAGE_PATH_BACKUP "/test1"))), backupCount + 1,
             "new backup repo2");


### PR DESCRIPTION
If the file size changed during backup then the progress percentage in the log would not be accurate.

Fix this by using the original size to increment the progress since progress total was calculated from original file sizes.