### PR TITLE
Add FAQ about exporting self-contained cluster.

### DIFF
--- a/doc/xml/faq.xml
+++ b/doc/xml/faq.xml
@@ -132,15 +132,15 @@ process-max=1
 
     <!-- ======================================================================================================================= -->
     <section id="self-contained-backup">
-        <title>How can I export a self-contained PostgreSQL backup from pgBackRest for use in a network-isolated environment (e.g., via USB)?</title>
+        <title>How can I export a backup for use in a network-isolated environment?</title>
 
         <p><backrest/> uses the repository not only to store backups and WAL archives but also to maintain essential metadata required for features such as compression, encryption, and file bundling. Because of this, simply copying a backup along with a subset of WAL files usually will not work unless very specific and restrictive conditions are met.</p>
 
-        <p>However, there is a workaround if your goal is to create a self-contained export of a database that you can transfer (e.g., via USB). You can take a backup with the <link url="https://pgbackrest.org/command.html#command-backup/category-command/option-archive-copy">--archive-copy</link> option enabled to ensure that the necessary WAL segments are stored along with the backup. Then, restore it using <link url="https://pgbackrest.org/command.html#command-restore/category-command/option-type">--type=none --pg1-path=/your/target/path</link>. This produces a restored PostgreSQL data directory with all required WAL files already placed in <code>pg_wal</code>, similar to what <code>pg_basebackup</code> would create.</p>
+        <p>However, there is a workaround if your goal is to create a self-contained export of a database that you can transfer (e.g., via USB). You can make a backup with the <link url="https://pgbackrest.org/command.html#command-backup/category-command/option-archive-copy">--archive-copy</link> option enabled to ensure that the necessary WAL segments are stored along with the backup. Then, restore it using <link url="https://pgbackrest.org/command.html#command-restore/category-command/option-type">--type=none</link> --pg1-path=/your/target/path. This produces a restored PostgreSQL data directory with all required WAL files already placed in <code>pg_wal</code>, similar to what <file>pg_basebackup</file> would create.</p>
 
-        <p>You can then copy this directory to another system, and <postgres/> should be able to recover from it without needing access to the <backrest/> repository anymore.</p>
+        <p>You can then copy this directory to another system, and <postgres/> should be able to recover from it without needing access to the <backrest/> repository.</p>
 
-        <p>Please note that this is not something we explicitly support, and working with <postgres/> recovery settings does require a certain level of expertise. If you need help tailoring this approach to your specific environment, you may want to consider seeking professional support.</p>
+        <p>Please note that recovering this backup will not result in a timeline switch, which means that this cluster should not push WAL to the original repository that it was exported from. If the new cluster is in a network-isolated environment this should not be a problem.</p>
     </section>
 
     <!-- ======================================================================================================================= -->

--- a/doc/xml/faq.xml
+++ b/doc/xml/faq.xml
@@ -131,6 +131,19 @@ process-max=1
     </section>
 
     <!-- ======================================================================================================================= -->
+    <section id="self-contained-backup">
+        <title>How can I export a self-contained PostgreSQL backup from pgBackRest for use in a network-isolated environment (e.g., via USB)?</title>
+
+        <p><backrest/> uses the repository not only to store backups and WAL archives but also to maintain essential metadata required for features such as compression, encryption, and file bundling. Because of this, simply copying a backup along with a subset of WAL files usually will not work unless very specific and restrictive conditions are met.</p>
+
+        <p>However, there is a workaround if your goal is to create a self-contained export of a database that you can transfer (e.g., via USB). You can take a backup with the <link url="https://pgbackrest.org/command.html#command-backup/category-command/option-archive-copy">--archive-copy</link> option enabled to ensure that the necessary WAL segments are stored along with the backup. Then, restore it using <link url="https://pgbackrest.org/command.html#command-restore/category-command/option-type">--type=none --pg1-path=/your/target/path</link>. This produces a restored PostgreSQL data directory with all required WAL files already placed in <code>pg_wal</code>, similar to what <code>pg_basebackup</code> would create.</p>
+
+        <p>You can then copy this directory to another system, and <postgres/> should be able to recover from it without needing access to the <backrest/> repository anymore.</p>
+
+        <p>Please note that this is not something we explicitly support, and working with <postgres/> recovery settings does require a certain level of expertise. If you need help tailoring this approach to your specific environment, you may want to consider seeking professional support.</p>
+    </section>
+
+    <!-- ======================================================================================================================= -->
     <!-- <section id="different-server">
         <title>How to restore a backup to a different server (for example, a production backup to a development server)?</title>
 

--- a/doc/xml/release/2025/2.55.0.xml
+++ b/doc/xml/release/2025/2.55.0.xml
@@ -310,6 +310,17 @@
             </release-item>
 
             <release-item>
+                <github-pull-request id="2605"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="stefan.fercot"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Add FAQ about exporting self-contained cluster.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2538"/>
 
                 <release-item-contributor-list>


### PR DESCRIPTION
Based on discussion in issue 2602, while we require the repository to efficiently work with pgBackRest, we can generate a restored pgdata (just like what `pg_basebackup` does) for the users to compress/encrypt/copy wherever they want.
