### PR TITLE
Fix "less than" in help output for archive-mode option.

### DIFF
--- a/doc/xml/release/2025/2.56.0.xml
+++ b/doc/xml/release/2025/2.56.0.xml
@@ -14,4 +14,19 @@
             </release-item>
         </release-improvement-list>
     </release-core-list>
+
+    <release-doc-list>
+        <release-improvement-list>
+            <release-item>
+                <github-pull-request id="2633"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="anton.kurochkin"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Fix <quote>less than</quote> in help output for <br-setting>archive-mode</br-setting> option.</p>
+            </release-item>
+        </release-improvement-list>
+    </release-doc-list>
 </release>

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1614,7 +1614,7 @@
                                 <list-item><id>preserve</id> - preserve current <setting>archive_mode</setting> setting.</list-item>
                             </list>
 
-                            <p><b>NOTE</b>: This option is not available on <postgres/> &amp;lt; 12.</p>
+                            <p><b>NOTE</b>: This option is not available on <postgres/> &lt; 12.</p>
                         </text>
 
                         <example>off</example>


### PR DESCRIPTION
A small fix for displaying the `<` symbol in help output  for archive-mode option.

Help output before:
```bash
$ pgbackrest help  restore archive-mode 
pgBackRest 2.55.1 - 'restore' command - 'archive-mode' option help

...

NOTE: This option is not available on PostgreSQL &lt; 12.
```

After:
```bash
$ pgbackrest help  restore archive-mode
pgBackRest 2.56.0dev - 'restore' command - 'archive-mode' option help
...

NOTE: This option is not available on PostgreSQL < 12.

```
