### PR TITLE
Document that expire-auto uses the backup command configuration.

### DIFF
--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -335,6 +335,19 @@
 
                 <p>Document that info reads encryption settings from global section.</p>
             </release-item>
+
+            <release-item>
+                <github-issue id="1874"/>
+                <github-pull-request id="2807"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="sebastien.lardiere"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Document that <setting>expire-auto</setting> uses the <cmd>backup</cmd> command configuration.</p>
+            </release-item>
         </release-improvement-list>
     </release-doc-list>
 

--- a/src/build/help/help.xml
+++ b/src/build/help/help.xml
@@ -1556,6 +1556,8 @@
 
                         <text>
                             <p>The setting is enabled by default. Use caution when disabling this option as doing so will result in retaining all backups and archives indefinitely, which could cause your repository to run out of space. The <cmd>expire</cmd> command will need to be run regularly to prevent this from happening.</p>
+
+                            <p>When <cmd>expire</cmd> is run automatically after a successful backup it uses the configuration of the <cmd>backup</cmd> command, so options set only in an <cmd>expire</cmd> command section (e.g. <id>[global:expire]</id>) are not applied. To apply <cmd>expire</cmd>-specific configuration, disable this option and run the <cmd>expire</cmd> command separately.</p>
                         </text>
 
                         <example>y</example>


### PR DESCRIPTION
When expire runs automatically after a successful backup it uses the configuration loaded for the backup command, so options set only in an expire command section are not applied. Note this behavior in the expire-auto option help and point users to disabling it and running expire separately when expire-specific configuration is needed.