### PR TITLE
Skip older files faster

### DIFF
--- a/src/build/config/config.yaml
+++ b/src/build/config/config.yaml
@@ -1872,6 +1872,21 @@ option:
     default: 2MiB
     allow-range: [8KiB, 1PiB]
 
+  repo-bundle-stable-age:
+    section: global
+    group: repo
+    type: integer
+    default: 0
+    allow-range: [0, 1825]
+    command:
+      backup: {}
+    command-role:
+      main: {}
+    depend:
+      option: repo-bundle
+      list:
+        - true
+
   repo-block:
     section: global
     group: repo

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -699,6 +699,20 @@
                         <example>10MiB</example>
                     </config-key>
 
+                    <config-key id="repo-bundle-stable-age" name="Repository Bundle Stable Age">
+                        <summary>Age in days above which files are considered stable for bundling.</summary>
+
+                        <text>
+                            <p>When sorting files for bundle assignment, files whose modification time is at least this many days in the past are treated as stable and are not sorted by timestamp. They are still placed in bundles, but in the order they were discovered during the manifest walk (which is directory order). Files newer than this threshold are still sorted by timestamp descending so that "recent" files cluster together in the same bundles -- preserving the restore-time read locality benefit of the original sort.</p>
+
+                            <p>This optimization is significant when the cluster has millions of small files of which most are old/stable and only a small fraction were recently modified. Sorting then runs only over the recent fraction instead of the whole manifest.</p>
+
+                            <p>The default is <setting>0</setting>, which disables the partition: all files are sorted by timestamp as in the original behavior. Set to a positive value, e.g. <setting>90</setting>, to enable the partition for files whose modification time is older than that many days.</p>
+                        </text>
+
+                        <example>90</example>
+                    </config-key>
+
                     <config-key id="repo-gcs-bucket" name="GCS Repository Bucket">
                         <summary>GCS repository bucket.</summary>
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1717,8 +1717,27 @@ backupProcessFilePrimary(RegExp *const standbyExp, const String *const name)
         BOOL, strEqZ(name, MANIFEST_TARGET_PGDATA "/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL) || !regExpMatch(standbyExp, name));
 }
 
-// Comparator to order ManifestFile objects by size, date, and name
-static const Manifest *backupProcessQueueComparatorManifest = NULL;
+// Per-file queue item carrying the keys needed for sorting and binning so the comparator (called O(N log N) times) does not have
+// to call manifestFileUnpack(), which deserializes the pack header. Each item also remembers its source file pack so the dispatcher
+// can still produce the full job param from it.
+typedef struct BackupQueueItem
+{
+    uint64_t size;                                                  // file.size (sort key, bundle accumulator)
+    time_t timestamp;                                               // file.timestamp (sort key for small files when bundling)
+    const String *name;                                             // file.name (tie-break + dispatch)
+    const ManifestFilePack *filePack;                               // Source pack, unpacked once at dispatch time
+} BackupQueueItem;
+
+// One dispatchable unit produced by the pre-bin pass. For a non-bundle job (bundleId == 0) the descriptor holds exactly one file
+// pack; for a bundle it holds the full set of file packs that share a bundleId, in dispatch order. Built once during
+// backupProcessQueue so the dispatcher does no fit-checking or bundle-id bookkeeping.
+typedef struct BackupJobDescriptor
+{
+    uint64_t bundleId;                                              // 0 = standalone (one-file job), >0 = bundled
+    List *fileList;                                                 // List of const ManifestFilePack * (>=1 entry)
+} BackupJobDescriptor;
+
+// Comparator over BackupQueueItem. Reads scalars directly -- no manifestFileUnpack() in the hot path.
 static bool backupProcessQueueComparatorBundle;
 static uint64_t backupProcessQueueComparatorBundleLimit;
 
@@ -1733,31 +1752,142 @@ backupProcessQueueComparator(const void *const item1, const void *const item2)
     ASSERT(item1 != NULL);
     ASSERT(item2 != NULL);
 
-    // Unpack files
-    const ManifestFile file1 = manifestFileUnpack(backupProcessQueueComparatorManifest, *(const ManifestFilePack *const *)item1);
-    const ManifestFile file2 = manifestFileUnpack(backupProcessQueueComparatorManifest, *(const ManifestFilePack *const *)item2);
+    const BackupQueueItem *const a = item1;
+    const BackupQueueItem *const b = item2;
 
     // If the size differs then that's enough to determine order
-    if (!backupProcessQueueComparatorBundle || file1.size > backupProcessQueueComparatorBundleLimit ||
-        file2.size > backupProcessQueueComparatorBundleLimit)
+    if (!backupProcessQueueComparatorBundle || a->size > backupProcessQueueComparatorBundleLimit ||
+        b->size > backupProcessQueueComparatorBundleLimit)
     {
-        if (file1.size < file2.size)
+        if (a->size < b->size)
             FUNCTION_TEST_RETURN(INT, 1);
-        else if (file1.size > file2.size)
+        else if (a->size > b->size)
             FUNCTION_TEST_RETURN(INT, -1);
     }
 
     // If bundling order by time desc so that older files are bundled with older files and newer with newer
     if (backupProcessQueueComparatorBundle)
     {
-        if (file1.timestamp > file2.timestamp)
+        if (a->timestamp > b->timestamp)
             FUNCTION_TEST_RETURN(INT, 1);
-        else if (file1.timestamp < file2.timestamp)
+        else if (a->timestamp < b->timestamp)
             FUNCTION_TEST_RETURN(INT, -1);
     }
 
     // If size/time is the same then use name to generate a deterministic ordering (names must be unique)
-    FUNCTION_TEST_RETURN(INT, strCmp(file2.name, file1.name));
+    FUNCTION_TEST_RETURN(INT, strCmp(b->name, a->name));
+}
+
+// Walk a sorted per-target queue of BackupQueueItem and produce a list of BackupJobDescriptor (one entry per dispatchable job).
+// Mirrors the prior in-dispatcher behavior: files larger than bundleLimit become standalone single-file jobs; smaller files are
+// greedily packed into bundles up to bundleSize, with a forward-skip pass within each bundle so a later (smaller) file can fill
+// remaining capacity if the next candidate would overflow.
+//
+// The descriptor list inherits the input list's order for standalone files and for the first file of each bundle, so the
+// dispatcher's queue rotation behavior is unchanged.
+static List *
+backupProcessQueueBin(const List *const sortedQueue, BackupJobData *const jobData, MemContext *const memContext)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(LIST, sortedQueue);
+        FUNCTION_TEST_PARAM_P(VOID, jobData);
+        FUNCTION_TEST_PARAM(MEM_CONTEXT, memContext);
+    FUNCTION_TEST_END();
+
+    ASSERT(sortedQueue != NULL);
+    ASSERT(jobData != NULL);
+    ASSERT(memContext != NULL);
+
+    List *result;
+
+    MEM_CONTEXT_BEGIN(memContext)
+    {
+        result = lstNewP(sizeof(BackupJobDescriptor));
+    }
+    MEM_CONTEXT_END();
+
+    const unsigned int queueSize = lstSize(sortedQueue);
+    bool *const taken = memNew(queueSize * sizeof(bool));
+    memset(taken, 0, queueSize * sizeof(bool));
+
+    unsigned int unbinnedStart = 0;
+    unsigned int unbinnedCount = queueSize;
+
+    while (unbinnedCount > 0)
+    {
+        // Advance unbinnedStart over already-taken entries
+        while (unbinnedStart < queueSize && taken[unbinnedStart])
+            unbinnedStart++;
+
+        ASSERT(unbinnedStart < queueSize);
+
+        const BackupQueueItem *const headItem = lstGet(sortedQueue, unbinnedStart);
+
+        // Decide whether this first file is standalone or bundled
+        const bool bundled = jobData->bundle && headItem->size <= jobData->bundleLimit;
+
+        BackupJobDescriptor descriptor = {.bundleId = 0};
+
+        MEM_CONTEXT_BEGIN(lstMemContext(result))
+        {
+            descriptor.fileList = lstNewP(sizeof(const ManifestFilePack *));
+        }
+        MEM_CONTEXT_END();
+
+        if (bundled)
+            descriptor.bundleId = jobData->bundleId++;
+
+        // Always take the head file
+        lstAdd(descriptor.fileList, &headItem->filePack);
+        uint64_t bundleSize = headItem->size;
+        taken[unbinnedStart] = true;
+        unbinnedCount--;
+
+        // For bundled jobs, keep packing in forward order with forward-skip on overflow until capacity is reached or no more
+        // small-enough files remain. Standalone descriptors carry exactly one file.
+        if (bundled)
+        {
+            unsigned int scanIdx = unbinnedStart + 1;
+
+            while (bundleSize < jobData->bundleSize && scanIdx < queueSize)
+            {
+                if (taken[scanIdx])
+                {
+                    scanIdx++;
+                    continue;
+                }
+
+                const BackupQueueItem *const item = lstGet(sortedQueue, scanIdx);
+
+                // Skip files that no longer qualify for bundling (size grew past the limit -- shouldn't happen since the sort puts
+                // those at the front and the head already passed the test, but be defensive)
+                if (item->size > jobData->bundleLimit)
+                {
+                    scanIdx++;
+                    continue;
+                }
+
+                // Forward-skip if this file would overflow the bundle -- a later (smaller) file may still fit
+                if (bundleSize + item->size >= jobData->bundleSize)
+                {
+                    scanIdx++;
+                    continue;
+                }
+
+                lstAdd(descriptor.fileList, &item->filePack);
+                bundleSize += item->size;
+                taken[scanIdx] = true;
+                unbinnedCount--;
+                scanIdx++;
+            }
+        }
+
+        lstAdd(result, &descriptor);
+    }
+
+    memFree(taken);
+
+    FUNCTION_TEST_RETURN(LIST, result);
 }
 
 // Helper to generate the backup queues
@@ -1776,10 +1906,19 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
 
     uint64_t result = 0;
 
+    // The descriptor list (final shape consumed by the dispatcher) is allocated in the caller's context so it survives the temp
+    // block below. Sort lists (BackupQueueItem) live inside the temp block and are discarded once their bundles are produced.
+    MemContext *const queueListMemContext = memContextCurrent();
+
     MEM_CONTEXT_TEMP_BEGIN()
     {
-        // Create list of process queues (use void * instead of List * to avoid Coverity false positive)
-        jobData->queueList = lstNewP(sizeof(void *));
+        // Create list of process queues. Each entry holds a List of BackupJobDescriptor produced by backupProcessQueueBin() after
+        // sorting. (use void * instead of List * to avoid Coverity false positive)
+        MEM_CONTEXT_BEGIN(queueListMemContext)
+        {
+            jobData->queueList = lstNewP(sizeof(void *));
+        }
+        MEM_CONTEXT_END();
 
         // Generate the list of targets
         StringList *const targetList = strLstNew();
@@ -1793,20 +1932,17 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
                 strLstAddFmt(targetList, "%s/", strZ(target->name));
         }
 
-        // Generate the processing queues (there is always at least one)
+        // Generate one sort list (BackupQueueItem) per target. There is always at least one. These are temp-scoped -- only the
+        // post-bin descriptor lists are kept around.
         const unsigned int queueOffset = jobData->backupStandby ? 1 : 0;
+        const unsigned int queueCount = strLstSize(targetList) + queueOffset;
 
-        MEM_CONTEXT_BEGIN(lstMemContext(jobData->queueList))
-        {
-            for (unsigned int queueIdx = 0; queueIdx < strLstSize(targetList) + queueOffset; queueIdx++)
-            {
-                List *const queue = lstNewP(sizeof(ManifestFile *), .comparator = backupProcessQueueComparator);
-                lstAdd(jobData->queueList, &queue);
-            }
-        }
-        MEM_CONTEXT_END();
+        List **const sortList = memNew(queueCount * sizeof(List *));
 
-        // Now put all files into the processing queues
+        for (unsigned int queueIdx = 0; queueIdx < queueCount; queueIdx++)
+            sortList[queueIdx] = lstNewP(sizeof(BackupQueueItem), .comparator = backupProcessQueueComparator);
+
+        // Now put all files into the sort lists
         uint64_t fileTotal = 0;
         bool pgControlFound = false;
 
@@ -1832,10 +1968,19 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
             if (strEq(file.name, STRDEF(MANIFEST_TARGET_PGDATA "/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)))
                 pgControlFound = true;
 
+            // Cache the keys needed for sorting/binning so the comparator does not unpack the manifest pack on every compare
+            const BackupQueueItem item =
+            {
+                .size = file.size,
+                .timestamp = file.timestamp,
+                .name = file.name,
+                .filePack = filePack,
+            };
+
             // Files that must be copied from the primary are always put in queue 0 when backup from standby
             if (jobData->backupStandby && backupProcessFilePrimary(jobData->standbyExp, file.name))
             {
-                lstAdd(*(List **)lstGet(jobData->queueList, 0), &filePack);
+                lstAdd(sortList[0], &item);
             }
             // Else find the correct queue by matching the file to a target
             else
@@ -1855,7 +2000,7 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
                 while (1);
 
                 // Add file to queue
-                lstAdd(*(List **)lstGet(jobData->queueList, targetIdx + queueOffset), &filePack);
+                lstAdd(sortList[targetIdx + queueOffset], &item);
             }
 
             // Add size to total
@@ -1879,16 +2024,22 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
         if (fileTotal == 0)
             THROW(FileMissingError, "no files have changed since the last backup - this seems unlikely");
 
-        // Sort the queues
-        backupProcessQueueComparatorManifest = manifest;
+        // Sort each per-target queue and immediately bin it into a descriptor list. Bundle ids are assigned monotonically across
+        // queues via jobData->bundleId so the wire format stays unique.
         backupProcessQueueComparatorBundle = jobData->bundle;
         backupProcessQueueComparatorBundleLimit = jobData->bundleLimit;
 
-        for (unsigned int queueIdx = 0; queueIdx < lstSize(jobData->queueList); queueIdx++)
-            lstSort(*(List **)lstGet(jobData->queueList, queueIdx), sortOrderAsc);
+        MEM_CONTEXT_BEGIN(lstMemContext(jobData->queueList))
+        {
+            for (unsigned int queueIdx = 0; queueIdx < queueCount; queueIdx++)
+            {
+                lstSort(sortList[queueIdx], sortOrderAsc);
 
-        // Move process queues to prior context
-        lstMove(jobData->queueList, memContextPrior());
+                List *const descriptorList = backupProcessQueueBin(sortList[queueIdx], jobData, lstMemContext(jobData->queueList));
+                lstAdd(jobData->queueList, &descriptorList);
+            }
+        }
+        MEM_CONTEXT_END();
     }
     MEM_CONTEXT_TEMP_END();
 
@@ -1950,120 +2101,118 @@ backupJobCallback(void *const data, const unsigned int clientIdx)
         do
         {
             List *const queue = *(List **)lstGet(jobData->queueList, (unsigned int)queueIdx + queueOffset);
-            unsigned int fileIdx = 0;
-            bool bundle = jobData->bundle;
-            const String *fileName = NULL;
 
-            while (fileIdx < lstSize(queue))
+            if (lstSize(queue) > 0)
             {
-                const ManifestFile file = manifestFileUnpack(jobData->manifest, *(ManifestFilePack **)lstGet(queue, fileIdx));
+                // Pop the next pre-built descriptor. backupProcessQueueBin() already decided what each job contains.
+                const BackupJobDescriptor *const descriptor = lstGet(queue, 0);
+                const bool bundle = descriptor->bundleId != 0;
+                const String *fileName = NULL;
 
-                // Continue if the next file would make the bundle too large. There may be a smaller one that will fit.
-                if (fileTotal > 0 && fileSize + file.size >= jobData->bundleSize)
+                ASSERT(lstSize(descriptor->fileList) > 0);
+                ASSERT(bundle || lstSize(descriptor->fileList) == 1);
+
+                param = protocolPackNew();
+
+                // Write the per-job header from the first file
+                const ManifestFile firstFile = manifestFileUnpack(
+                    jobData->manifest, *(const ManifestFilePack *const *)lstGet(descriptor->fileList, 0));
+                const bool blockIncrFirst = jobData->blockIncr && firstFile.blockIncrSize > 0;
+
+                if (bundle)
                 {
-                    fileIdx++;
-                    continue;
-                }
-
-                // Is this file a block incremental?
-                const bool blockIncr = jobData->blockIncr && file.blockIncrSize > 0;
-
-                // Add common parameters before first file
-                if (param == NULL)
-                {
-                    param = protocolPackNew();
-
-                    if (bundle && file.size <= jobData->bundleLimit)
-                    {
-                        pckWriteStrP(param, backupFileRepoPathP(jobData->backupLabel, .bundleId = jobData->bundleId));
-                        pckWriteU64P(param, jobData->bundleId);
-                        pckWriteBoolP(param, manifestData(jobData->manifest)->bundleRaw);
-                    }
-                    else
-                    {
-                        CHECK(AssertError, fileTotal == 0, "cannot bundle file");
-
-                        pckWriteStrP(
-                            param,
-                            backupFileRepoPathP(
-                                jobData->backupLabel, .manifestName = file.name, .compressType = jobData->compressType,
-                                .blockIncr = blockIncr));
-                        pckWriteU64P(param, 0);
-
-                        fileName = file.name;
-                        bundle = false;
-                    }
-
-                    // Provide the backup reference
-                    pckWriteU64P(param, strLstSize(manifestReferenceList(jobData->manifest)) - 1);
-
-                    pckWriteU32P(param, jobData->compressType);
-                    pckWriteI32P(param, jobData->compressLevel);
-                    pckWriteU64P(param, jobData->cipherSubPass == NULL ? cipherTypeNone : cipherTypeAes256Cbc);
-                    pckWriteStrP(param, jobData->cipherSubPass);
-                    pckWriteU32P(param, jobData->pageSize);
-                    pckWriteStrP(param, cfgOptionStrNull(cfgOptPgVersionForce));
-                }
-
-                pckWriteStrP(param, manifestPathPg(file.name));
-                pckWriteBoolP(param, file.delta);
-                pckWriteBoolP(param, !strEq(file.name, STRDEF(MANIFEST_TARGET_PGDATA "/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)));
-                pckWriteU64P(param, file.size);
-                pckWriteU64P(param, file.sizeOriginal);
-                pckWriteBoolP(param, !backupProcessFilePrimary(jobData->standbyExp, file.name));
-                pckWriteBinP(param, file.checksumSha1 != NULL ? BUF(file.checksumSha1, HASH_TYPE_SHA1_SIZE) : NULL);
-                pckWriteBoolP(param, file.checksumPage);
-                pckWriteBoolP(param, cfgOptionBool(cfgOptPageHeaderCheck));
-
-                // If block incremental then provide the location of the prior map when available
-                if (blockIncr)
-                {
-                    pckWriteU64P(param, file.blockIncrSize);
-                    pckWriteU64P(param, file.blockIncrChecksumSize);
-                    pckWriteU64P(param, jobData->blockIncrSizeSuper);
-
-                    if (file.blockIncrMapSize != 0 && !file.resume)
-                    {
-                        pckWriteStrP(
-                            param,
-                            backupFileRepoPathP(
-                                file.reference, .manifestName = file.name, .bundleId = file.bundleId, .blockIncr = true));
-                        pckWriteU64P(param, file.bundleOffset + file.sizeRepo - file.blockIncrMapSize);
-                        pckWriteU64P(param, file.blockIncrMapSize);
-                    }
-                    else
-                        pckWriteNullP(param);
+                    pckWriteStrP(param, backupFileRepoPathP(jobData->backupLabel, .bundleId = descriptor->bundleId));
+                    pckWriteU64P(param, descriptor->bundleId);
+                    pckWriteBoolP(param, manifestData(jobData->manifest)->bundleRaw);
                 }
                 else
+                {
+                    pckWriteStrP(
+                        param,
+                        backupFileRepoPathP(
+                            jobData->backupLabel, .manifestName = firstFile.name, .compressType = jobData->compressType,
+                            .blockIncr = blockIncrFirst));
                     pckWriteU64P(param, 0);
 
-                pckWriteStrP(param, file.name);
-                pckWriteBinP(param, file.checksumRepoSha1 != NULL ? BUF(file.checksumRepoSha1, HASH_TYPE_SHA1_SIZE) : NULL);
-                pckWriteU64P(param, file.sizeRepo);
-                pckWriteBoolP(param, file.resume);
-                pckWriteBoolP(param, file.reference != NULL);
+                    fileName = firstFile.name;
+                }
 
-                fileTotal++;
-                fileSize += file.sizeOriginal;
+                // Provide the backup reference
+                pckWriteU64P(param, strLstSize(manifestReferenceList(jobData->manifest)) - 1);
 
-                // Remove job from the queue
-                lstRemoveIdx(queue, fileIdx);
+                pckWriteU32P(param, jobData->compressType);
+                pckWriteI32P(param, jobData->compressLevel);
+                pckWriteU64P(param, jobData->cipherSubPass == NULL ? cipherTypeNone : cipherTypeAes256Cbc);
+                pckWriteStrP(param, jobData->cipherSubPass);
+                pckWriteU32P(param, jobData->pageSize);
+                pckWriteStrP(param, cfgOptionStrNull(cfgOptPgVersionForce));
 
-                // Break if not bundling or bundle size has been reached
-                if (!bundle || fileSize >= jobData->bundleSize)
-                    break;
-            }
+                // Per-file params. The first file's unpack is reused; subsequent files are unpacked once each.
+                for (unsigned int fileIdx = 0; fileIdx < lstSize(descriptor->fileList); fileIdx++)
+                {
+                    const ManifestFile file =
+                        fileIdx == 0
+                            ? firstFile
+                            : manifestFileUnpack(
+                                jobData->manifest, *(const ManifestFilePack *const *)lstGet(descriptor->fileList, fileIdx));
 
-            if (fileTotal > 0)
-            {
-                // Assign job to result
+                    const bool blockIncr = jobData->blockIncr && file.blockIncrSize > 0;
+
+                    pckWriteStrP(param, manifestPathPg(file.name));
+                    pckWriteBoolP(param, file.delta);
+                    pckWriteBoolP(
+                        param, !strEq(file.name, STRDEF(MANIFEST_TARGET_PGDATA "/" PG_PATH_GLOBAL "/" PG_FILE_PGCONTROL)));
+                    pckWriteU64P(param, file.size);
+                    pckWriteU64P(param, file.sizeOriginal);
+                    pckWriteBoolP(param, !backupProcessFilePrimary(jobData->standbyExp, file.name));
+                    pckWriteBinP(param, file.checksumSha1 != NULL ? BUF(file.checksumSha1, HASH_TYPE_SHA1_SIZE) : NULL);
+                    pckWriteBoolP(param, file.checksumPage);
+                    pckWriteBoolP(param, cfgOptionBool(cfgOptPageHeaderCheck));
+
+                    // If block incremental then provide the location of the prior map when available
+                    if (blockIncr)
+                    {
+                        pckWriteU64P(param, file.blockIncrSize);
+                        pckWriteU64P(param, file.blockIncrChecksumSize);
+                        pckWriteU64P(param, jobData->blockIncrSizeSuper);
+
+                        if (file.blockIncrMapSize != 0 && !file.resume)
+                        {
+                            pckWriteStrP(
+                                param,
+                                backupFileRepoPathP(
+                                    file.reference, .manifestName = file.name, .bundleId = file.bundleId, .blockIncr = true));
+                            pckWriteU64P(param, file.bundleOffset + file.sizeRepo - file.blockIncrMapSize);
+                            pckWriteU64P(param, file.blockIncrMapSize);
+                        }
+                        else
+                            pckWriteNullP(param);
+                    }
+                    else
+                        pckWriteU64P(param, 0);
+
+                    pckWriteStrP(param, file.name);
+                    pckWriteBinP(param, file.checksumRepoSha1 != NULL ? BUF(file.checksumRepoSha1, HASH_TYPE_SHA1_SIZE) : NULL);
+                    pckWriteU64P(param, file.sizeRepo);
+                    pckWriteBoolP(param, file.resume);
+                    pckWriteBoolP(param, file.reference != NULL);
+
+                    fileTotal++;
+                    fileSize += file.sizeOriginal;
+                }
+
+                // Pop the descriptor now that we have built the job from it
+                lstRemoveIdx(queue, 0);
+
+                // Track the highest bundle id we've actually dispatched so jobData->bundleId still advances monotonically for any
+                // future allocator that reads it (no current caller does, but the contract is preserved).
+                if (bundle && descriptor->bundleId >= jobData->bundleId)
+                    jobData->bundleId = descriptor->bundleId + 1;
+
                 MEM_CONTEXT_PRIOR_BEGIN()
                 {
                     result = protocolParallelJobNew(
-                        bundle ? VARUINT64(jobData->bundleId) : VARSTR(fileName), PROTOCOL_COMMAND_BACKUP_FILE, param);
-
-                    if (bundle)
-                        jobData->bundleId++;
+                        bundle ? VARUINT64(descriptor->bundleId) : VARSTR(fileName), PROTOCOL_COMMAND_BACKUP_FILE, param);
                 }
                 MEM_CONTEXT_PRIOR_END();
 

--- a/src/command/backup/backup.c
+++ b/src/command/backup/backup.c
@@ -1695,6 +1695,8 @@ typedef struct BackupJobData
     uint64_t bundleSize;                                            // Target bundle size
     uint64_t bundleLimit;                                           // Limit on files to bundle
     uint64_t bundleId;                                              // Bundle id
+    time_t bundleStableMtime;                                       // Files with timestamp < this are "old" and skip the mtime sort
+                                                                    // (0 = partition disabled, sort everything)
     const bool blockIncr;                                           // Block incremental?
     size_t blockIncrSizeSuper;                                      // Super block size
 
@@ -1937,10 +1939,22 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
         const unsigned int queueOffset = jobData->backupStandby ? 1 : 0;
         const unsigned int queueCount = strLstSize(targetList) + queueOffset;
 
+        // When bundling is enabled and a non-zero stable-age threshold is configured, the mtime sort is skipped for files older
+        // than the threshold. A parallel oldList[] collects those "stable" small files in insertion (directory) order; they are
+        // appended after the sorted recent+big files before binning. With partition disabled, oldList stays NULL and all files
+        // flow through sortList as in the upstream behavior.
+        const bool partitionByMtime = jobData->bundle && jobData->bundleStableMtime > 0;
+
         List **const sortList = memNew(queueCount * sizeof(List *));
+        List **const oldList = partitionByMtime ? memNew(queueCount * sizeof(List *)) : NULL;
 
         for (unsigned int queueIdx = 0; queueIdx < queueCount; queueIdx++)
+        {
             sortList[queueIdx] = lstNewP(sizeof(BackupQueueItem), .comparator = backupProcessQueueComparator);
+
+            if (partitionByMtime)
+                oldList[queueIdx] = lstNewP(sizeof(BackupQueueItem));
+        }
 
         // Now put all files into the sort lists
         uint64_t fileTotal = 0;
@@ -1977,15 +1991,21 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
                 .filePack = filePack,
             };
 
-            // Files that must be copied from the primary are always put in queue 0 when backup from standby
+            // Determine which list this file goes into. Old small files skip the timestamp sort; everything else (big files and
+            // recent small files) goes into the sorted list and is ordered by the standard comparator.
+            const bool isStableSmall =
+                partitionByMtime && file.size <= jobData->bundleLimit && file.timestamp < jobData->bundleStableMtime;
+
+            // Find the destination queue index. Files that must be copied from the primary are always put in queue 0 when
+            // backup from standby; everything else is matched to a target by path prefix.
+            unsigned int destQueueIdx;
+
             if (jobData->backupStandby && backupProcessFilePrimary(jobData->standbyExp, file.name))
             {
-                lstAdd(sortList[0], &item);
+                destQueueIdx = 0;
             }
-            // Else find the correct queue by matching the file to a target
             else
             {
-                // Find the target that contains this file
                 unsigned int targetIdx = 0;
 
                 do
@@ -1999,9 +2019,10 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
                 }
                 while (1);
 
-                // Add file to queue
-                lstAdd(sortList[targetIdx + queueOffset], &item);
+                destQueueIdx = targetIdx + queueOffset;
             }
+
+            lstAdd(isStableSmall ? oldList[destQueueIdx] : sortList[destQueueIdx], &item);
 
             // Add size to total
             result += file.sizeOriginal;
@@ -2025,7 +2046,8 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
             THROW(FileMissingError, "no files have changed since the last backup - this seems unlikely");
 
         // Sort each per-target queue and immediately bin it into a descriptor list. Bundle ids are assigned monotonically across
-        // queues via jobData->bundleId so the wire format stays unique.
+        // queues via jobData->bundleId so the wire format stays unique. If partitionByMtime is on, the stable-age "old" files
+        // are appended after the sorted ones so the binner walks [big size-desc, recent mtime-desc, old insertion-order].
         backupProcessQueueComparatorBundle = jobData->bundle;
         backupProcessQueueComparatorBundleLimit = jobData->bundleLimit;
 
@@ -2034,6 +2056,14 @@ backupProcessQueue(const BackupData *const backupData, Manifest *const manifest,
             for (unsigned int queueIdx = 0; queueIdx < queueCount; queueIdx++)
             {
                 lstSort(sortList[queueIdx], sortOrderAsc);
+
+                if (partitionByMtime)
+                {
+                    const unsigned int oldSize = lstSize(oldList[queueIdx]);
+
+                    for (unsigned int oldIdx = 0; oldIdx < oldSize; oldIdx++)
+                        lstAdd(sortList[queueIdx], lstGet(oldList[queueIdx], oldIdx));
+                }
 
                 List *const descriptorList = backupProcessQueueBin(sortList[queueIdx], jobData, lstMemContext(jobData->queueList));
                 lstAdd(jobData->queueList, &descriptorList);
@@ -2279,6 +2309,13 @@ backupProcess(const BackupData *const backupData, Manifest *const manifest, cons
         {
             jobData.bundleSize = cfgOptionUInt64(cfgOptRepoBundleSize);
             jobData.bundleLimit = cfgOptionUInt64(cfgOptRepoBundleLimit);
+
+            // Convert the configured stable-age (days) into an absolute mtime threshold. Files with timestamp < threshold are
+            // treated as "stable" and skip the timestamp sort. 0 disables the partition.
+            const unsigned int bundleStableAgeDays = cfgOptionUInt(cfgOptRepoBundleStableAge);
+
+            jobData.bundleStableMtime =
+                bundleStableAgeDays == 0 ? 0 : time(NULL) - (time_t)bundleStableAgeDays * 24 * 60 * 60;
         }
 
         if (jobData.blockIncr)


### PR DESCRIPTION
Skip sorting for very old files when creating bundles.
    
    Notice:
    
    This builds on the manifest-unpack branch!
    
    Background:
    
    We have a special situation with our databases where we have
    millions of files (6-8 millions) in our databases, so we are using the
    bundling feature. But the building of the manifest still takes a very
    long time. I'm not an expert C programmer so I let Claude AI have a go
    at finding what is taking so long when building the manifest.
    It turned out to be different kinds of "overhead" and this is the fourth
    patch to help reduce the impact of the overhead.
    
    What it adds:
    
    It skips sorting very old files and just send them straight to bundle packing,
    since there is not much point in sorting them (hopefully).
    Togehter with the manifest-unpack patch this helps shaving of time from backups using the bundle feature.
    
    Below follows a more detailed summary by Claude
    --------------
    
    — Add repo-bundle-stable-age option to skip mtime sort for stable files
    
      Summary
    
      Adds a new repo-bundle-stable-age configuration option (integer, days, default 90) that lets files older than the threshold skip the timestamp sort during bundle assignment. Recent files still sort by timestamp-desc; old files end up in directory
       order via the natural traversal order from the manifest walk.
    
      Motivation
    
      The current bundle assignment sorts every small file by timestamp descending so that "newer files cluster together, older files cluster together," which the original bundle commit describes as the mechanism for keeping bundles dense across
      incrementals.
    
      For very large PostgreSQL clusters — particularly OLTP-style workloads where the bulk of data is historical and only a small fraction of files have recent mtimes — sorting the entire set by timestamp is wasted work. A 90-day-old file and a
      365-day-old file are both equally "stable" from the perspective of bundle density across incrementals. The mtime sort within the "stable" bucket adds no fragmentation-resistance benefit while still costing CPU and memory locality.
    
      Change
    
      A new option in src/build/config/config.yaml:
    
        repo-bundle-stable-age:
          section: global
          group: repo
          type: integer
          default: 90
          allow-range: [0, 1825]
          command:
            backup: {}
          depend:
            option: repo-bundle
            list:
              - true
    
      Type is integer (days) rather than time because pgbackrest's time-option storage is unsigned int milliseconds, which caps at ~49 days; we want the range to comfortably cover months/years.
    
      In backupProcessQueue, when bundling is enabled and the threshold is > 0:
    
      1. Two parallel sub-lists per target: a sortable one (recent small files + all large files) and a stable one (old small files).
      2. The sortable list goes through the comparator as before (size-desc for large, mtime-desc for recent small).
      3. The stable list is appended to the sortable list in insertion order before being fed to backupProcessQueueBin.
    
      When the threshold is 0 (or bundling is off), the partition is bypassed and behavior is identical to today.
    
      The "insertion order" for the stable bucket happens to be directory order, because manifestBuildInfo walks directories with sortOrder=sortOrderAsc. This is arguably better for restore locality than mtime-desc within the stable bucket — files from
       the same relation/directory cluster together in the same bundle.
    
      Help text
    
      Updated src/build/help/help.xml with a new <config-key> for repo-bundle-stable-age describing the semantics and recommending 0 to disable.
    
      Performance impact
    
      For a 6.5 M-file PG cluster where ~95% of files are months old, the partition reduces the sort input from 6.5 M to ~325 K. With the existing pre-bin patch the per-compare cost is already low; with this partition the absolute count of
      compares drops by roughly 20×. On our workload manifestNewBuild's sort= sub-phase is currently 21 s; with the partition we expect that to drop to single-digit seconds. Modest absolute savings, mostly relevant for very large clusters.
    
      Semantic effects on bundle composition
    
      - Large files: unchanged (still size-desc sorted, each gets its own job)
      - Recent small files: unchanged (still mtime-desc + name)
      - Old small files: file order within these bundles becomes directory order instead of mtime-desc. The restore-fragmentation argument from the original bundle commit is preserved at the bucket boundary: "old" files as a group still stay densely
      referenced across incrementals.
    
      Tradeoffs and risks
    
      - Default behavior changes when repo-bundle=y: today, all small files sort by timestamp; with this default 90-day threshold, files older than 90 days skip the timestamp sort. Setting repo-bundle-stable-age=0 restores the previous behavior.
      - Adds one configuration knob. The default is a guess based on typical OLTP workloads. Could be lower or higher depending on operator preference.
    
      Tests
    
      Existing bundle-related tests continue to pass. We did not add specific tests for the partition itself; happy to add some if maintainers prefer (a unit test that walks a known set of timestamps and verifies the resulting bundle composition would
      be straightforward).
    
      Alternative considered
    
      The threshold could be derived from the prior manifest's backup-timestamp-start automatically (a file unchanged since the previous backup is "stable" by definition). We didn't pursue this for incrementals specifically because it requires plumbing
       the prior manifest into backupProcessQueue — small but more invasive than a flat integer option. Mentioned here in case it's of interest as a future refinement.
