### PR TITLE
Fix crash during checksum error warning

### DIFF
--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1569,7 +1569,7 @@ backupJobResult(
                                 }
 
                                 // Make message plural when appropriate
-                                const String *const plural = errorTotalMin > 1 ? STRDEF("s") : EMPTY_STR;
+                                const String *const plural = errorTotalMin > 1 ? strNewZ("s") : EMPTY_STR;
 
                                 // ??? Update formatting after migration
                                 LOG_WARN_FMT(


### PR DESCRIPTION
The STRDEF definition of plural is out of scope in the log message just below it, which leads to either garbage in the log message or a crash with SIGSEGV.

This is particularly visible with pg_tde, which encrypts tables: if pgbackrest is run with checksum enabled, it tries to emit this message for all encrypted files.