### PR TITLE
Fix expire archive range logging.

### DIFF
--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -678,8 +678,11 @@ removeExpiredArchive(const InfoBackup *const infoBackup, const bool timeBasedFul
                                     }
 
                                     archiveExpire.total++;
-                                    archiveExpire.start = strDup(walPath);
                                     archiveExpire.stop = strDup(walPath);
+
+                                    // Update start for the first WAL path removed
+                                    if (archiveExpire.start == NULL)
+                                        archiveExpire.start = strDup(walPath);
                                 }
                                 // Else delete individual files instead if the major path is less than or equal to the most recent
                                 // retention backup. This optimization prevents scanning though major paths that could not possibly

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -760,6 +760,8 @@ testRun(void)
         HRN_STORAGE_PUT_EMPTY(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F/" BACKUP_MANIFEST_FILE);
         HRN_STORAGE_PUT_EMPTY(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152900F_20181119-152500I/" BACKUP_MANIFEST_FILE);
 
+        archiveGenerate(storageRepoWrite(), STORAGE_REPO_ARCHIVE, 1, 10, "9.4-1", "0000000100000001");
+
         argList = strLstDup(argListBase);
         hrnCfgArgRawZ(argList, cfgOptRepoRetentionFull, "2");
         hrnCfgArgRawZ(argList, cfgOptRepoRetentionDiff, "3");
@@ -779,7 +781,7 @@ testRun(void)
         TEST_RESULT_LOG(
             "P00   INFO: [DRY-RUN] repo1: expire full backup 20181119-152138F\n"
             "P00   INFO: [DRY-RUN] repo1: remove expired backup 20181119-152138F\n"
-            "P00   INFO: [DRY-RUN] repo1: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000000\n"
+            "P00   INFO: [DRY-RUN] repo1: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000001\n"
             "P00   INFO: [DRY-RUN] repo1: 9.4-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000008\n"
             "P00   INFO: [DRY-RUN] repo1: 10-2 no archive to remove");
 
@@ -831,7 +833,7 @@ testRun(void)
         TEST_RESULT_LOG(
             "P00   INFO: repo2: expire full backup 20181119-152138F\n"
             "P00   INFO: repo2: remove expired backup 20181119-152138F\n"
-            "P00   INFO: repo2: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000000\n"
+            "P00   INFO: repo2: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000001\n"
             "P00   INFO: repo2: 9.4-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000008\n"
             "P00   INFO: repo2: 10-2 no archive to remove");
 
@@ -850,7 +852,7 @@ testRun(void)
         TEST_RESULT_LOG(
             "P00   INFO: repo1: expire full backup 20181119-152138F\n"
             "P00   INFO: repo1: remove expired backup 20181119-152138F\n"
-            "P00   INFO: repo1: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000000\n"
+            "P00   INFO: repo1: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000001\n"
             "P00   INFO: repo1: 9.4-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000008\n"
             "P00   INFO: repo1: 10-2 no archive to remove");
 


### PR DESCRIPTION
The prior logging only output the last path to be removed since start was overwritten as each path was deleted. This had no affect on expire functionality but was confusing since many more files might be expired than the logs indicated.

Fix logging so the correct start path is logged.