### PR TITLE
Fix archive-push-queue-max not enforced when a WAL file errors.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -15,6 +15,19 @@
             </release-item>
 
             <release-item>
+                <github-issue id="2629"/>
+                <github-pull-request id="2799"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="vut12"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Fix <setting>archive-push-queue-max</setting> not enforced when a WAL file errors.</p>
+            </release-item>
+
+            <release-item>
                 <release-item-contributor-list>
                     <release-item-contributor id="christophe.pettus"/>
                     <release-item-reviewer id="david.steele"/>

--- a/doc/xml/release/contributor.xml
+++ b/doc/xml/release/contributor.xml
@@ -1302,6 +1302,11 @@
     <contributor-id type="github">vthriller</contributor-id>
 </contributor>
 
+<contributor id="vut12">
+    <contributor-name-display>vut12</contributor-name-display>
+    <contributor-id type="github">vut12</contributor-id>
+</contributor>
+
 <contributor id="will.m">
     <contributor-name-display>Will M</contributor-name-display>
 </contributor>

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -548,8 +548,12 @@ cmdArchivePushAsync(void)
                 strLstSize(jobData.walFileList) == 1 ?
                     "" : zNewFmt("...%s", strZ(strLstGet(jobData.walFileList, strLstSize(jobData.walFileList) - 1))));
 
-            // Drop files if queue max has been exceeded
-            if (cfgOptionTest(cfgOptArchivePushQueueMax) && archivePushDrop(jobData.walPath, jobData.walFileList))
+            // Drop files if queue max has been exceeded. The queue is measured against the ready list (all WAL that PostgreSQL is
+            // waiting to archive) rather than the process list (WAL not yet pushed). If an earlier WAL file errors repeatedly then
+            // PostgreSQL keeps retrying it and never acknowledges the later files that look-ahead has already pushed, so those
+            // files drop out of the process list even though their WAL remains in pg_wal. Using the process list here would let the
+            // queue grow without bound in that case, exactly when dropping is most needed.
+            if (cfgOptionTest(cfgOptArchivePushQueueMax) && archivePushDrop(jobData.walPath, archivePushReadyList(jobData.walPath)))
             {
                 for (unsigned int walFileIdx = 0; walFileIdx < strLstSize(jobData.walFileList); walFileIdx++)
                 {

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -91,6 +91,20 @@ testRun(void)
         TEST_RESULT_BOOL(
             archivePushDrop(STRDEF("pg_wal"), archivePushProcessList(STRDEF(TEST_PATH "/db/pg_wal"))), true, "wal is dropped");
 
+        // The queue must be measured against the ready list rather than the process list. WAL 3 has already been pushed (ok file)
+        // but not yet acknowledged by PostgreSQL (ready file still present), so it is in the ready list but not the process list.
+        // Set queue max so the process list ({2, 5, 6} = 48MB) does not exceed it but the ready list ({2, 3, 5, 6} = 64MB) does.
+        argListDrop = strLstDup(argList);
+        hrnCfgArgRawFmt(argListDrop, cfgOptArchivePushQueueMax, "%zu", (size_t)16 * 1024 * 1024 * 3);
+        HRN_CFG_LOAD(cfgCmdArchivePush, argListDrop, .role = cfgCmdRoleAsync);
+
+        TEST_RESULT_BOOL(
+            archivePushDrop(STRDEF("pg_wal"), archivePushProcessList(STRDEF(TEST_PATH "/db/pg_wal"))), false,
+            "process list does not exceed queue max");
+        TEST_RESULT_BOOL(
+            archivePushDrop(STRDEF("pg_wal"), archivePushReadyList(STRDEF(TEST_PATH "/db/pg_wal"))), true,
+            "ready list exceeds queue max");
+
         // No WAL to be processed
         TEST_RESULT_BOOL(archivePushDrop(STRDEF("pg_wal"), strLstNew()), false, "no WAL to be processed");
     }


### PR DESCRIPTION
In asynchronous mode archive-push-queue-max measured the queue against the process list (WAL that still needs to be pushed) rather than the ready list (all WAL that PostgreSQL is waiting to archive). When a WAL file errored repeatedly the async look-ahead kept pushing the later files successfully and writing their ok status files, but PostgreSQL retries the failed file in order and never acknowledges the later ones, so those files dropped out of the process list while their WAL remained in pg_wal. The queue therefore appeared tiny and was never dropped, letting pg_wal fill the disk — exactly the outcome the option exists to prevent.

Measure the queue against the ready list, as synchronous mode already does. The files that get dropped are unchanged, so writing the ok status for the failed file unblocks PostgreSQL, which then acknowledges the already-pushed files from their existing status files and drains the queue.