### PR TITLE
WIP: Add config-dry-run option.

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -281,6 +281,12 @@ option:
     default: CFGOPTDEF_CONFIG_PATH
     default-literal: true
 
+  config-dry-run:
+    type: boolean
+    default: false
+    command-role:
+      main: {}
+
   dry-run:
     type: boolean
     default: false

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1970,6 +1970,16 @@
                     <example>/conf/pgbackrest/pgbackrest.conf</example>
                 </option>
 
+                <option id="config-dry-run" name="Config Dry Run">
+                    <summary>Configuration dry run.</summary>
+
+                    <text>
+                        <p>Log command begin/end and exit. Configuration errors and warnings will also be logged.</p>
+                    </text>
+
+                    <example>y</example>
+                </option>
+
                 <option id="config-include-path" name="Config Include Path">
                     <summary>Path to additional <backrest/> configuration files.</summary>
 

--- a/src/config/config.auto.h
+++ b/src/config/config.auto.h
@@ -67,6 +67,7 @@ Option constants
 #define CFGOPT_COMPRESS_LEVEL_NETWORK                               "compress-level-network"
 #define CFGOPT_COMPRESS_TYPE                                        "compress-type"
 #define CFGOPT_CONFIG                                               "config"
+#define CFGOPT_CONFIG_DRY_RUN                                       "config-dry-run"
 #define CFGOPT_CONFIG_INCLUDE_PATH                                  "config-include-path"
 #define CFGOPT_CONFIG_PATH                                          "config-path"
 #define CFGOPT_DB_EXCLUDE                                           "db-exclude"
@@ -137,7 +138,7 @@ Option constants
 #define CFGOPT_TYPE                                                 "type"
 #define CFGOPT_VERBOSE                                              "verbose"
 
-#define CFG_OPTION_TOTAL                                            181
+#define CFG_OPTION_TOTAL                                            182
 
 /***********************************************************************************************************************************
 Option value constants
@@ -407,6 +408,7 @@ typedef enum
     cfgOptCompressLevelNetwork,
     cfgOptCompressType,
     cfgOptConfig,
+    cfgOptConfigDryRun,
     cfgOptConfigIncludePath,
     cfgOptConfigPath,
     cfgOptDbExclude,

--- a/src/config/load.h
+++ b/src/config/load.h
@@ -12,7 +12,7 @@ Configuration Load
 Functions
 ***********************************************************************************************************************************/
 // Load the configuration
-FN_EXTERN void cfgLoad(unsigned int argListSize, const char *argList[]);
+FN_EXTERN bool cfgLoad(unsigned int argListSize, const char *argList[]);
 
 // Load the configuration using the specified stanza
 FN_EXTERN void cfgLoadStanza(const String *stanza);

--- a/src/config/parse.auto.c.inc
+++ b/src/config/parse.auto.c.inc
@@ -1975,6 +1975,51 @@ static const ParseRuleOption parseRuleOption[CFG_OPTION_TOTAL] =
         ),                                                                                                             // opt/config
     ),                                                                                                                 // opt/config
     // -----------------------------------------------------------------------------------------------------------------------------
+    PARSE_RULE_OPTION                                                                                          // opt/config-dry-run
+    (                                                                                                          // opt/config-dry-run
+        PARSE_RULE_OPTION_NAME("config-dry-run"),                                                              // opt/config-dry-run
+        PARSE_RULE_OPTION_TYPE(Boolean),                                                                       // opt/config-dry-run
+        PARSE_RULE_OPTION_REQUIRED(true),                                                                      // opt/config-dry-run
+        PARSE_RULE_OPTION_SECTION(CommandLine),                                                                // opt/config-dry-run
+                                                                                                               // opt/config-dry-run
+        PARSE_RULE_OPTION_COMMAND_ROLE_MAIN_VALID_LIST                                                         // opt/config-dry-run
+        (                                                                                                      // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Annotate)                                                                // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(ArchiveGet)                                                              // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(ArchivePush)                                                             // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Backup)                                                                  // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Check)                                                                   // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Expire)                                                                  // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Info)                                                                    // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Manifest)                                                                // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(RepoCreate)                                                              // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(RepoGet)                                                                 // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(RepoLs)                                                                  // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(RepoPut)                                                                 // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(RepoRm)                                                                  // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Restore)                                                                 // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Server)                                                                  // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(ServerPing)                                                              // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(StanzaCreate)                                                            // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(StanzaDelete)                                                            // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(StanzaUpgrade)                                                           // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Start)                                                                   // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Stop)                                                                    // opt/config-dry-run
+            PARSE_RULE_OPTION_COMMAND(Verify)                                                                  // opt/config-dry-run
+        ),                                                                                                     // opt/config-dry-run
+                                                                                                               // opt/config-dry-run
+        PARSE_RULE_OPTIONAL                                                                                    // opt/config-dry-run
+        (                                                                                                      // opt/config-dry-run
+            PARSE_RULE_OPTIONAL_GROUP                                                                          // opt/config-dry-run
+            (                                                                                                  // opt/config-dry-run
+                PARSE_RULE_OPTIONAL_DEFAULT                                                                    // opt/config-dry-run
+                (                                                                                              // opt/config-dry-run
+                    PARSE_RULE_VAL_BOOL_FALSE,                                                                 // opt/config-dry-run
+                ),                                                                                             // opt/config-dry-run
+            ),                                                                                                 // opt/config-dry-run
+        ),                                                                                                     // opt/config-dry-run
+    ),                                                                                                         // opt/config-dry-run
+    // -----------------------------------------------------------------------------------------------------------------------------
     PARSE_RULE_OPTION                                                                                     // opt/config-include-path
     (                                                                                                     // opt/config-include-path
         PARSE_RULE_OPTION_NAME("config-include-path"),                                                    // opt/config-include-path
@@ -11093,6 +11138,7 @@ static const uint8_t optionResolveOrder[] =
     cfgOptCompressLevelNetwork,                                                                                 // opt-resolve-order
     cfgOptCompressType,                                                                                         // opt-resolve-order
     cfgOptConfig,                                                                                               // opt-resolve-order
+    cfgOptConfigDryRun,                                                                                         // opt-resolve-order
     cfgOptConfigIncludePath,                                                                                    // opt-resolve-order
     cfgOptConfigPath,                                                                                           // opt-resolve-order
     cfgOptDbExclude,                                                                                            // opt-resolve-order

--- a/src/main.c
+++ b/src/main.c
@@ -98,10 +98,12 @@ main(int argListSize, const char *argList[])
 
     TRY_BEGIN()
     {
-        // Load the configuration
+        // Load the configuration (exit when config dry run)
         // -------------------------------------------------------------------------------------------------------------------------
-        cfgLoad((unsigned int)argListSize, argList);
-        ConfigCommandRole commandRole = cfgCommandRole();
+        if (!cfgLoad((unsigned int)argListSize, argList))
+            FUNCTION_LOG_RETURN(INT, exitSafe(0, false, 0));
+
+        const ConfigCommandRole commandRole = cfgCommandRole();
 
         // Local role
         // -------------------------------------------------------------------------------------------------------------------------

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -232,6 +232,7 @@ testRun(void)
             "  --cmd-ssh                           SSH client command\n"
             "  --compress-level-network            network compression level\n"
             "  --config                            pgBackRest configuration file\n"
+            "  --config-dry-run                    configuration dry run\n"
             "  --config-include-path               path to additional pgBackRest\n"
             "                                      configuration files\n"
             "  --config-path                       base path of pgBackRest configuration\n"

--- a/test/src/module/config/loadTest.c
+++ b/test/src/module/config/loadTest.c
@@ -23,7 +23,7 @@ testRun(void)
     {
         HRN_CFG_LOAD(cfgCmdVersion, strLstNew());
 
-        TEST_RESULT_VOID(cfgLoadLogSetting(), "load log settings all defaults");
+        TEST_RESULT_VOID(cfgLoadLogSetting(false), "load log settings all defaults");
 
         TEST_RESULT_INT(hrnLogLevelStdOut(), logLevelOff, "console logging is off");
         TEST_RESULT_INT(hrnLogLevelStdErr(), logLevelOff, "stderr logging is off");
@@ -785,6 +785,22 @@ testRun(void)
         hrnCfgArgRawBool(argList, cfgOptDryRun, true);
 
         TEST_RESULT_VOID(cfgLoad(strLstSize(argList), strLstPtr(argList)), "load config");
+        TEST_ERROR(
+            storageRepoWrite(), AssertError, "unable to get writable storage in dry-run mode or before dry-run is initialized");
+        cmdLockReleaseP();
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("config-dry-run");
+
+        argList = strLstNew();
+        strLstAddZ(argList, PROJECT_BIN);
+        hrnCfgArgRawZ(argList, cfgOptStanza, "db");
+        hrnCfgArgRawZ(argList, cfgOptLockPath, HRN_PATH "/lock");
+        hrnCfgArgRawZ(argList, cfgOptLogLevelStderr, CFGOPTVAL_ARCHIVE_MODE_OFF_Z);
+        hrnCfgArgRawBool(argList, cfgOptConfigDryRun, true);
+        strLstAddZ(argList, CFGCMD_EXPIRE);
+
+        TEST_RESULT_BOOL(cfgLoad(strLstSize(argList), strLstPtr(argList)), false, "config dry run");
         TEST_ERROR(
             storageRepoWrite(), AssertError, "unable to get writable storage in dry-run mode or before dry-run is initialized");
         cmdLockReleaseP();


### PR DESCRIPTION
This option allows debugging of the configuration for any command:
```
pgbackrest --config-dry-run backup --stanza=test --log-level-console=info
```
outputs:
```
2024-07-11 14:38:34.082 P00   INFO: [DRY-RUN] backup command begin 2.53dev: --config-dry-run --exec-id=23275-1b2d660f --log-level-console=info --log-level-file=off --pg1-path=/pg1 --stanza=test
2024-07-11 14:38:34.082 P00   INFO: [DRY-RUN] backup command end: completed successfully (5ms)
```
This would seem to provide the functionality that is missing after #2395.

Not sure if I am entirely satisfied with this, but I figured I would get it out there for discussion.