### PR TITLE
expire: fix inconsistent dry-run guard in expireAdhocBackup

### DIFF
--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -149,7 +149,7 @@ expireAdhocBackup(InfoBackup *const infoBackup, const String *const backupLabel,
                 cfgOptionGroupName(cfgOptGrpRepo, repoIdx), strZ(latestBackup),
                 cfgOptionIdxName(cfgOptRepoRetentionArchive, repoIdx), cfgOptionIdxName(cfgOptRepoRetentionArchiveType, repoIdx));
 
-            // Adhoc expire is never performed through backup command so only check to determine if dry-run has been set or not
+
             if (!cfgOptionValid(cfgOptDryRun) || !cfgOptionBool(cfgOptDryRun))
                 backupLinkLatest(infoBackupData(infoBackup, infoBackupDataTotal(infoBackup) - 1).backupLabel, repoIdx);
         }

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -150,7 +150,7 @@ expireAdhocBackup(InfoBackup *const infoBackup, const String *const backupLabel,
                 cfgOptionIdxName(cfgOptRepoRetentionArchive, repoIdx), cfgOptionIdxName(cfgOptRepoRetentionArchiveType, repoIdx));
 
             // Adhoc expire is never performed through backup command so only check to determine if dry-run has been set or not
-            if (!cfgOptionBool(cfgOptDryRun))
+            if (!cfgOptionValid(cfgOptDryRun) || !cfgOptionBool(cfgOptDryRun))
                 backupLinkLatest(infoBackupData(infoBackup, infoBackupDataTotal(infoBackup) - 1).backupLabel, repoIdx);
         }
 


### PR DESCRIPTION
expire: fix inconsistent dry-run guard in expireAdhocBackup

All other dry-run checks in this file use:

    if (!cfgOptionValid(cfgOptDryRun) || !cfgOptionBool(cfgOptDryRun))

to guard against calling cfgOptionBool() when the option is not valid in the current command context. The guard in expireAdhocBackup skips the cfgOptionValid() check, meaning backupLinkLatest() could be called during a dry-run if cfgOptDryRun is not a valid option and cfgOptionBool() returns an unexpected default.

Please read [Submitting a Pull Request](https://github.com/pgbackrest/pgbackrest/blob/main/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
