### PR TITLE
Fix lower bounds checking for option keys.

### DIFF
--- a/doc/xml/release/2025/2.56.0.xml
+++ b/doc/xml/release/2025/2.56.0.xml
@@ -9,6 +9,7 @@
                     <release-item-ideator id="wolfgang.walther"/>
                     <release-item-contributor id="david.steele"/>
                     <release-item-reviewer id="david.christensen"/>
+                    <release-item-reviewer id="wolfgang.walther"/>
                 </release-item-contributor-list>
 
                 <p>Fix lower bounds checking for option keys.</p>

--- a/doc/xml/release/2025/2.56.0.xml
+++ b/doc/xml/release/2025/2.56.0.xml
@@ -1,2 +1,18 @@
 <release date="XXXX-XX-XX" version="2.56.0dev" title="UNDER DEVELOPMENT">
+    <release-core-list>
+        <release-bug-list>
+            <release-item>
+                <github-issue id="2610"/>
+                <github-pull-request id="2611"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="wolfgang.walther"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="david.christensen"/>
+                </release-item-contributor-list>
+
+                <p>Fix lower bounds checking for option keys.</p>
+            </release-item>
+        </release-bug-list>
+    </release-core-list>
 </release>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -1181,6 +1181,11 @@
     <contributor-id type="github">mydimension</contributor-id>
 </contributor>
 
+<contributor id="wolfgang.walther">
+    <contributor-name-display>Wolfgang Walther</contributor-name-display>
+    <contributor-id type="github">wolfgangwalther</contributor-id>
+</contributor>
+
 <contributor id="wu.ning">
     <contributor-name-display>Wu Ning</contributor-name-display>
     <contributor-id type="github">50wu</contributor-id>

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -614,7 +614,7 @@ cfgParseOption(const String *const optionCandidate, const CfgParseOptionParam pa
             optionNameSize -= (size_t)(dashPtr - numberPtr);
             memmove(numberPtr, dashPtr, optionNameSize + 1);
 
-            // Check that the index does not exceed the maximum
+            // Check that the index is within bounds
             if (result.keyIdx < 1 || result.keyIdx > CFG_OPTION_KEY_MAX)
             {
                 THROW_FMT(

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -615,10 +615,11 @@ cfgParseOption(const String *const optionCandidate, const CfgParseOptionParam pa
             memmove(numberPtr, dashPtr, optionNameSize + 1);
 
             // Check that the index does not exceed the maximum
-            if (result.keyIdx > CFG_OPTION_KEY_MAX)
+            if (result.keyIdx < 1 || result.keyIdx > CFG_OPTION_KEY_MAX)
             {
                 THROW_FMT(
-                    OptionInvalidError, "option '%s' key exceeds maximum of " STRINGIFY(CFG_OPTION_KEY_MAX), strZ(optionCandidate));
+                    OptionInvalidError, "option '%s' key must be between 1 and " STRINGIFY(CFG_OPTION_KEY_MAX),
+                    strZ(optionCandidate));
             }
 
             // Subtract one to represent a key index

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -831,7 +831,7 @@ testRun(void)
             "option 'pg0-path' key must be between 1 and 256");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error if option great than key max");
+        TEST_TITLE("error if option greater than key max");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -821,14 +821,24 @@ testRun(void)
             "option 'reset-force' cannot be reset");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("error if option exceeds key max");
+        TEST_TITLE("error if option less than key min");
+
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        strLstAddZ(argList, "--pg0-path=/dude");
+        TEST_ERROR(
+            cfgParseP(storageTest, strLstSize(argList), strLstPtr(argList), .noResetLogLevel = true), OptionInvalidError,
+            "option 'pg0-path' key must be between 1 and 256");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("error if option great than key max");
 
         argList = strLstNew();
         strLstAddZ(argList, TEST_BACKREST_EXE);
         strLstAddZ(argList, "--pg257-path");
         TEST_ERROR(
             cfgParseP(storageTest, strLstSize(argList), strLstPtr(argList), .noResetLogLevel = true), OptionInvalidError,
-            "option 'pg257-path' key exceeds maximum of 256");
+            "option 'pg257-path' key must be between 1 and 256");
 
         // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("error if option begins with a number");


### PR DESCRIPTION
Specifying an indexed option with a key of 0, e.g. pg0-path, would lead to a segfault.

Add lower bounds checking to fix the issue.