### PR TITLE
Clarify requirement for local/remote pgBackRest versions to match.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -127,6 +127,17 @@
     <release-doc-list>
         <release-improvement-list>
             <release-item>
+                <github-pull-request id="2541"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="greg.clough"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Clarify requirement for local/remote <backrest/> versions to match.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2538"/>
 
                 <release-item-contributor-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -403,6 +403,11 @@
     <contributor-id type="github">gmustdie</contributor-id>
 </contributor>
 
+<contributor id="greg.clough">
+    <contributor-name-display>Greg Clough</contributor-name-display>
+    <contributor-id type="github">gclough</contributor-id>
+</contributor>
+
 <contributor id="greg.sabino.mullane">
     <contributor-name-display>Greg Sabino Mullane</contributor-name-display>
     <contributor-id type="github">turnstep</contributor-id>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -989,6 +989,17 @@
             <title>Upgrading {[project]} from v2.x to v2.y</title>
 
             <p>Upgrading from <proper>v2.x</proper> to <proper>v2.y</proper> is straight-forward. The repository format has not changed, so for most installations it is simply a matter of installing binaries for the new version. It is also possible to downgrade if you have not used new features that are unsupported by the older version.</p>
+
+            <p>CAUTION: The local and remote software versions must match exactly, and so should be upgraded together. If there is a mismatch, then WAL archiving and backups will not function until that is corrected. In such a case, the below error will be reported:</p>
+
+            <execute skip="y">
+                <exe-cmd>
+                    status: error (other)
+                            [ProtocolError] expected value '2.x' for greeting key 'version' but got '2.y'
+                            HINT: is the same version of pgBackRest installed on the local and remote host?
+                </exe-cmd>
+            </execute>
+
         </section>
     </section>
 

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -990,16 +990,7 @@
 
             <p>Upgrading from <proper>v2.x</proper> to <proper>v2.y</proper> is straight-forward. The repository format has not changed, so for most installations it is simply a matter of installing binaries for the new version. It is also possible to downgrade if you have not used new features that are unsupported by the older version.</p>
 
-            <p>CAUTION: The local and remote software versions must match exactly, and so should be upgraded together. If there is a mismatch, then WAL archiving and backups will not function until that is corrected. In such a case, the below error will be reported:</p>
-
-            <execute skip="y">
-                <exe-cmd>
-                    status: error (other)
-                            [ProtocolError] expected value '2.x' for greeting key 'version' but got '2.y'
-                            HINT: is the same version of pgBackRest installed on the local and remote host?
-                </exe-cmd>
-            </execute>
-
+            <admonition type="important">The local and remote <backrest/> versions must match exactly so they should be upgraded together. If there is a mismatch, WAL archiving and backups will not function until the versions match. In such a case, the following error will be reported: <id>[ProtocolError] expected value '2.x' for greeting key 'version' but got '2.y'</id>.</admonition>
         </section>
     </section>
 


### PR DESCRIPTION
Updates documentation to make to clear that local and remote software versions must match at all times.

Partial fix for #2540