### PR TITLE
Change --process-max recommendation for object stores to --repo-bundle.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -125,6 +125,17 @@
 
                 <p>Caveat <br-setting>--tablespace-map-all</br-setting> regarding tablespace creation.</p>
             </release-item>
+
+            <release-item>
+                <github-pull-request id="2544"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Change <br-setting>--process-max</br-setting> recommendation for object stores to <br-setting>--repo-bundle</br-setting>.</p>
+            </release-item>
         </release-improvement-list>
     </release-doc-list>
 </release>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -720,8 +720,6 @@
             <backrest-config-option section="global" key="repo{[azure-setup-repo-id]}-azure-key">{[azure-key]}</backrest-config-option>
             <backrest-config-option section="global" key="repo{[azure-setup-repo-id]}-azure-container">{[azure-container]}</backrest-config-option>
             <backrest-config-option if="'{[azure-all]}' ne 'y'" section="global" key="repo{[azure-setup-repo-id]}-retention-full">4</backrest-config-option>
-
-            <backrest-config-option section="global" key="process-max">4</backrest-config-option>
         </backrest-config>
 
         <execute-list if="'{[azure-local]}' eq 'y'" host="{[azure-setup-host]}" show="n">
@@ -756,8 +754,6 @@
             <backrest-config-option if="'{[gcs-key-type]}' ne 'service'" section="global" key="repo{[gcs-setup-repo-id]}-gcs-key-type">{[gcs-key-type]}</backrest-config-option>
             <backrest-config-option section="global" key="repo{[gcs-setup-repo-id]}-gcs-key">{[gcs-key]}</backrest-config-option>
             <backrest-config-option section="global" key="repo{[gcs-setup-repo-id]}-gcs-bucket">{[gcs-bucket]}</backrest-config-option>
-
-            <backrest-config-option section="global" key="process-max">4</backrest-config-option>
         </backrest-config>
 
         <p>When running in <proper>GCE</proper> set <br-option>repo{[gcs-setup-repo-id]}-gcs-key-type=auto</br-option> to automatically authenticate using the instance service account.</p>
@@ -778,8 +774,6 @@
             <backrest-config-option section="global" key="repo{[s3-setup-repo-id]}-s3-endpoint">{[s3-endpoint]}</backrest-config-option>
             <backrest-config-option section="global" key="repo{[s3-setup-repo-id]}-s3-region">{[s3-region]}</backrest-config-option>
             <backrest-config-option if="'{[s3-all]}' ne 'y'" section="global" key="repo{[s3-setup-repo-id]}-retention-full">4</backrest-config-option>
-
-            <backrest-config-option section="global" key="process-max">4</backrest-config-option>
         </backrest-config>
 
         <execute-list if="'{[s3-local]}' eq 'y'" host="{[s3-setup-host]}" show="n">
@@ -1419,7 +1413,7 @@
             <list>
                 <list-item><br-option>compress-type</br-option> - determines the compression algorithm used by the <cmd>backup</cmd> and <cmd>archive-push</cmd> commands. The default is <id>gz</id> (Gzip) but <id>zst</id> (Zstandard) is recommended because it is much faster and provides compression similar to <id>gz</id>. <id>zst</id> has been supported by the <br-option>compress-type</br-option> option since <link url="release.html#2.27">v2.27</link>. See <link page="configuration" section="/section-general/option-compress-type">Compress Type</link> for more details.</list-item>
 
-                <list-item><br-option>repo-bundle</br-option> - combines small files during backup to save space and improve the speed of both the <cmd>backup</cmd> and <cmd>restore</cmd> commands, especially on object stores. The <br-option>repo-bundle</br-option> option was introduced in <link url="release.html#2.39">v2.39</link>. See <link section="/backup/bundle">File Bundling</link> for more details.</list-item>
+                <list-item><br-option>repo-bundle</br-option> - combines small files during backup to save space and improve the speed of both the <cmd>backup</cmd> and <cmd>restore</cmd> commands, especially on object stores such as S3. The <br-option>repo-bundle</br-option> option was introduced in <link url="release.html#2.39">v2.39</link>. See <link section="/backup/bundle">File Bundling</link> for more details.</list-item>
 
                 <list-item><br-option>repo-block</br-option> - stores only the portions of of files that have changed rather than the entire file during <id>diff</id>/<id>incr</id> <cmd>backup</cmd>. This saves space and increases the speed of the <cmd>backup</cmd>. The <br-option>repo-block</br-option> option was introduced in <link url="release.html#2.46">v2.46</link> but at least <link url="release.html#2.52.1">v2.52.1</link> is recommended. See <link section="/backup/block">Block Incremental</link> for more details.</list-item>
             </list>
@@ -2435,7 +2429,7 @@
             </execute>
         </execute-list>
 
-        <p>File creation time in object stores is relatively slow so commands benefit by increasing <br-option>process-max</br-option> to parallelize file creation.</p>
+        <p>File creation time in Azure is relatively slow so <cmd>backup</cmd>/<cmd>restore</cmd> performance is improved by enabling <link section="/backup/bundle">file bundling</link>.</p>
 
         <execute-list host="{[host-pg1]}">
             <title>Backup the {[postgres-cluster-demo]} cluster</title>
@@ -2534,7 +2528,7 @@
             </execute>
         </execute-list>
 
-        <p>File creation time in object stores is relatively slow so commands benefit by increasing <br-option>process-max</br-option> to parallelize file creation.</p>
+        <p>File creation time in S3 is relatively slow so <cmd>backup</cmd>/<cmd>restore</cmd> performance is improved by enabling <link section="/backup/bundle">file bundling</link>.</p>
 
         <execute-list host="{[host-pg1]}">
             <title>Backup the {[postgres-cluster-demo]} cluster</title>
@@ -2606,7 +2600,7 @@
 
         <p>Commands are run exactly as if the repository were stored on a local disk.</p>
 
-        <p>File creation time in object stores is relatively slow so commands benefit by increasing <br-option>process-max</br-option> to parallelize file creation.</p>
+        <p>File creation time in GCS is relatively slow so <cmd>backup</cmd>/<cmd>restore</cmd> performance is improved by enabling <link section="/backup/bundle">file bundling</link>.</p>
     </section>
 
     <!-- ======================================================================================================================= -->


### PR DESCRIPTION
While process-max is as useful for object stores as any other storage type, for file creation time in particular file bundling is far more effective since fewer files are created.

Update the recommendation to reflect this.