### PR TITLE
Correctly display current values for indexed options in help.

### DIFF
--- a/doc/xml/release/2024/2.54.xml
+++ b/doc/xml/release/2024/2.54.xml
@@ -50,6 +50,17 @@
             </release-item>
 
             <release-item>
+                <github-pull-request id="2453"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="david.christensen"/>
+                </release-item-contributor-list>
+
+                <p>Correctly display current values for indexed options in help.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2403"/>
 
                 <release-item-contributor-list>

--- a/src/command/help/help.c
+++ b/src/command/help/help.c
@@ -240,7 +240,6 @@ helpRenderValue(const ConfigOption optionId)
             for (unsigned int optionIdx = 1; optionIdx < cfgOptionGroupIdxTotal(cfgOptionGroupId(optionId)); optionIdx++)
             {
                 const String *const value = helpRenderValueIdx(optionId, optionIdx);
-                // fprintf(stdout, "!!!RESULT %s VALUE %s\n", strZNull(result), strZNull(value));fflush(stdout);
 
                 if (!strEq(result, value))
                 {

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -587,7 +587,7 @@ testRun(void)
         TEST_RESULT_STR_Z(helpRender(helpData), optionHelp, "check admonition text");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("multiple current values");
+        TEST_TITLE("multiple current values (with one missing)");
 
         optionHelp = zNewFmt(
             "%s - 'restore' command - 'repo-host' option help\n"

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -308,14 +308,14 @@ testRun(void)
             "  --repo-cipher-pass                  repository cipher passphrase\n"
             "                                      [current=<redacted>]\n"
             "  --repo-cipher-type                  cipher used to encrypt the repository\n"
-            "                                      [current=aes-256-cbc, default=none]\n"
+            "                                      [current=<multi>, default=none]\n"
             "  --repo-gcs-bucket                   GCS repository bucket\n"
             "  --repo-gcs-endpoint                 GCS repository endpoint\n"
             "                                      [default=storage.googleapis.com]\n"
             "  --repo-gcs-key                      GCS repository key\n"
             "  --repo-gcs-key-type                 GCS repository key type [default=service]\n"
             "  --repo-host                         repository host when operating remotely\n"
-            "                                      [current=backup.example.net]\n"
+            "                                      [current=<multi>]\n"
             "  --repo-host-ca-file                 repository host certificate authority file\n"
             "  --repo-host-ca-path                 repository host certificate authority path\n"
             "  --repo-host-cert-file               repository host certificate file\n"
@@ -383,7 +383,8 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptBufferSize, "32768");
         hrnCfgArgRawZ(argList, cfgOptRepoCipherType, "aes-256-cbc");
         hrnCfgEnvRawZ(cfgOptRepoCipherPass, TEST_CIPHER_PASS);
-        hrnCfgArgRawZ(argList, cfgOptRepoHost, "backup.example.net");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 1, "backup.example.net");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 2, "dr.test.org");
         hrnCfgArgRawZ(argList, cfgOptLinkMap, "/link1=/dest1");
         hrnCfgArgRawZ(argList, cfgOptLinkMap, "/link2=/dest2");
         hrnCfgArgRawZ(argList, cfgOptDbInclude, "db1");
@@ -584,6 +585,61 @@ testRun(void)
         strLstAddZ(argList, "repo-retention-archive");
         TEST_RESULT_VOID(testCfgLoad(argList), "help for backup command, repo-retention-archive option");
         TEST_RESULT_STR_Z(helpRender(helpData), optionHelp, "check admonition text");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("multiple current values");
+
+        optionHelp = zNewFmt(
+            "%s - 'restore' command - 'repo-host' option help\n"
+            "\n"
+            "Repository host when operating remotely.\n"
+            "\n"
+            "When backing up and archiving to a locally mounted filesystem this setting is\n"
+            "not required.\n"
+            "\n"
+            "current:\n"
+            "  repo1: backup.example.net\n"
+            "  repo3: dr.test.org\n"
+            "\n"
+            "deprecated name: backup-host\n",
+            helpVersion);
+
+        argList = strLstNew();
+        strLstAddZ(argList, "/path/to/pgbackrest");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 1, "backup.example.net");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 3, "dr.test.org");
+        strLstAddZ(argList, "help");
+        strLstAddZ(argList, "restore");
+        strLstAddZ(argList, "repo-host");
+        TEST_RESULT_VOID(testCfgLoad(argList), "help for restore command, repo-host option");
+        TEST_RESULT_STR_Z(helpRender(helpData), optionHelp, "check text");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("multiple current values (with one unset)");
+
+        optionHelp = zNewFmt(
+            "%s - 'restore' command - 'repo-host' option help\n"
+            "\n"
+            "Repository host when operating remotely.\n"
+            "\n"
+            "When backing up and archiving to a locally mounted filesystem this setting is\n"
+            "not required.\n"
+            "\n"
+            "current:\n"
+            "  repo3: dr.test.org\n"
+            "\n"
+            "deprecated name: backup-host\n",
+            helpVersion);
+
+        argList = strLstNew();
+        strLstAddZ(argList, "/path/to/pgbackrest");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoType, 1, "s3");
+        hrnCfgArgKeyRawZ(argList, cfgOptRepoHost, 3, "dr.test.org");
+        strLstAddZ(argList, "help");
+        strLstAddZ(argList, "restore");
+        strLstAddZ(argList, "repo-host");
+        TEST_RESULT_VOID(testCfgLoad(argList), "help for restore command, repo-host option");
+        TEST_RESULT_STR_Z(helpRender(helpData), optionHelp, "check text");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
The current value for an indexed option was always for the first index, e.g. pg1-path. This is likely legacy from before indexing was added (and faithfully copied over from Perl, apparently).

Fix this by enumerating the current values in the option help and displaying <multi> in the option list when more than one value exists.