### PR TITLE
Default log-level-stderr option to off.

### DIFF
--- a/doc/xml/release/2024/2.53.xml
+++ b/doc/xml/release/2024/2.53.xml
@@ -26,6 +26,7 @@
                 <release-item-contributor-list>
                     <release-item-contributor id="david.steele"/>
                     <release-item-reviewer id="greg.sabino.mullane"/>
+                    <release-item-reviewer id="stefan.fercot"/>
                 </release-item-contributor-list>
 
                 <p>Default <br-setting>log-level-stderr</br-setting> option to <id>off</id>.</p>

--- a/doc/xml/release/2024/2.53.xml
+++ b/doc/xml/release/2024/2.53.xml
@@ -1,5 +1,9 @@
 <release date="XXXX-XX-XX" version="2.53dev" title="UNDER DEVELOPMENT">
     <release-core-list>
+        <text>
+            <p><b>IMPORTANT NOTE</b>: The <br-setting>log-level-stderr</br-setting> option default has been changed from <id>warn</id> to <id>off</id>. This makes it easier to capture errors when only redirecting <id>stdout</id>. To preserve the prior behavior set <br-setting>log-level-stderr=warn</br-setting>.</p>
+        </text>
+
         <release-bug-list>
             <release-item>
                 <github-issue id="2358"/>

--- a/doc/xml/release/2024/2.53.xml
+++ b/doc/xml/release/2024/2.53.xml
@@ -21,6 +21,17 @@
 
         <release-improvement-list>
             <release-item>
+                <github-pull-request id="2379"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="greg.sabino.mullane"/>
+                </release-item-contributor-list>
+
+                <p>Default <br-setting>log-level-stderr</br-setting> option to <id>off</id>.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2303"/>
 
                 <release-item-contributor-list>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -1174,7 +1174,6 @@
 
                 <backrest-config-option section="demo" key="pg1-path">{[pg-path]}</backrest-config-option>
 
-                <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
 
@@ -2712,7 +2711,6 @@
                 <backrest-config-option section="global" key="start-fast">y</backrest-config-option>
                 <backrest-config-option section="global" key="repo1-retention-full">2</backrest-config-option>
 
-                <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
 
@@ -2737,8 +2735,6 @@
                 <backrest-config-option if="{[protocol-tls]}" section="global" key="tls-server-key-file">/etc/pgbackrest/cert/server.key</backrest-config-option>
 
                 <backrest-config-option section="global" key="log-level-file">detail</backrest-config-option>
-
-                <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
 
@@ -3104,8 +3100,6 @@
                 <backrest-config-option if="{[protocol-tls]}" section="global" key="tls-server-key-file">/etc/pgbackrest/cert/server.key</backrest-config-option>
 
                 <backrest-config-option section="global" key="log-level-file">detail</backrest-config-option>
-
-                <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
 
@@ -3478,8 +3472,6 @@
                 <backrest-config-option if="{[protocol-tls]}" section="global" key="tls-server-key-file">/etc/pgbackrest/cert/server.key</backrest-config-option>
 
                 <backrest-config-option section="global" key="log-level-file">detail</backrest-config-option>
-
-                <backrest-config-option section="global" key="log-level-stderr">off</backrest-config-option>
                 <backrest-config-option section="global" key="log-timestamp">n</backrest-config-option>
             </backrest-config>
 

--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1050,7 +1050,7 @@ option:
   log-level-stderr:
     section: global
     type: string-id
-    default: warn
+    default: off
     allow-list: log-level-console
 
   log-path:

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -44,6 +44,7 @@ static const StringPub parseRuleValueStr[] =
     PARSE_RULE_STRPUB("latest"),                                                                                          // val/str
     PARSE_RULE_STRPUB("localhost"),                                                                                       // val/str
     PARSE_RULE_STRPUB("none"),                                                                                            // val/str
+    PARSE_RULE_STRPUB("off"),                                                                                             // val/str
     PARSE_RULE_STRPUB("pause"),                                                                                           // val/str
     PARSE_RULE_STRPUB("pgbackrest"),                                                                                      // val/str
     PARSE_RULE_STRPUB("posix"),                                                                                           // val/str
@@ -96,6 +97,7 @@ typedef enum
     parseRuleValStrQT_latest_QT,                                                                                     // val/str/enum
     parseRuleValStrQT_localhost_QT,                                                                                  // val/str/enum
     parseRuleValStrQT_none_QT,                                                                                       // val/str/enum
+    parseRuleValStrQT_off_QT,                                                                                        // val/str/enum
     parseRuleValStrQT_pause_QT,                                                                                      // val/str/enum
     parseRuleValStrQT_pgbackrest_QT,                                                                                 // val/str/enum
     parseRuleValStrQT_posix_QT,                                                                                      // val/str/enum
@@ -2811,8 +2813,8 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
                                                                                                              // opt/log-level-stderr
                 PARSE_RULE_OPTIONAL_DEFAULT                                                                  // opt/log-level-stderr
                 (                                                                                            // opt/log-level-stderr
-                    PARSE_RULE_VAL_STRID(parseRuleValStrIdWarn),                                             // opt/log-level-stderr
-                    PARSE_RULE_VAL_STR(parseRuleValStrQT_warn_QT),                                           // opt/log-level-stderr
+                    PARSE_RULE_VAL_STRID(parseRuleValStrIdOff),                                              // opt/log-level-stderr
+                    PARSE_RULE_VAL_STR(parseRuleValStrQT_off_QT),                                            // opt/log-level-stderr
                 ),                                                                                           // opt/log-level-stderr
             ),                                                                                               // opt/log-level-stderr
         ),                                                                                                   // opt/log-level-stderr

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -1825,7 +1825,7 @@ cfgParse(const Storage *const storage, const unsigned int argListSize, const cha
 
         // Enable logging for main role so config file warnings will be output
         if (!param.noResetLogLevel && config->commandRole == cfgCmdRoleMain)
-            logInit(logLevelWarn, logLevelWarn, logLevelOff, false, 0, 1, false);
+            logInit(logLevelWarn, logLevelOff, logLevelOff, false, 0, 1, false);
 
         // Only continue if command options need to be validated, i.e. a real command is running or we are getting help for a
         // specific command and would like to display actual option values in the help.

--- a/test/src/common/harnessHost.c
+++ b/test/src/common/harnessHost.c
@@ -624,7 +624,6 @@ hrnHostConfig(HrnHost *const this)
         // Log options
         strCatZ(config, "\n");
         strCatFmt(config, "log-path=%s\n", strZ(hrnHostLogPath(this)));
-        strCatZ(config, "log-level-stderr=off\n");
         strCatZ(config, "log-level-console=warn\n");
         strCatZ(config, "log-level-file=info\n");
         strCatZ(config, "log-subprocess=n\n");

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -261,7 +261,7 @@ testRun(void)
             "\n"
             "  --log-level-console                 level for console logging [default=warn]\n"
             "  --log-level-file                    level for file logging [default=info]\n"
-            "  --log-level-stderr                  level for stderr logging [default=warn]\n"
+            "  --log-level-stderr                  level for stderr logging [default=off]\n"
             "  --log-path                          path where log files are stored\n"
             "                                      [default=/var/log/pgbackrest]\n"
             "  --log-subprocess                    enable logging in subprocesses [default=n]\n"

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -1517,7 +1517,7 @@ testRun(void)
         TEST_RESULT_BOOL(cfgCommandHelp(), true, "help is set");
         TEST_RESULT_INT(cfgCommand(), cfgCmdNone, "command is none");
         TEST_RESULT_INT(hrnLogLevelStdOut(), logLevelWarn, "console logging is warn");
-        TEST_RESULT_INT(hrnLogLevelStdErr(), logLevelWarn, "stderr logging is warn");
+        TEST_RESULT_INT(hrnLogLevelStdErr(), logLevelOff, "stderr logging is warn");
         harnessLogLevelReset();
 
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -1517,7 +1517,7 @@ testRun(void)
         TEST_RESULT_BOOL(cfgCommandHelp(), true, "help is set");
         TEST_RESULT_INT(cfgCommand(), cfgCmdNone, "command is none");
         TEST_RESULT_INT(hrnLogLevelStdOut(), logLevelWarn, "console logging is warn");
-        TEST_RESULT_INT(hrnLogLevelStdErr(), logLevelOff, "stderr logging is warn");
+        TEST_RESULT_INT(hrnLogLevelStdErr(), logLevelOff, "stderr logging is off");
         harnessLogLevelReset();
 
         // -------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Writing warnings and errors to stderr by default leads to error messages being lost when the user does not correctly redirect stderr while generating logs for analysis. This happens so often that it seems worth changing the default to increase the quality of the logs we receive.