### PR TITLE
Add detail logging for expired archive path.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -78,6 +78,21 @@
             </release-item>
 
             <release-item>
+                <commit subject="Add detail logging to expire test."/>
+                <commit subject="Add detail logging for expired archive path.">
+                    <github-issue id="2543"/>
+                    <github-pull-request id="2559"/>
+                </commit>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="stefan.fercot"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Add detail logging for expired archive path.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2472"/>
 
                 <release-item-contributor-list>

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -677,6 +677,10 @@ removeExpiredArchive(const InfoBackup *const infoBackup, const bool timeBasedFul
                                             .recurse = true);
                                     }
 
+                                    LOG_DETAIL_FMT(
+                                        "%s: %s remove archive path %s", cfgOptionGroupName(cfgOptGrpRepo, repoIdx),
+                                        strZ(archiveId), strZ(walPath));
+
                                     archiveExpire.total++;
                                     archiveExpire.stop = strDup(walPath);
 

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -768,6 +768,7 @@ testRun(void)
         hrnCfgArgRawZ(argList, cfgOptRepoRetentionArchive, "2");
         hrnCfgArgRawZ(argList, cfgOptRepoRetentionArchiveType, "diff");
         hrnCfgArgRawBool(argList, cfgOptDryRun, true);
+        harnessLogLevelSet(logLevelDetail);
         HRN_CFG_LOAD(cfgCmdExpire, argList);
 
         TEST_RESULT_VOID(cmdExpire(), "expire (dry-run) do not remove last backup in archive sub path or sub path");
@@ -781,9 +782,22 @@ testRun(void)
         TEST_RESULT_LOG(
             "P00   INFO: [DRY-RUN] repo1: expire full backup 20181119-152138F\n"
             "P00   INFO: [DRY-RUN] repo1: remove expired backup 20181119-152138F\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 archive retention on backup 20181119-152800F, start = 000000020000000000000002,"
+            " stop = 000000020000000000000002\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 archive retention on backup 20181119-152800F_20181119-152152D,"
+            " start = 000000020000000000000004, stop = 000000020000000000000005\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 archive retention on backup 20181119-152800F_20181119-152155I,"
+            " start = 000000020000000000000007, stop = 000000020000000000000007\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 archive retention on backup 20181119-152800F_20181119-152252D,"
+            " start = 000000020000000000000009\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 remove archive path 0000000100000000\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 9.4-1 remove archive path 0000000100000001\n"
             "P00   INFO: [DRY-RUN] repo1: 9.4-1 remove archive, start = 0000000100000000, stop = 0000000100000001\n"
             "P00   INFO: [DRY-RUN] repo1: 9.4-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000008\n"
+            "P00 DETAIL: [DRY-RUN] repo1: 10-2 archive retention on backup 20181119-152900F, start = 000000010000000000000003\n"
             "P00   INFO: [DRY-RUN] repo1: 10-2 no archive to remove");
+
+        harnessLogLevelReset();
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("expire via backup command");


### PR DESCRIPTION
Based on discussion in the [fix expire archive range logging](https://github.com/pgbackrest/pgbackrest/pull/2554#issuecomment-2660997246) PR, as logging each archive expired at DETAIL level would be too much, I propose to add a DETAIL log after each removed/expired path.

Turned on DETAIL log level during the dry-run expire test to see what a DETAIL log level would produce.

This case could be beneficial when a big expire is happening and users tend to think that the expire command gets stuck somehow.