### PR TITLE
Fix heap overflow when a pg option is set without pg1.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -9,6 +9,19 @@
 
                 <p>Fix potential buffer overrun in error module.</p>
             </release-item>
+
+            <release-item>
+                <github-issue id="1768"/>
+                <github-pull-request id="2796"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="naveen"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="douglas.j.hunley"/>
+                </release-item-contributor-list>
+
+                <p>Fix heap overflow when a pg option is set without pg1.</p>
+            </release-item>
         </release-bug-list>
 
         <release-feature-list>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -855,6 +855,11 @@
     <contributor-id type="github">silent-observer</contributor-id>
 </contributor>
 
+<contributor id="naveen">
+    <contributor-name-display>Naveen</contributor-name-display>
+    <contributor-id type="github">navaneswarareddy</contributor-id>
+</contributor>
+
 <contributor id="mibiio">
     <contributor-name-display>mibiio</contributor-name-display>
     <contributor-id type="github">mibiio</contributor-id>

--- a/src/config/parse.c
+++ b/src/config/parse.c
@@ -2305,8 +2305,12 @@ cfgParse(const Storage *const storage, const unsigned int argListSize, const cha
             if (!config->optionGroup[groupId].valid)
                 continue;
 
-            // Allocate memory for the index to key index map
-            const unsigned int optionIdxTotal = config->optionGroup[groupId].indexTotal;
+            // Allocate memory for the index to key index map. The pg group always reserves index 0 for key 1 (see below) even when
+            // key 1 was not configured, so allocate an extra slot in that case to avoid writing past the end of the map.
+            unsigned int optionIdxTotal = config->optionGroup[groupId].indexTotal;
+
+            if (groupId == cfgOptGrpPg && optionIdxTotal > 0 && !groupIdxMap[groupId][0])
+                optionIdxTotal++;
 
             MEM_CONTEXT_BEGIN(config->memContext)
             {
@@ -2346,6 +2350,9 @@ cfgParse(const Storage *const storage, const unsigned int argListSize, const cha
                         optionIdxMax++;
                     }
                 }
+
+                // Update the index total to include the reserved pg index 0 when key 1 was not configured
+                config->optionGroup[groupId].indexTotal = optionIdxMax;
             }
         }
 

--- a/test/src/module/config/parseTest.c
+++ b/test/src/module/config/parseTest.c
@@ -2079,6 +2079,30 @@ testRun(void)
         TEST_RESULT_INT(cfgOptionSource(cfgOptSpoolPath), cfgSourceDefault, "spool-path is source default");
 
         // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("pg group with no key 1");
+
+        // The pg group always reserves index 0 for key 1 even when key 1 was not configured, so the index map must be sized to
+        // include the reserved index. Configure pg paths at keys other than 1 to exercise this path.
+        argList = strLstNew();
+        strLstAddZ(argList, TEST_BACKREST_EXE);
+        hrnCfgArgRawZ(argList, cfgOptStanza, "db");
+        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 2, "/path/to/db2");
+        hrnCfgArgKeyRawZ(argList, cfgOptPgPath, 3, "/path/to/db3");
+        strLstAddZ(argList, CFGCMD_ARCHIVE_PUSH);
+
+        TEST_RESULT_VOID(
+            cfgParseP(storageTest, strLstSize(argList), strLstPtr(argList), .noResetLogLevel = true),
+            "archive-push with pg2-path and pg3-path");
+
+        TEST_RESULT_UINT(cfgOptionGroupIdxTotal(cfgOptGrpPg), 2, "pg2 and pg3 are both retained");
+        TEST_RESULT_UINT(cfgOptionGroupIdxToKey(cfgOptGrpPg, 0), 2, "index 0 maps to pg2");
+        TEST_RESULT_UINT(cfgOptionGroupIdxToKey(cfgOptGrpPg, 1), 3, "index 1 maps to pg3");
+        TEST_RESULT_STR_Z(
+            cfgOptionIdxStr(cfgOptPgPath, cfgOptionKeyToIdx(cfgOptPgPath, 2)), "/path/to/db2", "pg2-path is set");
+        TEST_RESULT_STR_Z(
+            cfgOptionIdxStr(cfgOptPgPath, cfgOptionKeyToIdx(cfgOptPgPath, 3)), "/path/to/db3", "pg3-path is set");
+
+        // -------------------------------------------------------------------------------------------------------------------------
         TEST_TITLE("invalid key/value");
 
         argList = strLstNew();


### PR DESCRIPTION
The pg group always reserves index 0 for key 1 (pg1) to maintain compatibility with older versions, but the index map was sized only from the keys that were actually configured. When pg options were set at keys other than 1 while key 1 was absent (e.g. pg2-path and pg3-path with no pg1-path) the reserved index was written one element past the end of the map. The stray write landed in allocator slack on glibc but corrupted the heap on musl, causing the segmentation fault reported on Alpine.

The undersized map also caused the highest-numbered pg path to be silently dropped even where the overflow itself did no visible damage.

Size the map to include the reserved index and set the group index total to the number of entries actually written. The reserved key 1 has no values in this case so it is removed later as a phantom group index, and commands that require pg1-path continue to error as before.