### PR TITLE
Tag pgbackrest build target in meson as installable.

### DIFF
--- a/doc/xml/release/2024/2.52.xml
+++ b/doc/xml/release/2024/2.52.xml
@@ -1,2 +1,16 @@
 <release date="XXXX-XX-XX" version="2.52dev" title="UNDER DEVELOPMENT">
+    <release-core-list>
+        <release-improvement-list>
+            <release-item>
+                <github-pull-request id="2312"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="bradford.boyle"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Tag <id>pgbackrest</id> build target in meson as installable.</p>
+            </release-item>
+        </release-improvement-list>
+    </release-core-list>
 </release>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -125,6 +125,11 @@
     <contributor-id type="github">bradnicholson</contributor-id>
 </contributor>
 
+<contributor id="bradford.boyle">
+    <contributor-name-display>Bradford Boyle</contributor-name-display>
+    <contributor-id type="github">bradfordboyle</contributor-id>
+</contributor>
+
 <contributor id="brent.graveland">
     <contributor-name-display>Brent Graveland</contributor-name-display>
     <contributor-id type="github">graveland</contributor-id>

--- a/src/meson.build
+++ b/src/meson.build
@@ -274,7 +274,6 @@ executable(
     src_pgbackrest,
     help_auto_c_inc,
     interface_auto_c_inc,
-    install : true,
     dependencies : [
         lib_backtrace,
         lib_bz2,
@@ -285,5 +284,6 @@ executable(
         lib_xml,
         lib_z,
         lib_zstd,
-    ]
+    ],
+    install: true,
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -274,6 +274,7 @@ executable(
     src_pgbackrest,
     help_auto_c_inc,
     interface_auto_c_inc,
+    install : true,
     dependencies : [
         lib_backtrace,
         lib_bz2,


### PR DESCRIPTION
By defauly, Meson does not install anything. Targets can be installed by tagging them as installable in the build definition.

[1]: https://mesonbuild.com/Installing.html

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
