### PR TITLE
Add x-amz-checksum-sha256 header to S3 requests.

### DIFF
--- a/doc/resource/git-history.cache
+++ b/doc/resource/git-history.cache
@@ -85,7 +85,7 @@
         "commit": "20bfd14b73ad6d75b6fb1169565b18dcfa183c9b",
         "date": "2025-04-09 12:27:27 -0500",
         "subject": "Calculate content-md5 on S3 only when required.",
-        "body": "The content-md5 header was generated for all requests with content but it is only required for batch delete requests. It is not clear why this header is required when x-amz-content-sha256 is also provided or why it\nis required only for this request but the documentation is clear on the matter. However, the content for these requests is relatively small compared to uploading files so omitting content-md5 where possible will\nsave some CPU cycles.\n\nCurrent AWS S3 and recent Minio don't complain if this header is missing but since it is still required by older versions of Minio and it is specified in the documentation for batch delete it is makes sense to\nkeep it."
+        "body": "The content-md5 header was generated for all requests with content but it is only required for batch delete requests. It is not clear why this header is required when x-amz-content-sha256 is also provided or why it is required only for this request but the documentation is clear on the matter. However, the content for these requests is relatively small compared to uploading files so omitting content-md5 where possible will\nsave some CPU cycles.\n\nCurrent AWS S3 and recent Minio don't complain if this header is missing but since it is still required by older versions of Minio and it is specified in the documentation for batch delete it is makes sense to\nkeep it."
     },
     {
         "commit": "c925832e1737f1b5cac347c482a725a87f2237cb",

--- a/src/storage/s3/storage.c
+++ b/src/storage/s3/storage.c
@@ -476,8 +476,9 @@ storageS3RequestAsync(StorageS3 *const this, const String *const verb, const Str
             param.content == NULL || bufEmpty(param.content) ? ZERO_STR : strNewFmt("%zu", bufUsed(param.content)));
 
         // Calculate x-amz-checksum-sha256 header (will also be used for authentication)
-        const Buffer *const contentSha256 = param.content == NULL || bufEmpty(param.content) ?
-            HASH_TYPE_SHA256_ZERO_BUF : cryptoHashOne(hashTypeSha256, param.content);
+        const Buffer *const contentSha256 =
+            param.content == NULL || bufEmpty(param.content) ?
+                HASH_TYPE_SHA256_ZERO_BUF : cryptoHashOne(hashTypeSha256, param.content);
 
         if (param.content != NULL)
             httpHeaderAdd(requestHeader, S3_HEADER_CHECKSUM_SHA256_STR, strNewEncode(encodingBase64, contentSha256));

--- a/test/src/module/storage/s3Test.c
+++ b/test/src/module/storage/s3Test.c
@@ -134,8 +134,8 @@ testRequest(IoWrite *write, Storage *s3, const char *verb, const char *path, Tes
     if (s3 != NULL)
     {
         // Add sha256
-        const Buffer *const contentSha256 = param.content == NULL ?
-            HASH_TYPE_SHA256_ZERO_BUF : cryptoHashOne(hashTypeSha256, BUFSTRZ(param.content));
+        const Buffer *const contentSha256 =
+            param.content == NULL ? HASH_TYPE_SHA256_ZERO_BUF : cryptoHashOne(hashTypeSha256, BUFSTRZ(param.content));
 
         if (param.content != NULL)
             strCatFmt(request, "x-amz-checksum-sha256:%s\r\n", strZ(strNewEncode(encodingBase64, contentSha256)));


### PR DESCRIPTION
The x-amz-checksum-sha256 header is required in place of content-md5 (which was removed in 20bfd14b) for PUT when object lock is enabled. I confused x-amz-content-sha256 (which we already have) with x-amz-checksum-sha256 (which we now need) when writing the patch.

Determining if object lock is enabled may not be compatible across S3 clones, so just add the header to all requests with content. Since SHA-256 is already calculated for authentication this will not add overhead other than encoding the header in base64 (instead of the hex required for authentication).

However, this is not going to help clones that do not accept x-amz-checksum-sha256 and still require content-md5.