### PR TITLE
Fix issue after disabling bundling with block incremental enabled.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -1,5 +1,18 @@
 <release date="XXXX-XX-XX" version="2.55dev" title="UNDER DEVELOPMENT">
     <release-core-list>
+        <release-bug-list>
+            <release-item>
+                <github-pull-request id="2511"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="david.christensen"/>
+                </release-item-contributor-list>
+
+                <p>Fix issue after disabling bundling with block incremental enabled.</p>
+            </release-item>
+        </release-bug-list>
+
         <release-improvement-list>
             <release-item>
                 <commit subject="Use lz4 for protocol compression.">

--- a/src/info/manifest.c
+++ b/src/info/manifest.c
@@ -2608,13 +2608,13 @@ manifestSaveCallback(void *const callbackData, const String *const sectionNext, 
         {
             infoSaveValue(
                 infoSaveData, MANIFEST_SECTION_BACKUP, MANIFEST_KEY_BACKUP_BUNDLE, jsonFromVar(VARBOOL(manifest->pub.data.bundle)));
+        }
 
-            if (manifest->pub.data.bundleRaw)
-            {
-                infoSaveValue(
-                    infoSaveData, MANIFEST_SECTION_BACKUP, MANIFEST_KEY_BACKUP_BUNDLE_RAW,
-                    jsonFromVar(VARBOOL(manifest->pub.data.bundleRaw)));
-            }
+        if (manifest->pub.data.bundleRaw)
+        {
+            infoSaveValue(
+                infoSaveData, MANIFEST_SECTION_BACKUP, MANIFEST_KEY_BACKUP_BUNDLE_RAW,
+                jsonFromVar(VARBOOL(manifest->pub.data.bundleRaw)));
         }
 
         infoSaveValue(

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -4186,7 +4186,7 @@ testRun(void)
                 "20191108-080000F/pg_data/block-incr-wayback.pgbi {s=16384, m=0:{0,1}, ts=-222800}\n"
                 "--------\n"
                 "[backup:target]\n"
-                "pg_data={\"path\":\"/home/vagrant/test/test-0/pg1\",\"type\":\"path\"}\n",
+                "pg_data={\"path\":\"" TEST_PATH "/pg1\",\"type\":\"path\"}\n",
                 "compare file list");
         }
 

--- a/test/src/module/info/manifestTest.c
+++ b/test/src/module/info/manifestTest.c
@@ -987,6 +987,7 @@ testRun(void)
     {
         #define TEST_MANIFEST_HEADER_PRE                                                                                           \
             "[backup]\n"                                                                                                           \
+            "backup-bundle-raw=true\n"                                                                                             \
             "backup-label=null\n"                                                                                                  \
             "backup-prior=\"20190101-010101F\"\n"
 


### PR DESCRIPTION
When bundling and block incremental are both enabled the bundleRaw flag is set to indicate that headers are omitted (whenever possible) for encryption and compression. This is intended to save space, especially when there are very large numbers of small files.

If bundling is disabled this flag needs to be preserved so that existing bundles from prior backups are read correctly. However, the prior code was only saving the flag when bundling was enabled, which caused prior backups to be unreadable if bundling was disabled.

Fix so that the flag is preserved and backups are not broken.