### PR TITLE
Document that info reads encryption settings from global section.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -307,6 +307,23 @@
         </release-development-list>
     </release-core-list>
 
+    <release-doc-list>
+        <release-improvement-list>
+            <release-item>
+                <github-issue id="1407"/>
+                <github-pull-request id="2805"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="ron.johnson"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Document that info reads encryption settings from global section.</p>
+            </release-item>
+        </release-improvement-list>
+    </release-doc-list>
+
     <release-test-list>
         <release-improvement-list>
             <release-item>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -1351,6 +1351,8 @@
                 <backrest-config-option section="global" key="repo1-cipher-pass">{[backrest-repo-cipher-pass]}</backrest-config-option>
             </backrest-config>
 
+            <admonition type="note">Encryption settings are placed in the <id>[global]</id> section, above, so the <cmd>info</cmd> command can read all stanzas. Without the <br-option>stanza</br-option> option the <cmd>info</cmd> command reads encryption settings only from the <id>[global]</id> section, so encryption settings configured per stanza require the <br-option>stanza</br-option> option to read an encrypted stanza.</admonition>
+
             <p>Once the repository has been configured and the stanza created and checked, the repository encryption settings cannot be changed.</p>
         </section>
 

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1422,6 +1422,8 @@
 
                         <text>
                             <p>Passphrase used to encrypt/decrypt files of the repository.</p>
+
+                            <admonition type="note">When run without the <br-option>stanza</br-option> option the <cmd>info</cmd> command reads encryption settings only from the <setting>global</setting> section. If encryption settings are configured per stanza, run the <cmd>info</cmd> command with the <br-option>stanza</br-option> option to read an encrypted stanza.</admonition>
                         </text>
 
                         <example>zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO</example>

--- a/test/src/module/command/helpTest.c
+++ b/test/src/module/command/helpTest.c
@@ -504,6 +504,11 @@ testRun(void)
             "\n"
             "Passphrase used to encrypt/decrypt files of the repository.\n"
             "\n"
+            "NOTE: When run without the stanza option the info command reads encryption\n"
+            "settings only from the global section. If encryption settings are configured\n"
+            "per stanza, run the info command with the stanza option to read an encrypted\n"
+            "stanza.\n"
+            "\n"
             "current: <redacted>\n",
             helpVersion);
 


### PR DESCRIPTION
The info command reads encryption settings only from the global section when run without the stanza option, so encryption settings configured per stanza require the stanza option to read an encrypted stanza. Note this in the user guide encryption section and the repo-cipher-pass config reference.