### PR TITLE
Fix expire removing a backup in progress on another host.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -2,6 +2,19 @@
     <release-core-list>
         <release-bug-list>
             <release-item>
+                <github-issue id="2622"/>
+                <github-pull-request id="2797"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="dima19017"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="douglas.j.hunley"/>
+                </release-item-contributor-list>
+
+                <p>Fix <cmd>expire</cmd> removing a backup in progress on another host.</p>
+            </release-item>
+
+            <release-item>
                 <release-item-contributor-list>
                     <release-item-contributor id="christophe.pettus"/>
                     <release-item-reviewer id="david.steele"/>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -359,6 +359,11 @@
     <contributor-id type="github">devrimgunduz</contributor-id>
 </contributor>
 
+<contributor id="dima19017">
+    <contributor-name-display>Dmitrii</contributor-name-display>
+    <contributor-id type="github">dima19017</contributor-id>
+</contributor>
+
 <contributor id="dmitry.didovicher">
     <contributor-name-display>Dmitry Didovicher</contributor-name-display>
 </contributor>

--- a/src/command/expire/expire.c
+++ b/src/command/expire/expire.c
@@ -827,32 +827,34 @@ removeExpiredBackup(const InfoBackup *const infoBackup, const String *const adho
         // Initialize the index to the latest backup on disk
         unsigned int backupIdx = 0;
 
-        // Only remove the resumable backup if there is a possibility it is a dependent of the adhoc label being expired
-        if (adhocBackupLabel != NULL && !strLstEmpty(backupList))
+        // The latest backup on disk may be resumable or in-progress (has a backup.manifest.copy but no backup.manifest). A backup
+        // in this state must not be removed by default: it may be a crashed backup that the next backup will resume or clean, or it
+        // may be actively running on another host (e.g. backup runs on the primary while expire runs on a standby). Removing it in
+        // the latter case corrupts the in-progress backup. Only the latest backup can be in this state.
+        if (!strLstEmpty(backupList))
         {
             const String *const manifestFileName = strNewFmt(
-                STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(strLstGet(backupList, backupIdx)));
+                STORAGE_REPO_BACKUP "/%s/" BACKUP_MANIFEST_FILE, strZ(strLstGet(backupList, 0)));
             const String *const manifestCopyFileName = strNewFmt("%s" INFO_COPY_EXT, strZ(manifestFileName));
 
             // If the latest backup is resumable (has a backup.manifest.copy but no backup.manifest)
             if (!storageExistsP(storageRepoIdx(repoIdx), manifestFileName) &&
                 storageExistsP(storageRepoIdx(repoIdx), manifestCopyFileName))
             {
-                // If the resumable backup is not related to the expired adhoc backup then don't remove it
-                if (!strBeginsWith(strLstGet(backupList, backupIdx), strSubN(adhocBackupLabel, 0, 16)))
-                {
-                    backupIdx = 1;
-                }
-                // Else it may be related to the adhoc backup so check if its ancestor still exists
-                else
+                // Protect the resumable/in-progress backup by default
+                backupIdx = 1;
+
+                // During adhoc expiration the resumable backup may be a dependent of the label being expired, in which case it
+                // should be removed along with it -- but only when its ancestor no longer exists in backup.info
+                if (adhocBackupLabel != NULL && strBeginsWith(strLstGet(backupList, 0), strSubN(adhocBackupLabel, 0, 16)))
                 {
                     const Manifest *const manifestResume = manifestLoadFile(
                         storageRepoIdx(repoIdx), manifestFileName, cfgOptionIdxStrId(cfgOptRepoCipherType, repoIdx),
                         infoPgCipherPass(infoBackupPg(infoBackup)));
 
-                    // If the ancestor of the resumable backup still exists in backup.info then do not remove the resumable backup
-                    if (infoBackupLabelExists(infoBackup, manifestData(manifestResume)->backupLabelPrior))
-                        backupIdx = 1;
+                    // If the ancestor of the resumable backup no longer exists in backup.info then it can be removed
+                    if (!infoBackupLabelExists(infoBackup, manifestData(manifestResume)->backupLabelPrior))
+                        backupIdx = 0;
                 }
             }
         }

--- a/test/src/module/command/expireTest.c
+++ b/test/src/module/command/expireTest.c
@@ -444,6 +444,60 @@ testRun(void)
         TEST_TITLE("skip adhoc when no backups");
 
         TEST_RESULT_VOID(removeExpiredBackup(infoBackup, STRDEF("20181118-152100F"), 0), "expire");
+
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("in-progress/resumable latest backup is not removed by non-adhoc expire");
+
+        // Start from a clean backup path so the listing reflects only this test
+        HRN_STORAGE_PATH_REMOVE(storageRepoWrite(), STORAGE_REPO_BACKUP, .recurse = true);
+
+        // backup.info with a single committed full backup. The in-progress backup below is not yet in backup.info, which is exactly
+        // the state seen by expire on one host while a backup is running on another host.
+        HRN_INFO_PUT(
+            storageRepoWrite(), INFO_BACKUP_PATH_FILE,
+            "[backup:current]\n"
+            "20181119-152138F={"
+            "\"backrest-format\":5,\"backrest-version\":\"2.08dev\","
+            "\"backup-archive-start\":\"000000010000000000000002\",\"backup-archive-stop\":\"000000010000000000000002\","
+            "\"backup-info-repo-size\":2369186,\"backup-info-repo-size-delta\":2369186,"
+            "\"backup-info-size\":20162900,\"backup-info-size-delta\":20162900,"
+            "\"backup-timestamp-start\":1542640898,\"backup-timestamp-stop\":1542640911,\"backup-type\":\"full\","
+            "\"db-id\":1,\"option-archive-check\":true,\"option-archive-copy\":false,\"option-backup-standby\":false,"
+            "\"option-checksum-page\":true,\"option-compress\":true,\"option-hardlink\":false,\"option-online\":true}\n"
+            "\n"
+            "[db]\n"
+            "db-catalog-version=201409291\n"
+            "db-control-version=942\n"
+            "db-id=1\n"
+            "db-system-id=6625592122879095702\n"
+            "db-version=\"9.4\"\n"
+            "\n"
+            "[db:history]\n"
+            "1={\"db-catalog-version\":201409291,\"db-control-version\":942,\"db-system-id\":6625592122879095702"
+            ",\"db-version\":\"9.4\"}");
+
+        TEST_ASSIGN(
+            infoBackup, infoBackupLoadFile(storageRepo(), INFO_BACKUP_PATH_FILE_STR, cipherTypeNone, NULL), "get backup.info");
+
+        // Committed backup (in backup.info) and an older orphan backup that is not in backup.info and has no manifest copy
+        HRN_STORAGE_PUT_Z(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152138F/" BOGUS_STR, BOGUS_STR);
+        HRN_STORAGE_PUT_Z(storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152100F/" BOGUS_STR, BOGUS_STR);
+
+        // Latest backup on disk is in-progress/resumable: it has backup.manifest.copy but no backup.manifest and is not in
+        // backup.info, so it must not be removed
+        HRN_STORAGE_PUT_EMPTY(
+            storageRepoWrite(), STORAGE_REPO_BACKUP "/20181119-152800F/" BACKUP_MANIFEST_FILE INFO_COPY_EXT);
+
+        TEST_RESULT_VOID(removeExpiredBackup(infoBackup, NULL, 0), "expire with in-progress latest backup");
+
+        TEST_RESULT_LOG("P00   INFO: repo1: remove expired backup 20181119-152100F");
+        TEST_STORAGE_LIST(
+            storageRepo(), STORAGE_REPO_BACKUP,
+            "20181119-152138F/\n"
+            "20181119-152138F/BOGUS\n"
+            "20181119-152800F/\n"
+            "20181119-152800F/backup.manifest.copy\n"
+            "backup.info\n");
     }
 
     // *****************************************************************************************************************************


### PR DESCRIPTION
During expiration any backup directory on disk that is not present in backup.info is removed. A backup in progress is not added to backup.info until it completes, so when expire runs on one host while a backup runs on another (e.g. expire on a standby while the primary backs up) the in-progress backup is deleted and corrupted.

The guard that preserves a resumable backup (one with backup.manifest.copy but no backup.manifest) was only applied during adhoc expiration. Apply it during all expiration so an in-progress or resumable latest backup is never removed. The adhoc case, where a resumable dependent of the expired backup is removed when its ancestor no longer exists, is unchanged.