### PR TITLE
Remove unused backtrace-supported.h include.

### DIFF
--- a/src/common/stackTrace.c
+++ b/src/common/stackTrace.c
@@ -8,7 +8,6 @@ Stack Trace Handler
 #include <string.h>
 
 #ifdef HAVE_LIBBACKTRACE
-    #include <backtrace-supported.h>
     #include <backtrace.h>
 #endif
 


### PR DESCRIPTION
The "backtrace-supported.h" header is not used in the code and all functionality works through backtrace.h.
Our sanitizer can't find this file :)
