### PR TITLE
Exit async archive-push on first error.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -153,6 +153,19 @@
             </release-item>
 
             <release-item>
+                <github-issue id="1848"/>
+                <github-pull-request id="2802"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="sebastien.lardiere"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Exit async <cmd>archive-push</cmd> on first error.</p>
+            </release-item>
+
+            <release-item>
                 <github-pull-request id="2785"/>
 
                 <release-item-contributor-list>

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -40,13 +40,6 @@ Ready file extension constants
 #define STATUS_EXT_READY_SIZE                                       (sizeof(STATUS_EXT_READY) - 1)
 
 /***********************************************************************************************************************************
-Stop async processing after this many errors. The async process will be spawned again by the next archive-push, which rechecks the
-queue and drops WAL if it now exceeds queue-max. This prevents a failing repo from filling the WAL volume while retrying every ready
-segment and creating an error file for each one.
-***********************************************************************************************************************************/
-#define ARCHIVE_PUSH_ERROR_MAX                                      3
-
-/***********************************************************************************************************************************
 Format the warning when a file is dropped
 ***********************************************************************************************************************************/
 static String *
@@ -447,7 +440,7 @@ typedef struct ArchivePushAsyncData
     CompressType compressType;                                      // Type of compression for WAL segments
     int compressLevel;                                              // Compression level for wal files
     ArchivePushCheckResult archiveInfo;                             // Archive info
-    unsigned int errorTotal;                                        // Number of errored jobs so far
+    bool errorFound;                                                // Has a job errored? If so, stop scheduling new jobs
 } ArchivePushAsyncData;
 
 static ProtocolParallelJob *
@@ -465,11 +458,12 @@ archivePushAsyncCallback(void *const data, const unsigned int clientIdx)
         // No special logic based on the client, we'll just get the next job
         (void)clientIdx;
 
-        // Get a new job if there are any left. Stop getting new jobs once too many errors have occurred so the async process exits
-        // and lets the next run recheck the queue.
+        // Get a new job if there are any left. Stop scheduling new jobs as soon as one errors so the async process exits and the
+        // next run rechecks the queue. Continuing past an error does not relieve disk pressure since PostgreSQL cannot recycle any
+        // WAL past the oldest unarchived segment, so the sooner the queue is rechecked the sooner WAL can be dropped if needed.
         ArchivePushAsyncData *const jobData = data;
 
-        if (jobData->errorTotal < ARCHIVE_PUSH_ERROR_MAX && jobData->walFileIdx < strLstSize(jobData->walFileList))
+        if (!jobData->errorFound && jobData->walFileIdx < strLstSize(jobData->walFileList))
         {
             const String *const walFile = strLstGet(jobData->walFileList, jobData->walFileIdx);
             jobData->walFileIdx++;
@@ -617,7 +611,7 @@ cmdArchivePushAsync(void)
                             // Else the job errored
                             else
                             {
-                                jobData.errorTotal++;
+                                jobData.errorFound = true;
 
                                 LOG_WARN_PID_FMT(
                                     processId,
@@ -639,14 +633,10 @@ cmdArchivePushAsync(void)
                 }
                 MEM_CONTEXT_TEMP_END();
 
-                // If processing was stopped early because too many errors occurred then log a warning. The remaining WAL is left
-                // for the next run, which will recheck the queue and drop WAL if it now exceeds queue-max.
-                if (jobData.errorTotal >= ARCHIVE_PUSH_ERROR_MAX)
-                {
-                    LOG_WARN(
-                        "stopped archive-push after " STRINGIFY(ARCHIVE_PUSH_ERROR_MAX) " error(s), remaining WAL will be"
-                        " processed on the next run");
-                }
+                // If processing was stopped early because a job errored then log a warning. The remaining WAL is left for the next
+                // run, which will recheck the queue and drop WAL if it now exceeds queue-max.
+                if (jobData.errorFound)
+                    LOG_WARN("stopped archive-push after an error, remaining WAL will be processed on the next run");
             }
         }
         // On any global error write a single error file to cover all unprocessed files

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -44,7 +44,7 @@ Stop async processing after this many errors. The async process will be spawned 
 queue and drops WAL if it now exceeds queue-max. This prevents a failing repo from filling the WAL volume while retrying every ready
 segment and creating an error file for each one.
 ***********************************************************************************************************************************/
-#define ARCHIVE_PUSH_ERROR_MAX                                      3U
+#define ARCHIVE_PUSH_ERROR_MAX                                      3
 
 /***********************************************************************************************************************************
 Format the warning when a file is dropped

--- a/src/command/archive/push/push.c
+++ b/src/command/archive/push/push.c
@@ -40,6 +40,13 @@ Ready file extension constants
 #define STATUS_EXT_READY_SIZE                                       (sizeof(STATUS_EXT_READY) - 1)
 
 /***********************************************************************************************************************************
+Stop async processing after this many errors. The async process will be spawned again by the next archive-push, which rechecks the
+queue and drops WAL if it now exceeds queue-max. This prevents a failing repo from filling the WAL volume while retrying every ready
+segment and creating an error file for each one.
+***********************************************************************************************************************************/
+#define ARCHIVE_PUSH_ERROR_MAX                                      3U
+
+/***********************************************************************************************************************************
 Format the warning when a file is dropped
 ***********************************************************************************************************************************/
 static String *
@@ -440,6 +447,7 @@ typedef struct ArchivePushAsyncData
     CompressType compressType;                                      // Type of compression for WAL segments
     int compressLevel;                                              // Compression level for wal files
     ArchivePushCheckResult archiveInfo;                             // Archive info
+    unsigned int errorTotal;                                        // Number of errored jobs so far
 } ArchivePushAsyncData;
 
 static ProtocolParallelJob *
@@ -457,10 +465,11 @@ archivePushAsyncCallback(void *const data, const unsigned int clientIdx)
         // No special logic based on the client, we'll just get the next job
         (void)clientIdx;
 
-        // Get a new job if there are any left
+        // Get a new job if there are any left. Stop getting new jobs once too many errors have occurred so the async process exits
+        // and lets the next run recheck the queue.
         ArchivePushAsyncData *const jobData = data;
 
-        if (jobData->walFileIdx < strLstSize(jobData->walFileList))
+        if (jobData->errorTotal < ARCHIVE_PUSH_ERROR_MAX && jobData->walFileIdx < strLstSize(jobData->walFileList))
         {
             const String *const walFile = strLstGet(jobData->walFileList, jobData->walFileIdx);
             jobData->walFileIdx++;
@@ -608,6 +617,8 @@ cmdArchivePushAsync(void)
                             // Else the job errored
                             else
                             {
+                                jobData.errorTotal++;
+
                                 LOG_WARN_PID_FMT(
                                     processId,
                                     "could not push WAL file '%s' to the archive (will be retried): [%d] %s", strZ(walFile),
@@ -627,6 +638,15 @@ cmdArchivePushAsync(void)
                     while (!protocolParallelDone(parallelExec));
                 }
                 MEM_CONTEXT_TEMP_END();
+
+                // If processing was stopped early because too many errors occurred then log a warning. The remaining WAL is left
+                // for the next run, which will recheck the queue and drop WAL if it now exceeds queue-max.
+                if (jobData.errorTotal >= ARCHIVE_PUSH_ERROR_MAX)
+                {
+                    LOG_WARN(
+                        "stopped archive-push after " STRINGIFY(ARCHIVE_PUSH_ERROR_MAX) " error(s), remaining WAL will be"
+                        " processed on the next run");
+                }
             }
         }
         // On any global error write a single error file to cover all unprocessed files

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -1004,6 +1004,47 @@ testRun(void)
             "000000010000000100000002.ok\n",
             .comment = "check status files");
 
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("stop async processing after too many errors");
+
+        // Remove status and ready files to get a clean state
+        HRN_STORAGE_PATH_REMOVE(storageSpoolWrite(), STORAGE_SPOOL_ARCHIVE_OUT, .recurse = true);
+        HRN_STORAGE_PATH_CREATE(storageSpoolWrite(), STORAGE_SPOOL_ARCHIVE_OUT);
+        HRN_STORAGE_PATH_REMOVE(storagePgWrite(), "pg_xlog/archive_status", .recurse = true);
+        HRN_STORAGE_PATH_CREATE(storagePgWrite(), "pg_xlog/archive_status");
+
+        // Create ready files for segments that have no WAL so each one errors. There are more ready files than the error limit to
+        // prove that processing stops early and leaves the remaining WAL for the next run.
+        for (unsigned int walIdx = 4; walIdx <= 9; walIdx++)
+            HRN_STORAGE_PUT_EMPTY(storagePgWrite(), zNewFmt("pg_xlog/archive_status/00000001000000010000000%u.ready", walIdx));
+
+        argListTemp = strLstDup(argList);
+        HRN_CFG_LOAD(cfgCmdArchivePush, argListTemp, .role = cfgCmdRoleAsync);
+
+        TEST_RESULT_VOID(cmdArchivePushAsync(), "push WAL segments");
+        TEST_RESULT_LOG_FMT(
+            "P00   INFO: push 6 WAL file(s) to archive: 000000010000000100000004...000000010000000100000009\n"
+            "P01   WARN: could not push WAL file '000000010000000100000004' to the archive (will be retried): "
+            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
+            "P01   WARN: could not push WAL file '000000010000000100000005' to the archive (will be retried): "
+            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
+            "P01   WARN: could not push WAL file '000000010000000100000006' to the archive (will be retried): "
+            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
+            "P01   WARN: could not push WAL file '000000010000000100000007' to the archive (will be retried): "
+            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
+            "P00   WARN: stopped archive-push after 3 error(s), remaining WAL will be processed on the next run",
+            TEST_PATH "/pg/pg_xlog/000000010000000100000004", TEST_PATH "/pg/pg_xlog/000000010000000100000005",
+            TEST_PATH "/pg/pg_xlog/000000010000000100000006", TEST_PATH "/pg/pg_xlog/000000010000000100000007");
+
+        // Only the segments processed before stopping have status files; the rest are left for the next run
+        TEST_STORAGE_LIST(
+            storageSpool(), STORAGE_SPOOL_ARCHIVE_OUT,
+            "000000010000000100000004.error\n"
+            "000000010000000100000005.error\n"
+            "000000010000000100000006.error\n"
+            "000000010000000100000007.error\n",
+            .comment = "check status files");
+
         // Uninstall local command handler shim
         hrnProtocolLocalShimUninstall();
     }

--- a/test/src/module/command/archivePushTest.c
+++ b/test/src/module/command/archivePushTest.c
@@ -878,7 +878,8 @@ testRun(void)
             "P01 DETAIL: pushed WAL file '000000010000000100000001' to the archive\n"
             "P01   WARN: could not push WAL file '000000010000000100000002' to the archive (will be retried): "
             "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
-            "            [RETRY DETAIL OMITTED]",
+            "            [RETRY DETAIL OMITTED]\n"
+            "P00   WARN: stopped archive-push after an error, remaining WAL will be processed on the next run",
             TEST_PATH "/pg/pg_xlog/000000010000000100000002");
 
         TEST_STORAGE_EXISTS(
@@ -1005,7 +1006,7 @@ testRun(void)
             .comment = "check status files");
 
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("stop async processing after too many errors");
+        TEST_TITLE("stop async processing after an error");
 
         // Remove status and ready files to get a clean state
         HRN_STORAGE_PATH_REMOVE(storageSpoolWrite(), STORAGE_SPOOL_ARCHIVE_OUT, .recurse = true);
@@ -1013,14 +1014,15 @@ testRun(void)
         HRN_STORAGE_PATH_REMOVE(storagePgWrite(), "pg_xlog/archive_status", .recurse = true);
         HRN_STORAGE_PATH_CREATE(storagePgWrite(), "pg_xlog/archive_status");
 
-        // Create ready files for segments that have no WAL so each one errors. There are more ready files than the error limit to
-        // prove that processing stops early and leaves the remaining WAL for the next run.
+        // Create ready files for segments that have no WAL so each one errors. There are more ready files than will be processed to
+        // prove that processing stops after an error and leaves the remaining WAL for the next run.
         for (unsigned int walIdx = 4; walIdx <= 9; walIdx++)
             HRN_STORAGE_PUT_EMPTY(storagePgWrite(), zNewFmt("pg_xlog/archive_status/00000001000000010000000%u.ready", walIdx));
 
         argListTemp = strLstDup(argList);
         HRN_CFG_LOAD(cfgCmdArchivePush, argListTemp, .role = cfgCmdRoleAsync);
 
+        // The job that errors and the one already in flight (process-max is 1) both complete, then scheduling stops
         TEST_RESULT_VOID(cmdArchivePushAsync(), "push WAL segments");
         TEST_RESULT_LOG_FMT(
             "P00   INFO: push 6 WAL file(s) to archive: 000000010000000100000004...000000010000000100000009\n"
@@ -1028,21 +1030,14 @@ testRun(void)
             "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
             "P01   WARN: could not push WAL file '000000010000000100000005' to the archive (will be retried): "
             "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
-            "P01   WARN: could not push WAL file '000000010000000100000006' to the archive (will be retried): "
-            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
-            "P01   WARN: could not push WAL file '000000010000000100000007' to the archive (will be retried): "
-            "[55] raised from local-1 shim protocol: " STORAGE_ERROR_READ_MISSING "\n"
-            "P00   WARN: stopped archive-push after 3 error(s), remaining WAL will be processed on the next run",
-            TEST_PATH "/pg/pg_xlog/000000010000000100000004", TEST_PATH "/pg/pg_xlog/000000010000000100000005",
-            TEST_PATH "/pg/pg_xlog/000000010000000100000006", TEST_PATH "/pg/pg_xlog/000000010000000100000007");
+            "P00   WARN: stopped archive-push after an error, remaining WAL will be processed on the next run",
+            TEST_PATH "/pg/pg_xlog/000000010000000100000004", TEST_PATH "/pg/pg_xlog/000000010000000100000005");
 
         // Only the segments processed before stopping have status files; the rest are left for the next run
         TEST_STORAGE_LIST(
             storageSpool(), STORAGE_SPOOL_ARCHIVE_OUT,
             "000000010000000100000004.error\n"
-            "000000010000000100000005.error\n"
-            "000000010000000100000006.error\n"
-            "000000010000000100000007.error\n",
+            "000000010000000100000005.error\n",
             .comment = "check status files");
 
         // Uninstall local command handler shim


### PR DESCRIPTION
When the repository was unavailable the async archive-push process kept trying every ready WAL segment, retrying each failure and writing an error file for it. Because the archive queue is only checked at the start of each run, a run could take so long that the WAL volume filled and PostgreSQL stopped before archive-push-queue-max was rechecked.

Exit the run as soon as any job errors so the async process is respawned by the next archive-push, which rechecks the queue and drops WAL once it exceeds archive-push-queue-max. Continuing past an error cannot relieve disk pressure because PostgreSQL cannot recycle any WAL past the oldest unarchived segment, so the segments pushed ahead free nothing; the only relief is the queue-max drop. job-retry already absorbs transient failures before they are reported here, so a reported error is a real failure and there is little benefit to continuing.

In-flight jobs are allowed to finish so their status is recorded and no segment is pushed twice.