### PR TITLE
Harden HTTP chunked response parsing.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -53,6 +53,17 @@
             </release-item>
 
             <release-item>
+                <github-pull-request id="2785"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="shubham"/>
+                    <release-item-reviewer id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Harden HTTP chunked response parsing.</p>
+            </release-item>
+
+            <release-item>
                 <github-issue id="2732"/>
 
                 <release-item-contributor-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -1095,6 +1095,11 @@
     <contributor-id type="github">ShivakumarAmbigiTR</contributor-id>
 </contributor>
 
+<contributor id="shubham">
+    <contributor-name-display>Shubham</contributor-name-display>
+    <contributor-id type="github">bas3line</contributor-id>
+</contributor>
+
 <contributor id="slava.moudry">
     <contributor-name-display>Slava Moudry</contributor-name-display>
     <contributor-id type="github">slava-pagerduty</contributor-id>

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -37,7 +37,7 @@ struct HttpResponse
     HttpResponsePub pub;                                            // Publicly accessible variables
     HttpSession *session;                                           // HTTP session
     bool contentChunked;                                            // Is the response content chunked?
-    bool contentSizeSet;                                            // Was the content size specified?
+    bool contentSizeSet;                                            // Was content size specified?
     uint64_t contentSize;                                           // Content size (ignored for chunked)
     uint64_t contentRemaining;                                      // Content remaining (per chunk if chunked)
     bool closeOnContentEof;                                         // Will server close after content is sent?
@@ -144,7 +144,7 @@ httpResponseRead(THIS_VOID, Buffer *const buffer, const bool block)
                     if (this->contentChunked && this->contentRemaining == 0)
                     {
                         // Read length of next chunk
-                        String *chunkHeader = strTrim(ioReadLine(rawRead));
+                        const String *chunkHeader = strTrim(ioReadLine(rawRead));
                         const int chunkExtPos = strChr(chunkHeader, ';');
 
                         if (chunkExtPos != -1)

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -156,12 +156,7 @@ httpResponseRead(THIS_VOID, Buffer *const buffer, const bool block)
                         if (this->contentRemaining == 0)
                         {
                             // Consume chunk trailers and the blank line that terminates them.
-                            do
-                            {
-                                if (strSize(strTrim(ioReadLine(rawRead))) == 0)
-                                    break;
-                            }
-                            while (true);
+                            while (strSize(strTrim(ioReadLine(rawRead))) != 0);
 
                             this->contentEof = true;
                         }

--- a/src/common/io/http/response.c
+++ b/src/common/io/http/response.c
@@ -37,6 +37,7 @@ struct HttpResponse
     HttpResponsePub pub;                                            // Publicly accessible variables
     HttpSession *session;                                           // HTTP session
     bool contentChunked;                                            // Is the response content chunked?
+    bool contentSizeSet;                                            // Was the content size specified?
     uint64_t contentSize;                                           // Content size (ignored for chunked)
     uint64_t contentRemaining;                                      // Content remaining (per chunk if chunked)
     bool closeOnContentEof;                                         // Will server close after content is sent?
@@ -143,11 +144,27 @@ httpResponseRead(THIS_VOID, Buffer *const buffer, const bool block)
                     if (this->contentChunked && this->contentRemaining == 0)
                     {
                         // Read length of next chunk
-                        this->contentRemaining = cvtZToUInt64Base(strZ(strTrim(ioReadLine(rawRead))), 16);
+                        String *chunkHeader = strTrim(ioReadLine(rawRead));
+                        const int chunkExtPos = strChr(chunkHeader, ';');
+
+                        if (chunkExtPos != -1)
+                            chunkHeader = strTrim(strSubN(chunkHeader, 0, (size_t)chunkExtPos));
+
+                        this->contentRemaining = cvtZToUInt64Base(strZ(chunkHeader), 16);
 
                         // If content remaining is still zero then eof
                         if (this->contentRemaining == 0)
+                        {
+                            // Consume chunk trailers and the blank line that terminates them.
+                            do
+                            {
+                                if (strSize(strTrim(ioReadLine(rawRead))) == 0)
+                                    break;
+                            }
+                            while (true);
+
                             this->contentEof = true;
+                        }
                     }
 
                     // Read if there is content remaining
@@ -175,7 +192,7 @@ httpResponseRead(THIS_VOID, Buffer *const buffer, const bool block)
                     {
                         // If chunked then consume the blank line that follows every chunk. There might be more chunk data so loop
                         // back around to check.
-                        if (this->contentChunked)
+                        if (this->contentChunked && !this->contentEof)
                         {
                             ioReadLine(rawRead);
                         }
@@ -306,7 +323,7 @@ httpResponseHeaderRead(HttpResponse *const this, IoRead *const read)
             if (strEq(headerKey, HTTP_HEADER_TRANSFER_ENCODING_STR))
             {
                 // Error if transfer encoding is not chunked
-                if (!strEq(headerValue, HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR))
+                if (!strEq(strLower(headerValue), HTTP_VALUE_TRANSFER_ENCODING_CHUNKED_STR))
                 {
                     THROW_FMT(
                         FormatError, "only '%s' is supported for '%s' header", HTTP_VALUE_TRANSFER_ENCODING_CHUNKED,
@@ -319,6 +336,7 @@ httpResponseHeaderRead(HttpResponse *const this, IoRead *const read)
             // Read content size
             if (strEq(headerKey, HTTP_HEADER_CONTENT_LENGTH_STR))
             {
+                this->contentSizeSet = true;
                 this->contentSize = cvtZToUInt64(strZ(headerValue));
                 this->contentRemaining = this->contentSize;
             }
@@ -334,7 +352,7 @@ httpResponseHeaderRead(HttpResponse *const this, IoRead *const read)
         while (1);
 
         // Error if transfer encoding and content length are both set
-        if (this->contentChunked && this->contentSize > 0)
+        if (this->contentChunked && this->contentSizeSet)
         {
             THROW_FMT(
                 FormatError, "'%s' and '%s' headers are both set", HTTP_HEADER_TRANSFER_ENCODING,

--- a/test/src/module/common/ioHttpTest.c
+++ b/test/src/module/common/ioHttpTest.c
@@ -1,6 +1,7 @@
 /***********************************************************************************************************************************
 Test HTTP
 ***********************************************************************************************************************************/
+#include <errno.h>
 #include <unistd.h>
 
 #include "common/io/fdRead.h"
@@ -375,7 +376,7 @@ testRun(void)
 
         TEST_ERROR_FMT(
             httpRequestResponse(httpRequestNewP(client, STRDEF("GET"), STRDEF("/")), false), HostConnectError,
-            "unable to connect to 'localhost:34342 (127.0.0.1)': [111] Connection refused\n"
+            "unable to connect to 'localhost:34342 (127.0.0.1)': [" STRINGIFY(ECONNREFUSED) "] Connection refused\n"
             "[RETRY DETAIL OMITTED]");
 
         HRN_FORK_BEGIN()
@@ -521,6 +522,17 @@ testRun(void)
 
                 hrnServerScriptExpectZ(http, "GET / HTTP/1.1\r\n" TEST_USER_AGENT "\r\n");
                 hrnServerScriptReplyZ(http, "HTTP/1.1 200 OK\r\ntransfer-encoding:chunked\r\ncontent-length:777\r\n\r\n");
+
+                hrnServerScriptClose(http);
+
+                TEST_ERROR(
+                    httpRequestResponse(httpRequestNewP(client, STRDEF("GET"), STRDEF("/")), false), FormatError,
+                    "'transfer-encoding' and 'content-length' headers are both set");
+
+                hrnServerScriptAccept(http);
+
+                hrnServerScriptExpectZ(http, "GET / HTTP/1.1\r\n" TEST_USER_AGENT "\r\n");
+                hrnServerScriptReplyZ(http, "HTTP/1.1 200 OK\r\ntransfer-encoding:chunked\r\ncontent-length:0\r\n\r\n");
 
                 hrnServerScriptClose(http);
 
@@ -907,6 +919,35 @@ testRun(void)
 
                 TEST_RESULT_VOID(ioRead(httpResponseIoRead(response), buffer), "read response");
                 TEST_RESULT_STR_Z(strNewBuf(buffer), "", "check response");
+
+                // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("request with chunked content extensions and trailers");
+
+                hrnServerScriptAccept(http);
+
+                hrnServerScriptExpectZ(http, "GET / HTTP/1.1\r\n" TEST_USER_AGENT "\r\n");
+                hrnServerScriptReplyZ(
+                    http,
+                    "HTTP/1.1 200 OK\r\nTransfer-Encoding:Chunked\r\n\r\n"
+                    "5;foo=bar\r\nhello\r\n"
+                    "0\r\nx-trailer: y\r\n\r\n");
+
+                TEST_ASSIGN(response, httpRequestResponse(httpRequestNewP(client, STRDEF("GET"), STRDEF("/")), false), "request");
+                TEST_RESULT_VOID(
+                    FUNCTION_LOG_OBJECT_FORMAT(httpResponseHeader(response), httpHeaderToLog, logBuf, sizeof(logBuf)),
+                    "httpHeaderToLog");
+                TEST_RESULT_Z(logBuf, "{transfer-encoding: 'chunked'}", "check response headers");
+
+                buffer = bufNew(6);
+
+                TEST_RESULT_VOID(ioRead(httpResponseIoRead(response), buffer), "read response");
+                TEST_RESULT_STR_Z(strNewBuf(buffer), "hello", "check response");
+
+                hrnServerScriptExpectZ(http, "GET /reuse HTTP/1.1\r\n" TEST_USER_AGENT "\r\n");
+                hrnServerScriptReplyZ(http, "HTTP/1.1 200 OK\r\ncontent-length:2\r\n\r\nOK");
+
+                TEST_ASSIGN(response, httpRequestResponse(httpRequestNewP(client, STRDEF("GET"), STRDEF("/reuse")), true), "request");
+                TEST_RESULT_STR_Z(strNewBuf(httpResponseContent(response)), "OK", "check response");
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("request with multipart request and response");


### PR DESCRIPTION
## Summary
- parse HTTP chunk sizes with valid chunk extensions and consume trailers before reusing the connection
- treat transfer-encoding values case-insensitively
- reject responses that include both transfer-encoding and content-length even when content-length is 0
- make the io-http connection-refused test portable across platforms by using ECONNREFUSED

## Testing
- PKG_CONFIG_PATH="/opt/homebrew/opt/libpq/lib/pkgconfig:/opt/homebrew/opt/libxml2/lib/pkgconfig:$PKG_CONFIG_PATH" pgbackrest/test/test.pl --vm-out --module=common --test=io-http --no-coverage --no-valgrind
- uncrustify -c test/uncrustify.cfg --check src/common/io/http/response.c test/src/module/common/ioHttpTest.c