### PR TITLE
Fix block incremental restore issue on non-default repository.

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -2,6 +2,21 @@
     <release-core-list>
         <release-bug-list>
             <release-item>
+                <github-issue id="2577"/>
+                <github-pull-request id="2579"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="aleksander.lukasz"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="david.christensen"/>
+                    <!-- Actually tester, but we don't have a tag for that yet -->
+                    <release-item-reviewer id="aleksander.lukasz"/>
+                </release-item-contributor-list>
+
+                <p>Fix block incremental restore issue on non-default repository.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2533"/>
 
                 <release-item-contributor-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -40,6 +40,11 @@
     <contributor-id type="github">ahmed112212</contributor-id>
 </contributor>
 
+<contributor id="aleksander.lukasz">
+    <contributor-name-display>Aleksander &amp;Lstrok;ukasz</contributor-name-display>
+    <contributor-id type="github">aflukasz</contributor-id>
+</contributor>
+
 <contributor id="aleksandr.rogozin">
     <contributor-name-display>Aleksandr Rogozin</contributor-name-display>
     <contributor-id type="github">arogozin</contributor-id>

--- a/src/command/restore/file.c
+++ b/src/command/restore/file.c
@@ -320,7 +320,7 @@ restoreFile(
                             // Open the super block list for read. Using one read for all super blocks is cheaper than reading from
                             // the file multiple times, which is especially noticeable on object stores.
                             StorageRead *const superBlockRead = storageNewReadP(
-                                storageRepo(),
+                                storageRepoIdx(repoIdx),
                                 backupFileRepoPathP(
                                     strLstGet(referenceList, read->reference), .manifestName = file->manifestFile,
                                     .bundleId = read->bundleId, .blockIncr = true),


### PR DESCRIPTION
If the selected backup to restore was not in the default (lowest number) repository and block incremental was used, then restore would erroneously try to load the file super block list from the default repository. Specifying --repo would fix this since it changed the default repository.

Fix by updating the super block read to the specified repository.