### PR TITLE
Fix missing return in FUNCTION_LOG_RETURN_VOID().

### DIFF
--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -164,6 +164,17 @@
 
                 <p>Improve hex encode performance with bytewise lookup.</p>
             </release-item>
+
+            <release-item>
+                <github-pull-request id="2581"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="yegor.zhmak"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Fix missing <code>return</code> in <code>FUNCTION_LOG_RETURN_VOID()</code>.</p>
+            </release-item>
         </release-development-list>
     </release-core-list>
 

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -339,6 +339,7 @@ Macros to return function results (or void)
         STACK_TRACE_POP(false);                                                                                                    \
                                                                                                                                    \
         LOG(FUNCTION_LOG_LEVEL(), 0, "=> void");                                                                                   \
+        return;                                                                                                                    \
     }                                                                                                                              \
     while (0)
 


### PR DESCRIPTION
I checked: this macro is used only once at the end of all functions, so the missing `return` did not cause issues