### PR TITLE
Improve full/incr backup limit time for preliminary copy.

### DIFF
--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -2702,6 +2702,9 @@ cmdBackup(void)
 
             MEM_CONTEXT_TEMP_BEGIN()
             {
+                if (cfgOptionBool(cfgOptStartFast))
+                    dbCheckpoint(backupData->dbPrimary);
+
                 // Build the manifest
                 Manifest *const manifestPrelim = manifestNewBuild(
                     backupData->storagePrimary, infoPg.version, infoPg.catalogVersion, timestampStart,

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -732,10 +732,10 @@ backupManifestCopySize(Manifest *const manifest)
 }
 
 /***********************************************************************************************************************************
-Get the last full backup time in order to set the limit for full/incr preliminary copy
+Get the last full backup duration in order to set the limit for full/incr preliminary copy
 ***********************************************************************************************************************************/
 static time_t
-backupFullIncrLimit(const InfoBackup *const infoBackup)
+backupLastFullDuration(const InfoBackup *const infoBackup)
 {
     FUNCTION_LOG_BEGIN(logLevelDebug);
         FUNCTION_LOG_PARAM(INFO_BACKUP, infoBackup);
@@ -758,9 +758,31 @@ backupFullIncrLimit(const InfoBackup *const infoBackup)
         }
     }
 
-    // Round up to the nearest minute (ensures we do not have a zero limit). This is a bit imprecise since an interval exactly
-    // divisible by a minute will be rounded up another minute, but it seems fine for this purpose.
-    result = (result / SEC_PER_MIN + 1) * SEC_PER_MIN;
+    FUNCTION_LOG_RETURN(TIME, result);
+}
+
+/***********************************************************************************************************************************
+Calculate time limit for full/incr preliminary copy
+***********************************************************************************************************************************/
+static time_t
+backupFullIncrLimit(const time_t checkpointTime, const TimeMSec dbTime, const time_t lastFullDuration)
+{
+    FUNCTION_LOG_BEGIN(logLevelDebug);
+        FUNCTION_LOG_PARAM(TIME, checkpointTime);
+        FUNCTION_LOG_PARAM(TIME_MSEC, dbTime);
+        FUNCTION_LOG_PARAM(TIME, lastFullDuration);
+    FUNCTION_LOG_END();
+
+    ASSERT(checkpointTime != 0);
+    ASSERT(dbTime != 0);
+    ASSERT(lastFullDuration >= 0);
+
+    // Calculate the limit
+    time_t result = (time_t)(dbTime / MSEC_PER_SEC) - lastFullDuration;
+
+    // Limit must be at least one minute prior to the last checkpoint
+    if (result > checkpointTime - SEC_PER_MIN)
+        result = checkpointTime - SEC_PER_MIN;
 
     FUNCTION_LOG_RETURN(TIME, result);
 }
@@ -2717,7 +2739,8 @@ cmdBackup(void)
 
                 // Remove files that do not need to be considered for the preliminary copy because they were modified after the
                 // calculated limit time and are therefore likely to be modified during the backup
-                time_t timestampCopyStart = backupData->checkpointTime - backupFullIncrLimit(infoBackup);
+                const time_t timestampCopyStart = backupFullIncrLimit(
+                    backupData->checkpointTime, dbTimeMSec(backupData->dbPrimary), backupLastFullDuration(infoBackup));
 
                 manifestBuildFullIncr(
                     manifestPrelim, timestampCopyStart,

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -2724,6 +2724,7 @@ cmdBackup(void)
 
             MEM_CONTEXT_TEMP_BEGIN()
             {
+                // Checkpoint when start-fast enabled
                 if (cfgOptionBool(cfgOptStartFast))
                     dbCheckpoint(backupData->dbPrimary);
 

--- a/src/db/db.c
+++ b/src/db/db.c
@@ -688,7 +688,7 @@ dbReplayWait(Db *const this, const String *const targetLsn, const uint32_t targe
         }
 
         // Perform a checkpoint
-        dbExec(this, STRDEF("checkpoint"));
+        dbCheckpoint(this);
 
         // On PostgreSQL >= 9.6 the checkpoint location can be verified so loop until lsn has been reached or timeout
         if (dbPgVersion(this) >= PG_VERSION_96)
@@ -732,6 +732,21 @@ dbReplayWait(Db *const this, const String *const targetLsn, const uint32_t targe
             THROW_FMT(DbMismatchError, "standby is on timeline %u but expected %u", dbPgControl(this).timeline, targetTimeline);
     }
     MEM_CONTEXT_TEMP_END();
+
+    FUNCTION_LOG_RETURN_VOID();
+}
+
+/**********************************************************************************************************************************/
+FN_EXTERN void
+dbCheckpoint(Db *const this)
+{
+    FUNCTION_LOG_BEGIN(logLevelDebug);
+        FUNCTION_LOG_PARAM(DB, this);
+    FUNCTION_LOG_END();
+
+    ASSERT(this != NULL);
+
+    dbExec(this, STRDEF("checkpoint"));
 
     FUNCTION_LOG_RETURN_VOID();
 }

--- a/src/db/db.h
+++ b/src/db/db.h
@@ -128,6 +128,9 @@ FN_EXTERN Pack *dbList(Db *this);
 // Waits for replay on the standby to equal the target LSN
 FN_EXTERN void dbReplayWait(Db *this, const String *targetLsn, uint32_t targetTimeline, TimeMSec timeout);
 
+// Checkpoint the cluster
+FN_EXTERN void dbCheckpoint(Db *this);
+
 // Check that the cluster is alive and correctly configured during the backup
 FN_EXTERN void dbPing(Db *const this, bool force);
 

--- a/test/src/common/harnessBackup.c
+++ b/test/src/common/harnessBackup.c
@@ -347,6 +347,8 @@ hrnBackupPqScript(const unsigned int pgVersion, const time_t backupTimeStart, Hr
             else
                 HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_TABLESPACE_LIST_0(1));
 
+            HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_TIME_QUERY(1, (int64_t)backupTimeStart * 1000));
+
             if (!param.fullIncrNoOp)
             {
                 // Wait for standby to sync

--- a/test/src/common/harnessBackup.c
+++ b/test/src/common/harnessBackup.c
@@ -338,6 +338,9 @@ hrnBackupPqScript(const unsigned int pgVersion, const time_t backupTimeStart, Hr
 
         if (backupfullIncr)
         {
+            if (param.startFast)
+                HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_CHECKPOINT(1));
+
             // Tablespace check
             if (tablespace)
                 HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_TABLESPACE_LIST_1(1, 32768, "tblspc32768"));

--- a/test/src/common/harnessBackup.c
+++ b/test/src/common/harnessBackup.c
@@ -338,6 +338,7 @@ hrnBackupPqScript(const unsigned int pgVersion, const time_t backupTimeStart, Hr
 
         if (backupfullIncr)
         {
+            // Checkpoint if start-fast
             if (param.startFast)
                 HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_CHECKPOINT(1));
 
@@ -347,6 +348,7 @@ hrnBackupPqScript(const unsigned int pgVersion, const time_t backupTimeStart, Hr
             else
                 HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_TABLESPACE_LIST_0(1));
 
+            // Time to calculate limit from
             HRN_PQ_SCRIPT_ADD(HRN_PQ_SCRIPT_TIME_QUERY(1, (int64_t)backupTimeStart * 1000));
 
             if (!param.fullIncrNoOp)

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -3987,7 +3987,7 @@ testRun(void)
 
             TEST_RESULT_LOG(
                 "P00   WARN: backup '20191108-080000F' missing manifest removed from backup.info\n"
-                "P00   INFO: full/incr backup preliminary copy of files last modified before 2019-11-08 11:44:40\n"
+                "P00   INFO: full/incr backup preliminary copy of files last modified before 2019-11-08 11:46:40\n"
                 "P00   WARN: resumable backup 20191108-080000F of same type exists -- invalid files will be removed then the backup"
                 " will resume\n"
                 "P00 DETAIL: remove path '" TEST_PATH "/repo/backup/test1/20191108-080000F/bundle' from resumed backup\n"


### PR DESCRIPTION
Two enhancements to improve limit time:

1) If start-fast is enabled then checkpoint before the preliminary copy. This handles cases where checkpoint-timeout is very large and would force the preliminary copy to operate far in the past.

2) Calculate limit time from the current time and move it before the checkpoint only if it would fall after the checkpoint. This results in a more accurate limit time than before.