### PR TITLE
Do not set recovery_target_timeline=current for PostgreSQL < 12.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -1,5 +1,18 @@
 <release date="XXXX-XX-XX" version="2.55dev" title="UNDER DEVELOPMENT">
     <release-core-list>
+        <release-bug-list>
+            <release-item>
+                <github-pull-request id="2533"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Do not set <br-option>recovery_target_timeline=current</br-option> for PostgreSQL &amp;lt; 12.</p>
+            </release-item>
+        </release-bug-list>
+
         <release-improvement-list>
             <release-item>
                 <github-pull-request id="2512"/>

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1575,7 +1575,7 @@ restoreRecoveryOption(const unsigned int pgVersion)
         {
             // Do not set current when PostgreSQL < 12 since this is the default and if current is explicitly set it acts as latest
             if (pgVersion >= PG_VERSION_12 || !strEqZ(cfgOptionStr(cfgOptTargetTimeline), RECOVERY_TARGET_TIMELINE_CURRENT))
-            kvPut(result, VARSTRZ(RECOVERY_TARGET_TIMELINE), VARSTR(cfgOptionStr(cfgOptTargetTimeline)));
+                kvPut(result, VARSTRZ(RECOVERY_TARGET_TIMELINE), VARSTR(cfgOptionStr(cfgOptTargetTimeline)));
         }
         // Else explicitly set target timeline to "current" when type=immediate and PostgreSQL >= 12. We do this because
         // type=immediate means there won't be any actual attempt to change timelines, but if we leave the target timeline as the

--- a/src/command/restore/restore.c
+++ b/src/command/restore/restore.c
@@ -1573,6 +1573,8 @@ restoreRecoveryOption(const unsigned int pgVersion)
         // Write recovery_target_timeline if set
         if (cfgOptionTest(cfgOptTargetTimeline))
         {
+            // Do not set current when PostgreSQL < 12 since this is the default and if current is explicitly set it acts as latest
+            if (pgVersion >= PG_VERSION_12 || !strEqZ(cfgOptionStr(cfgOptTargetTimeline), RECOVERY_TARGET_TIMELINE_CURRENT))
             kvPut(result, VARSTRZ(RECOVERY_TARGET_TIMELINE), VARSTR(cfgOptionStr(cfgOptTargetTimeline)));
         }
         // Else explicitly set target timeline to "current" when type=immediate and PostgreSQL >= 12. We do this because

--- a/test/src/module/command/restoreTest.c
+++ b/test/src/module/command/restoreTest.c
@@ -1821,7 +1821,13 @@ testRun(void)
             restoreRecoveryConf(PG_VERSION_95, restoreLabel),
             RECOVERY_SETTING_HEADER
             "restore_command = 'my_restore_command'\n"
-            "standby_mode = 'on'\n"
+            "standby_mode = 'on'\n",
+            "check recovery options");
+
+        TEST_RESULT_STR_Z(
+            restoreRecoveryConf(PG_VERSION_12, restoreLabel),
+            RECOVERY_SETTING_HEADER
+            "restore_command = 'my_restore_command'\n"
             "recovery_target_timeline = 'current'\n",
             "check recovery options");
 


### PR DESCRIPTION
PostgreSQL < 12 defaults recovery_target_timeline to current but if current is explicitly set it behaves as if latest was set. Since current is not handled in the PostgreSQL code it looks as if there should be an error during the integer conversion but that doesn't happen due to incorrect strtoul() usage (not checking endptr).

Handle this by omitting recovery_target_timeline from recovery.conf when it is explicitly set by the user to current.