### PR TITLE
Fix error reporting for queries with no results.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -16,6 +16,7 @@
                 <github-pull-request id="2539"/>
 
                 <release-item-contributor-list>
+                    <release-item-ideator id="susantha.bathige"/>
                     <release-item-contributor id="david.steele"/>
                     <release-item-reviewer id="stefan.fercot"/>
                 </release-item-contributor-list>

--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -11,6 +11,17 @@
 
                 <p>Do not set <br-option>recovery_target_timeline=current</br-option> for PostgreSQL &amp;lt; 12.</p>
             </release-item>
+
+            <release-item>
+                <github-pull-request id="2539"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Fix error reporting for queries with no results.</p>
+            </release-item>
         </release-bug-list>
 
         <release-improvement-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -1000,6 +1000,10 @@
     <contributor-id type="github">sfrost</contributor-id>
 </contributor>
 
+<contributor id="susantha.bathige">
+    <contributor-name-display>Susantha Bathige</contributor-name-display>
+</contributor>
+
 <contributor id="t.anastacio">
     <contributor-name-display>T.Anastacio</contributor-name-display>
     <contributor-id type="github">Tiago-Anastacio</contributor-id>

--- a/src/postgres/client.c
+++ b/src/postgres/client.c
@@ -243,16 +243,17 @@ pgClientQuery(PgClient *const this, const String *const query, const PgClientQue
             }
             else
             {
-                if (resultType == pgClientQueryResultNone)
-                    THROW_FMT(DbQueryError, "no result expected from '%s'", strZ(query));
-
-                // Expect some rows to be returned
+                // Throw error if no tuples
                 if (resultStatus != PGRES_TUPLES_OK)
                 {
                     THROW_FMT(
                         DbQueryError, "unable to execute query '%s': %s", strZ(query),
                         strZ(strTrim(strNewZ(PQresultErrorMessage(pgResult)))));
                 }
+
+                // Expect some rows to be returned
+                if (resultType == pgClientQueryResultNone)
+                    THROW_FMT(DbQueryError, "no result expected from '%s'", strZ(query));
 
                 // Fetch row and column values
                 PackWrite *const pack = pckWriteNewP();

--- a/src/postgres/client.c
+++ b/src/postgres/client.c
@@ -243,7 +243,7 @@ pgClientQuery(PgClient *const this, const String *const query, const PgClientQue
             }
             else
             {
-                // Throw error if no tuples
+                // If no tuples then the result is an error
                 if (resultStatus != PGRES_TUPLES_OK)
                 {
                     THROW_FMT(


### PR DESCRIPTION
If a query that expected no results returned an error then it would incorrectly report that no results were expected because the error was interpreted as a result.

Switch the order of the checks so that an error is reported instead and add a test to prevent regression.