### PR TITLE
Fix segfault on delayed connection errors.

### DIFF
--- a/doc/xml/release/2024/2.54.xml
+++ b/doc/xml/release/2024/2.54.xml
@@ -15,6 +15,19 @@
             </release-item>
 
             <release-item>
+                <github-issue id="2420"/>
+                <github-pull-request id="2422"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="anton.glushakov"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="david.christensen"/>
+                </release-item-contributor-list>
+
+                <p>Fix segfault on delayed connection errors.</p>
+            </release-item>
+
+            <release-item>
                 <github-issue id="2418"/>
                 <github-pull-request id="2421"/>
 

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -161,12 +161,14 @@ sckClientOpen(THIS_VOID)
 
                     if (openDataWait->fd != 0)
                     {
+                        // Set this so error handling will work as expected
                         openData = openDataWait;
 
                         if (sckClientOpenWait(openDataWait, 0))
                             break;
-                        else
-                            openData = NULL;
+
+                        // Reset to NULL if the connection was not successful
+                        openData = NULL;
                     }
                 }
 

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -164,7 +164,8 @@ sckClientOpen(THIS_VOID)
                         // Set so the connection will be closed on error
                         openData = openDataWait;
 
-                        if (sckClientOpenWait(openDataWait, 0))
+                        // Check if the connection has completed without waiting
+                        if (sckClientOpenWait(openData, 0))
                             break;
 
                         // Reset to NULL if the connection is still waiting so another connection can be attempted

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -159,10 +159,12 @@ sckClientOpen(THIS_VOID)
                 {
                     SckClientOpenData *const openDataWait = lstGet(openDataList, openDataIdx);
 
-                    if (openDataWait->fd != 0 && sckClientOpenWait(openDataWait, 0))
+                    if (openDataWait->fd != 0)
                     {
                         openData = openDataWait;
-                        break;
+
+                        if (sckClientOpenWait(openDataWait, 0))
+                            break;
                     }
                 }
 
@@ -233,16 +235,14 @@ sckClientOpen(THIS_VOID)
             }
             CATCH_ANY()
             {
-                // Close when a connection was attempted
-                if (openData != NULL)
-                {
-                    // Close socket
-                    close(openData->fd);
+                ASSERT(openData != NULL);
 
-                    // Clear socket so the connection can be retried
-                    openData->fd = 0;
-                    openData->errNo = 0;
-                }
+                // Close socket
+                close(openData->fd);
+
+                // Clear socket so the connection can be retried
+                openData->fd = 0;
+                openData->errNo = 0;
 
                 // Add the error retry info
                 errRetryAddP(errRetry);

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -165,6 +165,8 @@ sckClientOpen(THIS_VOID)
 
                         if (sckClientOpenWait(openDataWait, 0))
                             break;
+                        else
+                            openData = NULL;
                     }
                 }
 

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -233,12 +233,16 @@ sckClientOpen(THIS_VOID)
             }
             CATCH_ANY()
             {
-                // Close socket
-                close(openData->fd);
+                // Close when a connection was attempted
+                if (openData != NULL)
+                {
+                    // Close socket
+                    close(openData->fd);
 
-                // Clear socket so the connection can be retried
-                openData->fd = 0;
-                openData->errNo = 0;
+                    // Clear socket so the connection can be retried
+                    openData->fd = 0;
+                    openData->errNo = 0;
+                }
 
                 // Add the error retry info
                 errRetryAddP(errRetry);

--- a/src/common/io/socket/client.c
+++ b/src/common/io/socket/client.c
@@ -161,13 +161,13 @@ sckClientOpen(THIS_VOID)
 
                     if (openDataWait->fd != 0)
                     {
-                        // Set this so error handling will work as expected
+                        // Set so the connection will be closed on error
                         openData = openDataWait;
 
                         if (sckClientOpenWait(openDataWait, 0))
                             break;
 
-                        // Reset to NULL if the connection was not successful
+                        // Reset to NULL if the connection is still waiting so another connection can be attempted
                         openData = NULL;
                     }
                 }


### PR DESCRIPTION
Connection errors could cause a segfault if the error was delayed enough to pass the initial call to sckClientOpenWait() and the error was instead thrown by a subsequent call to sckClientOpenWait(), which was not correctly initializing a variable required for error handling.

While this can be produced fairly easily in a test environment, I was unable to craft a unit test to hit this exact condition, probably due to timing. The new code still has full coverage and I added several comments to help prevent regressions.