### PR TITLE
Refresh web-id token for each S3 authentication.

### DIFF
--- a/doc/xml/release/2024/2.54.xml
+++ b/doc/xml/release/2024/2.54.xml
@@ -11,6 +11,18 @@
 
                 <p>Summarize backup reference list for <cmd>info</cmd> command text output.</p>
             </release-item>
+
+            <release-item>
+                <github-issue id="2428"/>
+                <github-pull-request id="2429"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="brent.graveland"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Refresh web-id token for each <proper>S3</proper> authentication.</p>
+            </release-item>
         </release-improvement-list>
 
         <release-development-list>

--- a/src/storage/s3/helper.c
+++ b/src/storage/s3/helper.c
@@ -53,9 +53,9 @@ storageS3Helper(const unsigned int repoIdx, const bool write, StoragePathExpress
         // Get role and token
         const StorageS3KeyType keyType = (StorageS3KeyType)cfgOptionIdxStrId(cfgOptRepoS3KeyType, repoIdx);
         const String *role = cfgOptionIdxStrNull(cfgOptRepoS3Role, repoIdx);
-        const String *webIdToken = NULL;
+        const String *webIdTokenFile = NULL;
 
-        // If web identity authentication then load the role and token from environment variables documented here:
+        // If web identity authentication then load the role and token filename from environment variables documented here:
         // https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
         if (keyType == storageS3KeyTypeWebId)
         {
@@ -75,7 +75,7 @@ storageS3Helper(const unsigned int repoIdx, const bool write, StoragePathExpress
             }
 
             role = strNewZ(roleZ);
-            webIdToken = strNewBuf(storageGetP(storageNewReadP(storagePosixNewP(FSLASH_STR), STR(webIdTokenFileZ))));
+            webIdTokenFile = strNewZ(webIdTokenFileZ);
         }
 
         MEM_CONTEXT_PRIOR_BEGIN()
@@ -86,7 +86,7 @@ storageS3Helper(const unsigned int repoIdx, const bool write, StoragePathExpress
                 (StorageS3UriStyle)cfgOptionIdxStrId(cfgOptRepoS3UriStyle, repoIdx), cfgOptionIdxStr(cfgOptRepoS3Region, repoIdx),
                 keyType, cfgOptionIdxStrNull(cfgOptRepoS3Key, repoIdx), cfgOptionIdxStrNull(cfgOptRepoS3KeySecret, repoIdx),
                 cfgOptionIdxStrNull(cfgOptRepoS3Token, repoIdx), cfgOptionIdxStrNull(cfgOptRepoS3KmsKeyId, repoIdx),
-                cfgOptionIdxStrNull(cfgOptRepoS3SseCustomerKey, repoIdx), role, webIdToken,
+                cfgOptionIdxStrNull(cfgOptRepoS3SseCustomerKey, repoIdx), role, webIdTokenFile,
                 (size_t)cfgOptionIdxUInt64(cfgOptRepoStorageUploadChunkSize, repoIdx),
                 cfgOptionIdxKvNull(cfgOptRepoStorageTag, repoIdx), host, port, ioTimeoutMs(),
                 cfgOptionIdxBool(cfgOptRepoStorageVerifyTls, repoIdx), cfgOptionIdxStrNull(cfgOptRepoStorageCaFile, repoIdx),

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -3,7 +3,6 @@ S3 Storage
 ***********************************************************************************************************************************/
 #include "build.auto.h"
 
-#include <stdlib.h>
 #include <string.h>
 
 #include "common/crypto/hash.h"
@@ -112,8 +111,7 @@ struct StorageS3
     HttpClient *credHttpClient;                                     // HTTP client to service credential requests
     const String *credHost;                                         // Credentials host
     const String *credRole;                                         // Role to use for credential requests
-    const String *webIdTokenFile;                                   // The file containing the token to use for web-id credential
-                                                                    // requests
+    const String *webIdTokenFile;                                   // File containing token to use for web-id credential requests
     time_t credExpirationTime;                                      // Time the temporary credentials expire
 
     // Current signing key and date it is valid for
@@ -389,9 +387,9 @@ storageS3AuthWebId(StorageS3 *const this, const HttpHeader *const header)
 
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        // We load the token from the given file for each request since the token can be updated during the middle
-        // of a long-running execution.
-        const String *webIdToken = strNewBuf(storageGetP(storageNewReadP(storagePosixNewP(FSLASH_STR), this->webIdTokenFile)));
+        // Load the token from the given file for each request since the token may be updated during execution
+        const String *const webIdToken = strNewBuf(
+            storageGetP(storageNewReadP(storagePosixNewP(FSLASH_STR), this->webIdTokenFile)));
 
         // Get credentials
         HttpQuery *const query = httpQueryNewP();

--- a/src/storage/s3/storage.h
+++ b/src/storage/s3/storage.h
@@ -37,7 +37,7 @@ FN_EXTERN Storage *storageS3New(
     const String *path, bool write, StoragePathExpressionCallback pathExpressionFunction, const String *bucket,
     const String *endPoint, StorageS3UriStyle uriStyle, const String *region, StorageS3KeyType keyType, const String *accessKey,
     const String *secretAccessKey, const String *securityToken, const String *kmsKeyId, const String *sseCustomerKey,
-    const String *credRole, const String *webIdToken, size_t partSize, const KeyValue *tag, const String *host, unsigned int port,
+    const String *credRole, const String *webIdTokenFile, size_t partSize, const KeyValue *tag, const String *host, unsigned int port,
     TimeMSec timeout, bool verifyPeer, const String *caFile, const String *caPath);
 
 #endif

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -933,6 +933,7 @@ testRun(void)
 
                 #define TEST_SERVICE_ROLE                           "arn:aws:iam::123456789012:role/TestRole"
                 #define TEST_SERVICE_TOKEN                          "TOKEN"
+                #define TEST_SERVICE_TOKEN_FILE                     TEST_PATH "web-id-token"
                 #define TEST_SERVICE_URI                                                                                           \
                     "/?Action=AssumeRoleWithWebIdentity&RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2FTestRole"               \
                         "&RoleSessionName=pgBackRest&Version=2011-06-15&WebIdentityToken=" TEST_SERVICE_TOKEN
@@ -967,13 +968,13 @@ testRun(void)
                     storageRepoGet(0, true), OptionInvalidError,
                     "option 'repo1-s3-key-type' is 'web-id' but 'AWS_ROLE_ARN' and 'AWS_WEB_IDENTITY_TOKEN_FILE' are not set");
 
-                setenv("AWS_WEB_IDENTITY_TOKEN_FILE", TEST_PATH "/web-id-token", true);
+                setenv("AWS_WEB_IDENTITY_TOKEN_FILE", TEST_SERVICE_TOKEN_FILE, true);
 
                 s3 = storageRepoGet(0, true);
                 driver = (StorageS3 *)storageDriver(s3);
 
                 TEST_RESULT_STR_Z(driver->credRole, TEST_SERVICE_ROLE, "check role");
-                TEST_RESULT_STR_Z(driver->webIdToken, TEST_SERVICE_TOKEN, "check token");
+                TEST_RESULT_STR_Z(driver->webIdTokenFile, TEST_SERVICE_TOKEN_FILE, "check token file");
 
                 // Set partSize to a small value for testing
                 driver->partSize = 16;

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -933,7 +933,7 @@ testRun(void)
 
                 #define TEST_SERVICE_ROLE                           "arn:aws:iam::123456789012:role/TestRole"
                 #define TEST_SERVICE_TOKEN                          "TOKEN"
-                #define TEST_SERVICE_TOKEN_FILE                     TEST_PATH "web-id-token"
+                #define TEST_SERVICE_TOKEN_FILE                     TEST_PATH "/web-id-token"
                 #define TEST_SERVICE_URI                                                                                           \
                     "/?Action=AssumeRoleWithWebIdentity&RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2FTestRole"               \
                         "&RoleSessionName=pgBackRest&Version=2011-06-15&WebIdentityToken=" TEST_SERVICE_TOKEN

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -951,7 +951,7 @@ testRun(void)
                     "</AssumeRoleWithWebIdentityResponse>"
                 // {uncrustify_on}
 
-                HRN_STORAGE_PUT_Z(storagePosixNewP(TEST_PATH_STR, .write = true), "web-id-token", TEST_SERVICE_TOKEN);
+                HRN_STORAGE_PUT_Z(storagePosixNewP(TEST_PATH_STR, .write = true), TEST_SERVICE_TOKEN_FILE, TEST_SERVICE_TOKEN);
 
                 argList = strLstDup(commonArgList);
                 hrnCfgArgRawFmt(argList, cfgOptRepoStorageHost, "%s:%u", strZ(host), testPort);


### PR DESCRIPTION
The token file pointed to by the `AWS_WEB_IDENTITY_TOKEN_FILE` env var was read once at startup, but for long operations the token might expire before we're complete. This switches to reading it on each S3 request so we immediately use the renewed token. This is especially likely when running in kubernetes using a projected service account token.

Fixes #2428

I was having tests in GH CI timing out- I may have more work to do with testing. I've also still got to build and deploy a version with this PR in our k8s and see how that goes too.
