### PR TITLE
v2.59.0: PostgreSQL 19 Support

### DIFF
--- a/.github/workflows/test-dist.yml
+++ b/.github/workflows/test-dist.yml
@@ -96,6 +96,7 @@ jobs:
               | grep -E "pgbackrest-[^/]+/(${files})\$" \
               | awk '$3 == 0 { print "ERROR: zero-size file: " $NF; rc = 1 } END { exit rc }'
 
+      # The release process depends on the upload filename so do not modify it without also modifying the release process
       - name: Upload Tarball
         uses: actions/upload-artifact@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,8 +348,8 @@ pgbackrest/test/test.pl --vm-build --vm=u22
 --- output ---
 
     P00   INFO: test begin on x86_64 - log level info
-    P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 ...
-    P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 image
+    P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260717A-bbc27d6dee5c ...
+    P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260717A-bbc27d6dee5c image
     P00   INFO: Building ghcr.io/pgbackrest/test:u22-test-x86_64 image ...
     P00   INFO: Build Complete
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,7 +260,7 @@ pgbackrest/test/test.pl --vm-out --module=common --test=wait
                 
     P00   INFO: P1-T1/1 - vm=none, module=common, test=wait
                 
-        P00   INFO: test command begin 2.58.0: [common/wait] --log-level=info --no-log-timestamp --repo-path=/home/vagrant/test/repo --scale=1 --test-path=/home/vagrant/test --vm=none --vm-id=0
+        P00   INFO: test command begin 2.59.0: [common/wait] --log-level=info --no-log-timestamp --repo-path=/home/vagrant/test/repo --scale=1 --test-path=/home/vagrant/test --vm=none --vm-id=0
         P00   INFO: test command end: completed successfully
         run 1 - waitNew(), waitMore, and waitFree()
                       L0018     expect AssertError: assertion 'waitTime <= 999999000' failed
@@ -348,8 +348,9 @@ pgbackrest/test/test.pl --vm-build --vm=u22
 --- output ---
 
     P00   INFO: test begin on x86_64 - log level info
-    P00   INFO: Using cached pgbackrest/test:u22-base-x86_64-20260119A image (8ee008aecbcf21b205116969db4000838c989a4a) ...
-    P00   INFO: Building pgbackrest/test:u22-test-x86_64 image ...
+    P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 ...
+    P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 image
+    P00   INFO: Building ghcr.io/pgbackrest/test:u22-test-x86_64 image ...
     P00   INFO: Build Complete
 ```
 > **NOTE:** to build all the vms, just omit the `--vm` option above.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 pgBackRest is a reliable backup and restore solution for PostgreSQL that seamlessly scales up to the largest databases and workloads.
 
-pgBackRest [v2.58.0](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.58.0) is the current stable release. Release notes are on the [Releases](https://pgbackrest.org/release.html) page.
+pgBackRest [v2.59.0](https://github.com/pgbackrest/pgbackrest/releases/tag/release/2.59.0) is the current stable release. Release notes are on the [Releases](https://pgbackrest.org/release.html) page.
 
 Please give us a star on [GitHub](https://github.com/pgbackrest/pgbackrest) if you like pgBackRest!
 
 ## News
 
+**July 20, 2026** - [New Distribution Tarball](https://pgbackrest.org/news.html#distribution-tarball)
+
+**July 20, 2026** - [pgBackRest 2.59.0 Released](https://pgbackrest.org/news.html#release-2-59-0)
+
 **May 18, 2026** - [pgBackRest Will Continue!](https://pgbackrest.org/news.html#will-continue)
-
-**May 7, 2026** - [Maintenance Update](https://pgbackrest.org/news.html#maintenance-update)
-
-**April 27, 2026** - [pgBackRest Is No Longer Being Maintained](https://pgbackrest.org/news.html#no-longer-maintained)
 
 ## Sponsors
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -67,7 +67,7 @@ tar czvf pgbackrest.tgz cov-int
 - Upload results:
 ```
 curl --form token=${COVERITY_TOKEN?} --form email="${COVERITY_EMAIL?}" --form file=@pgbackrest.tgz \
-    --form version="${COVERITY_VERSION?}" --form description="dev build" \
+    --form version="${COVERITY_VERSION?}" --form description="pre-release build" \
     "https://scan.coverity.com/builds?project=pgbackrest%2Fpgbackrest"
 ```
 
@@ -144,14 +144,14 @@ Wait for CI testing to complete before proceeding to the next step.
 
 ## Create release on Github and dist tarball
 
-Set the release variables. `GITHUB_TOKEN` needs the `contents: write` permission:
+Set the release variables. `GITHUB_TOKEN` needs the `contents: write` permission to create the release and `actions: read` to download the tarball artifact (a classic token with the `repo` scope covers both):
 ```
 export GITHUB_TOKEN=?
 export GITHUB_REPO=pgbackrest/pgbackrest
 export GIT_BRANCH=integration
 ```
 
-Build the distribution tarball from a fresh checkout so the tree is clean for `meson dist`. Run the commands below from an empty directory.
+Release the distribution tarball that CI built and tested for the release commit rather than building one locally. Every push to the release branch builds the tarball, checks it for missing files, and smoke tests it on a range of distributions, so the most recent run's artifact is the exact tested bytes to release. Run the commands below from an empty directory.
 
 Shallow clone the release branch, then derive the version, release commit, and commit subject from the checkout. `RELEASE_COMMIT` is the tip commit, but only if its subject starts with `v${VERSION}:` -- if it comes back blank a later commit was added and the release steps are out of order:
 ```
@@ -164,23 +164,31 @@ echo ${RELEASE_COMMIT?}
 echo ${RELEASE_TITLE?}
 ```
 
-Generate the distribution documentation. This writes the man page and HTML to `dist/repo/doc/output`, which the dist tarball picks up (the gitignored output does not dirty the tree):
+Find the most recent CI run for the release branch and confirm it built the release commit and passed. A mismatch means CI has not finished for the release commit or a later commit has landed; a non-success conclusion means the tarball was not fully tested:
 ```
-dist/repo/doc/release.pl --dist
-```
-
-Configure the build and build the code generator, which the dist script uses to produce the shipped files:
-```
-meson setup dist/build dist/repo
-ninja -C dist/build src/build-code
-```
-
-Build the tarball. `meson dist` runs `src/build/dist.sh` to generate the `.inc` files, copy the documentation into `doc`, and write the `dist` marker, then builds and tests the extracted tarball to confirm it compiles without the code generation tooling:
-```
-meson dist -C dist/build --formats gztar
+RUN=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN?}" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_REPO?}/actions/workflows/test.yml/runs?branch=${GIT_BRANCH?}&per_page=1")
+export RUN_ID=$(echo "${RUN?}" | jq -r '.workflow_runs[0].id')
+RUN_SHA=$(echo "${RUN?}" | jq -r '.workflow_runs[0].head_sha')
+RUN_STATUS=$(echo "${RUN?}" | jq -r '.workflow_runs[0].conclusion')
+echo "run ${RUN_ID?} ${RUN_SHA?} ${RUN_STATUS?}"
+[ "${RUN_SHA?}" = "${RELEASE_COMMIT?}" ] && [ "${RUN_STATUS?}" = "success" ] || { echo "not a passing build of the release commit"; false; }
 ```
 
-This produces `dist/build/meson-dist/pgbackrest-2.14.0.tar.gz` (named from the version in `meson.build`) along with its `pgbackrest-2.14.0.tar.gz.sha256sum` checksum. A successful `meson dist` means the tarball is self-contained and is the exact artifact to release.
+That run uploads the tarball as the `dist-tarball` artifact. Get its download URL, then download and extract it. The download needs the token, and GitHub wraps artifacts in a zip so it must be unzipped to get the tarball:
+```
+export ARTIFACT_URL=$(curl -sS -H "Authorization: Bearer ${GITHUB_TOKEN?}" -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_REPO?}/actions/runs/${RUN_ID?}/artifacts?name=dist-tarball" \
+    | jq -r '.artifacts[0].archive_download_url')
+mkdir -p dist/build/meson-dist
+curl -sSL -H "Authorization: Bearer ${GITHUB_TOKEN?}" "${ARTIFACT_URL?}" -o dist/dist-tarball.zip
+unzip -o dist/dist-tarball.zip -d dist/build/meson-dist
+```
+
+The artifact ships only the tarball, so regenerate its checksum. The result is identical to CI's since it is the same bytes, and it lands at the path the upload step below expects, `dist/build/meson-dist/pgbackrest-{version}.tar.gz` with its `pgbackrest-{version}.tar.gz.sha256sum`:
+```
+( cd dist/build/meson-dist && sha256sum pgbackrest-${VERSION?}.tar.gz > pgbackrest-${VERSION?}.tar.gz.sha256sum )
+```
 
 Immutable releases are enabled, so release assets are locked once the release is published. Create the release as a draft with the tarball attached, then set the notes and publish it in the next section.
 
@@ -234,7 +242,6 @@ rm -rf .cache/ccache
 meson setup dist/verify/build dist/verify/pgbackrest-${VERSION?}
 ninja -C dist/verify/build
 dist/verify/build/src/pgbackrest version
-meson test -C build --suite smoke
 ```
 
 ## Push to main

--- a/doc/manifest.xml
+++ b/doc/manifest.xml
@@ -99,6 +99,7 @@
 
         <render type="markdown">
             <render-source key="index" file="../../../README.md"/>
+            <render-source key="news" file="../../NEWS.md"/>
             <render-source key="coding" file="../../../CODING.md"/>
 
             <!--

--- a/doc/resource/exe.cache
+++ b/doc/resource/exe.cache
@@ -258,8 +258,8 @@
                "value" : {
                   "output" : [
                      "P00   INFO: test begin on x86_64 - log level info",
-                     "P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 ...",
-                     "P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 image",
+                     "P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260717A-bbc27d6dee5c ...",
+                     "P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260717A-bbc27d6dee5c image",
                      "P00   INFO: Building ghcr.io/pgbackrest/test:u22-test-x86_64 image ...",
                      "P00   INFO: Build Complete"
                   ]
@@ -505,7 +505,7 @@
                   "output" : [
                      "ninja: Entering directory `/build/pgbackrest'",
                      "ninja: no work to do.",
-                     "1/1 smoke OK               13.27s",
+                     "1/1 smoke OK               14.97s",
                      "",
                      "",
                      "       [filtered 7 lines of output]"
@@ -1050,7 +1050,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=416-8d9d3f53 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=415-78abd183 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -1077,10 +1077,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=425-d4d91767 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=424-13bdd96c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000100000000/000000010000000000000001-6d2c90e42839a6548583657daf286adff240b4b8.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000100000000/000000010000000000000001-da969c4afd42c88e82d82b8072c86786941339bf.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -1137,16 +1137,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=452-8587e630 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=451-8c17d67f --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000002:000000010000000000000003",
-                     "P00   INFO: new backup label = 20260716-105931F",
+                     "P00   INFO: new backup label = 20260720-005040F",
                      "P00   INFO: full backup size = 22MB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=452-8587e630 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=451-8c17d67f --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -1164,7 +1164,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105931F"
+                     "20260720-005040F"
                   ]
                }
             },
@@ -1192,10 +1192,10 @@
                   "output" : [
                      "       [filtered 7 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000004:000000010000000000000005",
-                     "P00   INFO: new backup label = 20260716-105931F_20260716-105934D",
+                     "P00   INFO: new backup label = 20260720-005040F_20260720-005043D",
                      "P00   INFO: diff backup size = 8.3KB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=479-21b56bef --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=478-06c17053 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -1227,14 +1227,14 @@
                      "    db (current)",
                      "        wal archive min/max (17): 000000010000000000000001/000000010000000000000005",
                      "",
-                     "        full backup: 20260716-105931F",
-                     "            timestamp start/stop: 2026-07-16 10:59:31+00 / 2026-07-16 10:59:33+00",
+                     "        full backup: 20260720-005040F",
+                     "            timestamp start/stop: 2026-07-20 00:50:40+00 / 2026-07-20 00:50:42+00",
                      "            wal start/stop: 000000010000000000000002 / 000000010000000000000003",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup set size: 2.9MB, backup size: 2.9MB",
                      "",
-                     "        diff backup: 20260716-105931F_20260716-105934D",
-                     "            timestamp start/stop: 2026-07-16 10:59:34+00 / 2026-07-16 10:59:35+00",
+                     "        diff backup: 20260720-005040F_20260720-005043D",
+                     "            timestamp start/stop: 2026-07-20 00:50:43+00 / 2026-07-20 00:50:44+00",
                      "            wal start/stop: 000000010000000000000004 / 000000010000000000000005",
                      "            database size: 22MB, database backup size: 8.3KB",
                      "            repo1: backup set size: 2.9MB, backup size: 464B",
@@ -1491,7 +1491,7 @@
                   "output" : [
                      "  name  | last_successful_backup |    last_archived_wal     ",
                      "--------+------------------------+--------------------------",
-                     " \"demo\" | 2026-07-16 10:59:35+00 | 000000010000000000000005",
+                     " \"demo\" | 2026-07-20 00:50:44+00 | 000000010000000000000005",
                      "(1 row)"
                   ]
                }
@@ -1525,7 +1525,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "1784199575"
+                     "1784508644"
                   ]
                }
             },
@@ -1670,7 +1670,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105951F"
+                     "20260720-005100F"
                   ]
                }
             },
@@ -1678,7 +1678,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-005100F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -1702,10 +1702,10 @@
                      "    db (current)",
                      "        wal archive min/max (17): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260716-105951F",
-                     "            timestamp start/stop: 2026-07-16 10:59:51+00 / 2026-07-16 10:59:54+00",
+                     "        full backup: 20260720-005100F",
+                     "            timestamp start/stop: 2026-07-20 00:51:00+00 / 2026-07-20 00:51:02+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
-                     "            lsn start/stop: 0/8000028 / 0/9000088",
+                     "            lsn start/stop: 0/8000028 / 0/9000050",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup size: 2.9MB",
                      "            database list: postgres (5)",
@@ -1719,7 +1719,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F \\",
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-005100F \\",
                      "    --annotation=key= --annotation=new_key=new_value annotate"
                   ],
                   "host" : "pg-primary",
@@ -1733,7 +1733,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-005100F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -1757,10 +1757,10 @@
                      "    db (current)",
                      "        wal archive min/max (17): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260716-105951F",
-                     "            timestamp start/stop: 2026-07-16 10:59:51+00 / 2026-07-16 10:59:54+00",
+                     "        full backup: 20260720-005100F",
+                     "            timestamp start/stop: 2026-07-20 00:51:00+00 / 2026-07-20 00:51:02+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
-                     "            lsn start/stop: 0/8000028 / 0/9000088",
+                     "            lsn start/stop: 0/8000028 / 0/9000050",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup size: 2.9MB",
                      "            database list: postgres (5)",
@@ -1813,7 +1813,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260716-105931F|remove archive"
+                        "archive retention on backup 20260720-005040F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1825,8 +1825,8 @@
                "value" : {
                   "output" : [
                      "       [filtered 975 lines of output]",
-                     "P00   INFO: repo1: remove expired backup 20260716-105949F",
-                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105951F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: remove expired backup 20260720-005057F",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260720-005100F, start = 000000020000000000000008",
                      "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
@@ -1846,7 +1846,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105955F"
+                     "20260720-005103F"
                   ]
                }
             },
@@ -1861,7 +1861,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire full backup set 20260716-105931F|archive retention on backup 20260716-105955F|remove archive"
+                        "expire full backup set 20260720-005040F|archive retention on backup 20260720-005103F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1873,9 +1873,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 11 lines of output]",
-                     "P00   INFO: repo1: expire full backup 20260716-105951F",
-                     "P00   INFO: repo1: remove expired backup 20260716-105951F",
-                     "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
+                     "P00   INFO: repo1: expire full backup 20260720-005100F",
+                     "P00   INFO: repo1: remove expired backup 20260720-005100F",
+                     "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000008, stop = 00000002000000000000000A",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1940,7 +1940,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105957F_20260716-105959D"
+                     "20260720-005106F_20260720-005108D"
                   ]
                }
             },
@@ -1968,7 +1968,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire diff backup set 20260716-105957F_20260716-105959D"
+                        "expire diff backup set 20260720-005106F_20260720-005108D"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1981,10 +1981,10 @@
                   "output" : [
                      "       [filtered 10 lines of output]",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=952-974c432c --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
-                     "P00   INFO: repo1: expire diff backup set 20260716-105957F_20260716-105959D, 20260716-105957F_20260716-110000I",
-                     "P00   INFO: repo1: remove expired backup 20260716-105957F_20260716-110000I",
-                     "P00   INFO: repo1: remove expired backup 20260716-105957F_20260716-105959D",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=952-88e66707 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
+                     "P00   INFO: repo1: expire diff backup set 20260720-005106F_20260720-005108D, 20260720-005106F_20260720-005109I",
+                     "P00   INFO: repo1: remove expired backup 20260720-005106F_20260720-005109I",
+                     "P00   INFO: repo1: remove expired backup 20260720-005106F_20260720-005108D",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -2036,7 +2036,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105957F_20260716-110001D"
+                     "20260720-005106F_20260720-005110D"
                   ]
                }
             },
@@ -2080,7 +2080,7 @@
                      "       [filtered 6 lines of output]",
                      "P00   INFO: backup stop archive = 000000020000000000000017, lsn = 0/17000050",
                      "P00   INFO: check archive for segment(s) 000000020000000000000016:000000020000000000000017",
-                     "P00   INFO: new backup label = 20260716-105957F_20260716-110004D",
+                     "P00   INFO: new backup label = 20260720-005106F_20260720-005112D",
                      "P00   INFO: diff backup size = 8.3KB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
                      "       [filtered 2 lines of output]"
@@ -2101,7 +2101,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105957F_20260716-110004D"
+                     "20260720-005106F_20260720-005112D"
                   ]
                }
             },
@@ -2116,7 +2116,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260716-105957F_20260716-110001D|remove archive"
+                        "archive retention on backup 20260720-005106F_20260720-005110D|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -2127,11 +2127,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1035-060f721b --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105955F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F_20260716-110001D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F_20260716-110004D, start = 000000020000000000000016",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1034-c8a8377e --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260720-005103F, start = 00000002000000000000000B, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260720-005106F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260720-005106F_20260720-005110D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260720-005106F_20260720-005112D, start = 000000020000000000000016",
                      "P00   INFO: repo1: 17-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
                      "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
                      "P00   INFO: expire command end: completed successfully"
@@ -2179,13 +2179,13 @@
                      "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/17/demo'",
                      "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/backup_label.old'",
                      "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/base/1/pg_internal.init'",
-                     "       [filtered 13 lines of output]",
-                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/postmaster.opts'",
-                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/backup_label (260B, 0.00%) checksum 3d708d165060df9b75bc052ca22668cfb52b7440",
-                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/PG_VERSION - exists and matches backup (bundle 20260716-105957F/1/0, 3B, 0.00%) checksum ad48103e4fc71796e9708cafc43adeed0d1076b7",
-                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/pg_multixact/members/0000 - exists and matches backup (bundle 20260716-105957F/1/24, 8KB, 0.04%) checksum 0631457264ff7f8d5fb1edc2c0211992a67c73e6",
-                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/global/pg_filenode.map - exists and matches backup (bundle 20260716-105957F/1/64, 524B, 0.04%) checksum 3de878cf56cdb80345e88da11f91bc6d46f9f804",
-                     "       [filtered 989 lines of output]"
+                     "       [filtered 129 lines of output]",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/base/1/113 - exists and matches backup (bundle 20260720-005106F/1/58072, 8KB, 5.76%) checksum 1cd643347b87a472ff001ae124e4b532ce998d2f",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/base/1/112 - exists and matches backup (bundle 20260720-005106F/1/58160, 8KB, 5.79%) checksum 2cbd5cf8fb22ef627eb539776c5ec7457bdb2890",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/PG_VERSION - exists and matches backup (bundle 20260720-005106F/1/58248, 3B, 5.79%) checksum ad48103e4fc71796e9708cafc43adeed0d1076b7",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/global/6303 - exists and matches backup (bundle 20260720-005106F/1/58272, 16KB, 5.86%) checksum f5bab995185b4b5cc2a02777c157dff2937879bf",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/global/6302 - exists and matches backup (bundle 20260720-005106F/1/58480, 16KB, 5.94%) checksum eb54339bce7ce3a899043e950ba88034d2450218",
+                     "       [filtered 873 lines of output]"
                   ]
                }
             },
@@ -2354,7 +2354,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105957F_20260716-110012I"
+                     "20260720-005106F_20260720-005120I"
                   ]
                }
             },
@@ -2363,7 +2363,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo \\",
-                     "    --set=20260716-105957F_20260716-110012I info"
+                     "    --set=20260720-005106F_20260720-005120I info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2382,7 +2382,7 @@
                   "output" : [
                      "       [filtered 12 lines of output]",
                      "            repo1: backup size: 1.9MB",
-                     "            backup reference list: 20260716-105957F, 20260716-105957F_20260716-110004D",
+                     "            backup reference list: 20260720-005106F, 20260720-005106F_20260720-005112D",
                      "            database list: postgres (5), test1 (32768), test2 (32769)"
                   ]
                }
@@ -2614,7 +2614,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-07-16 11:00:24.130959+00"
+                     "2026-07-20 00:51:32.323409+00"
                   ]
                }
             },
@@ -2691,7 +2691,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105957F_20260716-110025I"
+                     "20260720-005106F_20260720-005133I"
                   ]
                }
             },
@@ -2705,7 +2705,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "20260716-105957F_20260716-110025I"
+                        "20260720-005106F_20260720-005133I"
                      ]
                   },
                   "host" : "pg-primary",
@@ -2719,8 +2719,8 @@
                      "       [filtered 38 lines of output]",
                      "            backup reference total: 1 full, 1 diff",
                      "",
-                     "        incr backup: 20260716-105957F_20260716-110025I",
-                     "            timestamp start/stop: 2026-07-16 11:00:25+00 / 2026-07-16 11:00:27+00",
+                     "        incr backup: 20260720-005106F_20260720-005133I",
+                     "            timestamp start/stop: 2026-07-20 00:51:33+00 / 2026-07-20 00:51:35+00",
                      "            wal start/stop: 00000004000000000000001A / 00000004000000000000001A",
                      "       [filtered 2 lines of output]"
                   ]
@@ -2744,8 +2744,8 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --set=20260716-105957F_20260716-110025I --target-timeline=current \\",
-                     "    --type=time \"--target=2026-07-16 11:00:24.130959+00\" --target-action=promote restore"
+                     "    --set=20260720-005106F_20260720-005133I --target-timeline=current \\",
+                     "    --type=time \"--target=2026-07-20 00:51:32.323409+00\" --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2804,7 +2804,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --type=time \"--target=2026-07-16 11:00:24.130959+00\" \\",
+                     "    --type=time \"--target=2026-07-20 00:51:32.323409+00\" \\",
                      "    --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
@@ -2849,9 +2849,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 9 lines of output]",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "recovery_target_time = '2026-07-16 11:00:24.130959+00'",
+                     "recovery_target_time = '2026-07-20 00:51:32.323409+00'",
                      "recovery_target_action = 'promote'"
                   ]
                }
@@ -2934,15 +2934,15 @@
                      "       [filtered 7 lines of output]",
                      "LOG:  restored log file \"00000004.history\" from archive",
                      "LOG:  restored log file \"000000040000000000000019\" from archive",
-                     "LOG:  starting point-in-time recovery to 2026-07-16 11:00:24.130959+00",
+                     "LOG:  starting point-in-time recovery to 2026-07-20 00:51:32.323409+00",
                      "LOG:  restored log file \"00000003.history\" from archive",
                      "LOG:  redo starts at 0/19000028",
                      "       [filtered 2 lines of output]",
                      "LOG:  database system is ready to accept read-only connections",
                      "LOG:  restored log file \"00000004000000000000001A\" from archive",
-                     "LOG:  recovery stopping before commit of transaction 748, time 2026-07-16 11:00:25.574422+00",
+                     "LOG:  recovery stopping before commit of transaction 748, time 2026-07-20 00:51:33.723321+00",
                      "LOG:  redo done at 0/1901CC00 system usage: CPU: user: 0.00 s, system: 0.02 s, elapsed: 0.10 s",
-                     "LOG:  last completed transaction was at log time 2026-07-16 11:00:22.732209+00",
+                     "LOG:  last completed transaction was at log time 2026-07-20 00:51:30.931579+00",
                      "LOG:  restored log file \"000000040000000000000019\" from archive",
                      "LOG:  selected new timeline ID: 5",
                      "       [filtered 5 lines of output]"
@@ -2983,7 +2983,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stop command begin 2.59.0: --exec-id=1564-85de7e3e --log-level-console=info --no-log-timestamp --stanza=demo",
+                     "P00   INFO: stop command begin 2.59.0: --exec-id=1563-7c6f409e --log-level-console=info --no-log-timestamp --stanza=demo",
                      "P00   INFO: stop command end: completed successfully"
                   ]
                }
@@ -3010,7 +3010,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=1572-6d1c9f33 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=1571-372cc4e9 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -3131,7 +3131,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1653-117c526b --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1652-548991ed --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -3160,16 +3160,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=1662-722fcb35 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1661-ae2af622 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001B, lsn = 0/1B000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001B:00000005000000000000001B",
-                     "P00   INFO: new backup label = 20260716-110042F",
+                     "P00   INFO: new backup label = 20260720-005151F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1662-722fcb35 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1661-ae2af622 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
                   ]
                }
             },
@@ -3369,16 +3369,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=1765-94bfc14c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1763-f64148cd --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001D, lsn = 0/1D000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001D:00000005000000000000001D",
-                     "P00   INFO: new backup label = 20260716-110102F",
+                     "P00   INFO: new backup label = 20260720-005210F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1765-94bfc14c --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1763-f64148cd --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
                   ]
                }
             },
@@ -3396,7 +3396,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-07-16 11:01:20+00"
+                     "2026-07-20 00:52:29+00"
                   ]
                }
             },
@@ -3623,7 +3623,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=1856-dc7abe2f --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1854-09375597 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
@@ -3631,10 +3631,10 @@
                      "P00   INFO: backup start archive = 00000005000000000000001F, lsn = 0/1F000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001F:00000005000000000000001F",
-                     "P00   INFO: new backup label = 20260716-110123F",
+                     "P00   INFO: new backup label = 20260720-005234F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1856-dc7abe2f --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1854-09375597 --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -3812,9 +3812,9 @@
                      "+--------+----------------------------+-------------------------------------+",
                      "| Action |         Modified           |               Object                |",
                      "+--------+----------------------------+-------------------------------------+",
-                     "|  PUT   |  2026-07-16T11:01:02.464Z  |  demo-repo/backup/demo/backup.info  |",
-                     "|  PUT   |  2026-07-16T11:01:19.990Z  |  demo-repo/backup/demo/backup.info  |",
-                     "|  DELETE|  2026-07-16T11:01:29.959Z  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-20T00:52:10.222Z  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-20T00:52:29.141Z  |  demo-repo/backup/demo/backup.info  |",
+                     "|  DELETE|  2026-07-20T00:52:41.328Z  |  demo-repo/backup/demo/backup.info  |",
                      "+--------+----------------------------+-------------------------------------+"
                   ]
                }
@@ -3824,7 +3824,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 \\",
-                     "    --repo-target-time=\"2026-07-16 11:01:20+00\" info"
+                     "    --repo-target-time=\"2026-07-20 00:52:29+00\" info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -3844,8 +3844,8 @@
                      "       [filtered 5 lines of output]",
                      "        wal archive min/max (17): 00000005000000000000001C/00000005000000000000001D",
                      "",
-                     "        full backup: 20260716-110102F",
-                     "            timestamp start/stop: 2026-07-16 11:01:02+00 / 2026-07-16 11:01:19+00",
+                     "        full backup: 20260720-005210F",
+                     "            timestamp start/stop: 2026-07-20 00:52:10+00 / 2026-07-20 00:52:28+00",
                      "            wal start/stop: 00000005000000000000001D / 00000005000000000000001D",
                      "            repo3: backup set size: 3.8MB, backup size: 3.8MB"
                   ]
@@ -3856,7 +3856,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 --delta \\",
-                     "    --repo-target-time=\"2026-07-16 11:01:20+00\" --log-level-console=info restore"
+                     "    --repo-target-time=\"2026-07-20 00:52:29+00\" --log-level-console=info restore"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -3873,8 +3873,8 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=1950-39d23b15 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-16 11:01:20+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
-                     "P00   INFO: repo3: restore backup set 20260716-110102F, recovery will start at 2026-07-16 11:01:02",
+                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=1948-6793703a --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-20 00:52:29+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
+                     "P00   INFO: repo3: restore backup set 20260720-005210F, recovery will start at 2026-07-20 00:52:10",
                      "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/17/demo'",
                      "P00   INFO: write updated /var/lib/postgresql/17/demo/postgresql.auto.conf",
                      "       [filtered 2 lines of output]"
@@ -4492,14 +4492,14 @@
                      "    db (current)",
                      "        wal archive min/max (17): 000000070000000000000023/000000070000000000000025",
                      "",
-                     "        full backup: 20260716-110213F",
-                     "            timestamp start/stop: 2026-07-16 11:02:13+00 / 2026-07-16 11:02:17+00",
+                     "        full backup: 20260720-005325F",
+                     "            timestamp start/stop: 2026-07-20 00:53:25+00 / 2026-07-20 00:53:29+00",
                      "            wal start/stop: 000000070000000000000023 / 000000070000000000000023",
                      "            database size: 29.2MB, database backup size: 29.2MB",
                      "            repo1: backup set size: 3.8MB, backup size: 3.8MB",
                      "",
-                     "        full backup: 20260716-110219F",
-                     "            timestamp start/stop: 2026-07-16 11:02:19+00 / 2026-07-16 11:02:24+00",
+                     "        full backup: 20260720-005331F",
+                     "            timestamp start/stop: 2026-07-20 00:53:31+00 / 2026-07-20 00:53:36+00",
                      "            wal start/stop: 000000070000000000000024 / 000000070000000000000025",
                      "            database size: 29.2MB, database backup size: 29.2MB",
                      "            repo1: backup set size: 3.8MB, backup size: 3.8MB"
@@ -4943,24 +4943,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:59:37",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:50:46",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:06",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:51:14",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_time = '2026-07-16 11:00:24.130959+00'",
-                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:52:47 # recovery_target_time = '2026-07-20 00:51:32.323409+00'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:52:47 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:01:35",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 11:01:20+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:52:47",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-20 00:52:29+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:06",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:53:18",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:42",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:53:55",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
                }
@@ -5151,7 +5151,7 @@
                   "output" : [
                      " pg_switch_wal |       current_timestamp       ",
                      "---------------+-------------------------------",
-                     " 0/260195C8    | 2026-07-16 11:02:51.131426+00",
+                     " 0/26019600    | 2026-07-20 00:54:03.825464+00",
                      "(1 row)"
                   ]
                }
@@ -5178,9 +5178,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "    message     |      current_timestamp       ",
-                     "----------------+------------------------------",
-                     " Important Data | 2026-07-16 11:02:52.92811+00",
+                     "    message     |       current_timestamp       ",
+                     "----------------+-------------------------------",
+                     " Important Data | 2026-07-20 00:54:05.488701+00",
                      "(1 row)"
                   ]
                }
@@ -5206,7 +5206,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=488-6d9cbe16 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=487-8da2e26b --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -5356,24 +5356,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:59:37",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:50:46",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:06",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:51:14",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_time = '2026-07-16 11:00:24.130959+00'",
-                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:52:47 # recovery_target_time = '2026-07-20 00:51:32.323409+00'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:52:47 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:01:35",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 11:01:20+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:52:47",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-20 00:52:29+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:06",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:53:18",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:56",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:54:08",
                      "primary_conninfo = 'host=172.17.0.6 port=5432 user=replicator'",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
@@ -5475,7 +5475,7 @@
                      "       [filtered 4 lines of output]",
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-07-16 11:03:03.936939+00",
+                     " Important Data | 2026-07-20 00:54:16.127931+00",
                      "(1 row)"
                   ]
                }
@@ -5502,9 +5502,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "    message     |       current_timestamp       ",
-                     "----------------+-------------------------------",
-                     " Important Data | 2026-07-16 11:03:04.365141+00",
+                     "    message     |      current_timestamp       ",
+                     "----------------+------------------------------",
+                     " Important Data | 2026-07-20 00:54:16.56118+00",
                      "(1 row)"
                   ]
                }
@@ -5926,7 +5926,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=383-bcf8f14c --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=382-e3df02cb --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -5953,11 +5953,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=393-113428ec --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=392-66f94f82 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000001-25ac74677469a7daae1d1da6a7865d53a8fe2d04.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000001-203efafdd9df967f3a930969cc53b0303472f932.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -5983,15 +5983,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=1257-09213903 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1257-861abd63 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
                      "P00   INFO: check stanza 'demo'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/000000070000000000000027-9575963e3d490c9850a005702d908a3a356a6024.gz' on repo1",
+                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/000000070000000000000027-221bbbda8246b36621dd12ef128e8906b5b1f9ea.gz' on repo1",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000002-7f91d707821a5537890cc0ca6368265776662e45.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000002-e9f6eb2b48ad5cb3b1a169259690bbff3d7a2805.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -6222,10 +6222,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=2584-4848adfa --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=2581-64d295fa --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/00000007000000000000002D-b80ba4b534c54d64c41bd71d7c11fabd0a56eb81.gz' on repo1",
+                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/00000007000000000000002D-d2d2b7910f776f59b73a176513de8e15846608b8.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -6252,13 +6252,13 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2570-9158d236 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2567-fdf7e175 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 000000070000000000000028",
                      "P01 DETAIL: pushed WAL file '000000070000000000000028' to the archive",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2588-ee199f71 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2585-277ad4a9 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 5 WAL file(s) to archive: 000000070000000000000029...00000007000000000000002D",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002A' to the archive",
                      "P01 DETAIL: pushed WAL file '000000070000000000000029' to the archive",
@@ -6304,16 +6304,16 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=706-a65da116 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=707-b9ced134 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000024...00000007000000000000002B",
-                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 17-1 archive",
                      "P01 DETAIL: found 000000070000000000000024 in the repo1: 17-1 archive",
-                     "P02 DETAIL: found 000000070000000000000026 in the repo1: 17-1 archive",
-                     "P01 DETAIL: found 000000070000000000000027 in the repo1: 17-1 archive",
+                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 17-1 archive",
+                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 17-1 archive",
+                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 17-1 archive",
                      "P00 DETAIL: unable to find 000000070000000000000028 in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
                      "       [filtered 14 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=750-e74eda5d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=752-5e97a136 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000028...00000007000000000000002F",
                      "P01 DETAIL: found 000000070000000000000028 in the repo1: 17-1 archive",
                      "P02 DETAIL: found 000000070000000000000029 in the repo1: 17-1 archive",
@@ -6321,7 +6321,7 @@
                      "P00 DETAIL: unable to find 00000007000000000000002B in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
                      "       [filtered 2 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.59.0: [00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F, 000000070000000000000030, 000000070000000000000031] --archive-async --exec-id=759-456c780e --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F, 000000070000000000000030, 000000070000000000000031] --archive-async --exec-id=761-af866388 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 7 WAL file(s) from archive: 00000007000000000000002B...000000070000000000000031",
                      "P02 DETAIL: found 00000007000000000000002C in the repo1: 17-1 archive",
                      "P01 DETAIL: found 00000007000000000000002B in the repo1: 17-1 archive",
@@ -6419,9 +6419,9 @@
                      "P00   INFO: wait for replay on the standby to reach 0/2F000028",
                      "P00   INFO: replay on the standby reached 0/2F000028",
                      "P00   INFO: check archive for prior segment 00000007000000000000002E",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/17/demo/global/pg_control (8KB, 0.53%) checksum 02201a29953e5ea33614ba0ceb95b6f603142eec",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/17/demo/global/pg_control (8KB, 0.53%) checksum 2fef26e26ab8ddbe9e264353b23ff2e2dc12d814",
                      "P01 DETAIL: match file from prior backup pg-primary:/var/lib/postgresql/17/demo/pg_logical/replorigin_checkpoint (8B, 0.53%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
-                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/17/demo/base/5/1249 (448KB, 30.16%) checksum 42ae0e3b251da996bdcbaf9d012ca13ea8c4d01f",
+                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/17/demo/base/5/1249 (448KB, 30.16%) checksum 317023e2773903a20f6633ef1ae9066fccbf9192",
                      "       [filtered 1278 lines of output]"
                   ]
                }
@@ -6694,7 +6694,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=3008-0c8086a0 --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/18/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=3008-04f6b03b --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/18/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]
@@ -7118,7 +7118,7 @@
                   "output" : [
                      "ninja: Entering directory `/build/pgbackrest'",
                      "ninja: no work to do.",
-                     "1/1 smoke OK               13.99s",
+                     "1/1 smoke OK               12.24s",
                      "",
                      "Ok:                 1   ",
                      "       [filtered 6 lines of output]"
@@ -7661,7 +7661,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1208-4eada09d --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1199-1f088435 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -7688,10 +7688,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=1240-b29634f2 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1232-98ddd13f --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000100000000/000000010000000000000001-cad1c3b733b4b4f3327ed758790c5de8a9d33814.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000100000000/000000010000000000000001-95e05e4799302297b1d3e23fa830dd5e2c853776.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -7748,16 +7748,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=1332-07a8c4d0 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1326-1ed45d74 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000002:000000010000000000000003",
-                     "P00   INFO: new backup label = 20260716-105029F",
+                     "P00   INFO: new backup label = 20260720-004140F",
                      "P00   INFO: full backup size = 25.2MB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1332-07a8c4d0 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1326-1ed45d74 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -7775,7 +7775,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105029F"
+                     "20260720-004140F"
                   ]
                }
             },
@@ -7803,10 +7803,10 @@
                   "output" : [
                      "       [filtered 7 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000004:000000010000000000000005",
-                     "P00   INFO: new backup label = 20260716-105029F_20260716-105032D",
+                     "P00   INFO: new backup label = 20260720-004140F_20260720-004143D",
                      "P00   INFO: diff backup size = 9.2KB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=1403-ee6f5158 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1396-28b52cd4 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -7838,17 +7838,17 @@
                      "    db (current)",
                      "        wal archive min/max (14): 000000010000000000000001/000000010000000000000005",
                      "",
-                     "        full backup: 20260716-105029F",
-                     "            timestamp start/stop: 2026-07-16 10:50:29+00 / 2026-07-16 10:50:31+00",
+                     "        full backup: 20260720-004140F",
+                     "            timestamp start/stop: 2026-07-20 00:41:40+00 / 2026-07-20 00:41:42+00",
                      "            wal start/stop: 000000010000000000000002 / 000000010000000000000003",
                      "            database size: 25.2MB, database backup size: 25.2MB",
                      "            repo1: backup set size: 3.2MB, backup size: 3.2MB",
                      "",
-                     "        diff backup: 20260716-105029F_20260716-105032D",
-                     "            timestamp start/stop: 2026-07-16 10:50:32+00 / 2026-07-16 10:50:33+00",
+                     "        diff backup: 20260720-004140F_20260720-004143D",
+                     "            timestamp start/stop: 2026-07-20 00:41:43+00 / 2026-07-20 00:41:44+00",
                      "            wal start/stop: 000000010000000000000004 / 000000010000000000000005",
                      "            database size: 25.2MB, database backup size: 9.2KB",
-                     "            repo1: backup set size: 3.2MB, backup size: 864B",
+                     "            repo1: backup set size: 3.2MB, backup size: 880B",
                      "            backup reference total: 1 full"
                   ]
                }
@@ -8114,7 +8114,7 @@
                   "output" : [
                      "  name  | last_successful_backup |    last_archived_wal     ",
                      "--------+------------------------+--------------------------",
-                     " \"demo\" | 2026-07-16 10:50:33+00 | 000000010000000000000005",
+                     " \"demo\" | 2026-07-20 00:41:44+00 | 000000010000000000000005",
                      "(1 row)"
                   ]
                }
@@ -8241,7 +8241,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105049F"
+                     "20260720-004200F"
                   ]
                }
             },
@@ -8249,7 +8249,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-004200F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -8273,8 +8273,8 @@
                      "    db (current)",
                      "        wal archive min/max (14): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260716-105049F",
-                     "            timestamp start/stop: 2026-07-16 10:50:49+00 / 2026-07-16 10:50:51+00",
+                     "        full backup: 20260720-004200F",
+                     "            timestamp start/stop: 2026-07-20 00:42:00+00 / 2026-07-20 00:42:02+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
                      "            lsn start/stop: 0/8000028 / 0/9000050",
                      "            database size: 25.2MB, database backup size: 25.2MB",
@@ -8290,7 +8290,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F \\",
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-004200F \\",
                      "    --annotation=key= --annotation=new_key=new_value annotate"
                   ],
                   "host" : "pg-primary",
@@ -8304,7 +8304,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260720-004200F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -8328,8 +8328,8 @@
                      "    db (current)",
                      "        wal archive min/max (14): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260716-105049F",
-                     "            timestamp start/stop: 2026-07-16 10:50:49+00 / 2026-07-16 10:50:51+00",
+                     "        full backup: 20260720-004200F",
+                     "            timestamp start/stop: 2026-07-20 00:42:00+00 / 2026-07-20 00:42:02+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
                      "            lsn start/stop: 0/8000028 / 0/9000050",
                      "            database size: 25.2MB, database backup size: 25.2MB",
@@ -8384,7 +8384,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260716-105029F|remove archive"
+                        "archive retention on backup 20260720-004140F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8396,8 +8396,8 @@
                "value" : {
                   "output" : [
                      "       [filtered 963 lines of output]",
-                     "P00   INFO: repo1: remove expired backup 20260716-105046F",
-                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105049F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: remove expired backup 20260720-004157F",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260720-004200F, start = 000000020000000000000008",
                      "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
@@ -8417,7 +8417,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105053F"
+                     "20260720-004204F"
                   ]
                }
             },
@@ -8432,7 +8432,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire full backup set 20260716-105029F|archive retention on backup 20260716-105053F|remove archive"
+                        "expire full backup set 20260720-004140F|archive retention on backup 20260720-004204F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8444,8 +8444,8 @@
                "value" : {
                   "output" : [
                      "       [filtered 11 lines of output]",
-                     "P00   INFO: repo1: expire full backup 20260716-105049F",
-                     "P00   INFO: repo1: remove expired backup 20260716-105049F",
+                     "P00   INFO: repo1: expire full backup 20260720-004200F",
+                     "P00   INFO: repo1: remove expired backup 20260720-004200F",
                      "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
                      "P00   INFO: expire command end: completed successfully"
                   ]
@@ -8511,7 +8511,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105056F_20260716-105059D"
+                     "20260720-004206F_20260720-004209D"
                   ]
                }
             },
@@ -8539,7 +8539,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire diff backup set 20260716-105056F_20260716-105059D"
+                        "expire diff backup set 20260720-004206F_20260720-004209D"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8552,10 +8552,10 @@
                   "output" : [
                      "       [filtered 10 lines of output]",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=2645-c0b45b6a --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
-                     "P00   INFO: repo1: expire diff backup set 20260716-105056F_20260716-105059D, 20260716-105056F_20260716-105101I",
-                     "P00   INFO: repo1: remove expired backup 20260716-105056F_20260716-105101I",
-                     "P00   INFO: repo1: remove expired backup 20260716-105056F_20260716-105059D",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=2635-96bf1097 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
+                     "P00   INFO: repo1: expire diff backup set 20260720-004206F_20260720-004209D, 20260720-004206F_20260720-004210I",
+                     "P00   INFO: repo1: remove expired backup 20260720-004206F_20260720-004210I",
+                     "P00   INFO: repo1: remove expired backup 20260720-004206F_20260720-004209D",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8607,7 +8607,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105056F_20260716-105102D"
+                     "20260720-004206F_20260720-004212D"
                   ]
                }
             },
@@ -8651,7 +8651,7 @@
                      "       [filtered 6 lines of output]",
                      "P00   INFO: backup stop archive = 000000020000000000000017, lsn = 0/17000050",
                      "P00   INFO: check archive for segment(s) 000000020000000000000016:000000020000000000000017",
-                     "P00   INFO: new backup label = 20260716-105056F_20260716-105105D",
+                     "P00   INFO: new backup label = 20260720-004206F_20260720-004214D",
                      "P00   INFO: diff backup size = 11.5KB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
                      "       [filtered 2 lines of output]"
@@ -8672,7 +8672,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105056F_20260716-105105D"
+                     "20260720-004206F_20260720-004214D"
                   ]
                }
             },
@@ -8687,7 +8687,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260716-105056F_20260716-105102D|remove archive"
+                        "archive retention on backup 20260720-004206F_20260720-004212D|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8698,11 +8698,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=2881-cbaf3136 --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105053F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F, start = 00000002000000000000000D, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F_20260716-105102D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F_20260716-105105D, start = 000000020000000000000016",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=2871-c1e7faec --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260720-004204F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260720-004206F, start = 00000002000000000000000D, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260720-004206F_20260720-004212D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260720-004206F_20260720-004214D, start = 000000020000000000000016",
                      "P00   INFO: repo1: 14-1 remove archive, start = 00000002000000000000000C, stop = 00000002000000000000000C",
                      "P00   INFO: repo1: 14-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
                      "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
@@ -8920,7 +8920,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105056F_20260716-105116I"
+                     "20260720-004206F_20260720-004225I"
                   ]
                }
             },
@@ -8929,7 +8929,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo \\",
-                     "    --set=20260716-105056F_20260716-105116I info"
+                     "    --set=20260720-004206F_20260720-004225I info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -8948,7 +8948,7 @@
                   "output" : [
                      "       [filtered 12 lines of output]",
                      "            repo1: backup size: 2.1MB",
-                     "            backup reference list: 20260716-105056F, 20260716-105056F_20260716-105105D",
+                     "            backup reference list: 20260720-004206F, 20260720-004206F_20260720-004214D",
                      "            database list: postgres (13755), test1 (32768), test2 (32769)"
                   ]
                }
@@ -9180,7 +9180,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-07-16 10:51:29.006147+00"
+                     "2026-07-20 00:42:38.14485+00"
                   ]
                }
             },
@@ -9257,7 +9257,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260716-105056F_20260716-105130I"
+                     "20260720-004206F_20260720-004240I"
                   ]
                }
             },
@@ -9271,7 +9271,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "20260716-105056F_20260716-105130I"
+                        "20260720-004206F_20260720-004240I"
                      ]
                   },
                   "host" : "pg-primary",
@@ -9285,8 +9285,8 @@
                      "       [filtered 38 lines of output]",
                      "            backup reference total: 1 full, 1 diff",
                      "",
-                     "        incr backup: 20260716-105056F_20260716-105130I",
-                     "            timestamp start/stop: 2026-07-16 10:51:30+00 / 2026-07-16 10:51:31+00",
+                     "        incr backup: 20260720-004206F_20260720-004240I",
+                     "            timestamp start/stop: 2026-07-20 00:42:40+00 / 2026-07-20 00:42:41+00",
                      "            wal start/stop: 00000004000000000000001A / 00000004000000000000001A",
                      "       [filtered 2 lines of output]"
                   ]
@@ -9310,8 +9310,8 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --set=20260716-105056F_20260716-105130I --target-timeline=current \\",
-                     "    --type=time \"--target=2026-07-16 10:51:29.006147+00\" --target-action=promote restore"
+                     "    --set=20260720-004206F_20260720-004240I --target-timeline=current \\",
+                     "    --type=time \"--target=2026-07-20 00:42:38.14485+00\" --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9370,9 +9370,9 @@
                   "output" : [
                      "       [filtered 11 lines of output]",
                      "LOG:  database system is ready to accept read-only connections",
-                     "LOG:  redo done at 0/1A000100 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.02 s",
+                     "LOG:  redo done at 0/1A000100 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.01 s",
                      "FATAL:  recovery ended before configured recovery target was reached",
-                     "LOG:  startup process (PID 4046) exited with exit code 1",
+                     "LOG:  startup process (PID 4035) exited with exit code 1",
                      "LOG:  terminating any other active server processes",
                      "LOG:  database system is shut down"
                   ]
@@ -9383,7 +9383,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --type=time \"--target=2026-07-16 10:51:29.006147+00\" \\",
+                     "    --type=time \"--target=2026-07-20 00:42:38.14485+00\" \\",
                      "    --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
@@ -9428,9 +9428,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 9 lines of output]",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:42:47",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "recovery_target_time = '2026-07-16 10:51:29.006147+00'",
+                     "recovery_target_time = '2026-07-20 00:42:38.14485+00'",
                      "recovery_target_action = 'promote'"
                   ]
                }
@@ -9511,17 +9511,17 @@
                "value" : {
                   "output" : [
                      "       [filtered 5 lines of output]",
-                     "LOG:  database system was interrupted; last known up at 2026-07-16 10:51:16 UTC",
+                     "LOG:  database system was interrupted; last known up at 2026-07-20 00:42:25 UTC",
                      "LOG:  restored log file \"00000004.history\" from archive",
-                     "LOG:  starting point-in-time recovery to 2026-07-16 10:51:29.006147+00",
+                     "LOG:  starting point-in-time recovery to 2026-07-20 00:42:38.14485+00",
                      "LOG:  restored log file \"00000004.history\" from archive",
                      "LOG:  restored log file \"000000040000000000000019\" from archive",
                      "       [filtered 2 lines of output]",
                      "LOG:  consistent recovery state reached at 0/19000100",
                      "LOG:  database system is ready to accept read-only connections",
-                     "LOG:  recovery stopping before commit of transaction 743, time 2026-07-16 10:51:30.460687+00",
+                     "LOG:  recovery stopping before commit of transaction 743, time 2026-07-20 00:42:39.777503+00",
                      "LOG:  redo done at 0/1901E6C0 system usage: CPU: user: 0.00 s, system: 0.01 s, elapsed: 0.02 s",
-                     "LOG:  last completed transaction was at log time 2026-07-16 10:51:27.53862+00",
+                     "LOG:  last completed transaction was at log time 2026-07-20 00:42:36.512696+00",
                      "LOG:  selected new timeline ID: 5",
                      "LOG:  archive recovery complete",
                      "LOG:  database system is ready to accept connections"
@@ -9562,7 +9562,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stop command begin 2.59.0: --exec-id=4397-b746451f --log-level-console=info --no-log-timestamp --stanza=demo",
+                     "P00   INFO: stop command begin 2.59.0: --exec-id=4385-f7983994 --log-level-console=info --no-log-timestamp --stanza=demo",
                      "P00   INFO: stop command end: completed successfully"
                   ]
                }
@@ -9589,7 +9589,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=4429-40e2682c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=4417-d1112030 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -9710,7 +9710,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=4635-40bf54af --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=4624-6c22f9b1 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -9739,16 +9739,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=4668-274a601a --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=4656-51499292 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001B, lsn = 0/1B000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001B:00000005000000000000001B",
-                     "P00   INFO: new backup label = 20260716-105155F",
+                     "P00   INFO: new backup label = 20260720-004303F",
                      "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=4668-274a601a --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=4656-51499292 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
                   ]
                }
             },
@@ -9961,16 +9961,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=5061-d0e8ad62 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=5049-047bfb40 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001C, lsn = 0/1C000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001C:00000005000000000000001D",
-                     "P00   INFO: new backup label = 20260716-105216F",
+                     "P00   INFO: new backup label = 20260720-004325F",
                      "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=5061-d0e8ad62 --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=5049-047bfb40 --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
                   ]
                }
             },
@@ -9988,7 +9988,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-07-16 10:52:32+00"
+                     "2026-07-20 00:43:41+00"
                   ]
                }
             },
@@ -10215,7 +10215,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.59.0: --exec-id=5361-d61f2c4a --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=5351-7b0bda1e --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
@@ -10223,10 +10223,10 @@
                      "P00   INFO: backup start archive = 00000005000000000000001F, lsn = 0/1F000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001F:00000005000000000000001F",
-                     "P00   INFO: new backup label = 20260716-105236F",
+                     "P00   INFO: new backup label = 20260720-004346F",
                      "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.59.0: --exec-id=5361-d61f2c4a --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=5351-7b0bda1e --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -10404,9 +10404,9 @@
                      "+--------+------------------------------------+-------------------------------------+",
                      "| Action |             Modified               |               Object                |",
                      "+--------+------------------------------------+-------------------------------------+",
-                     "|  PUT   |  2026-07-16T10:52:16.238000+00:00  |  demo-repo/backup/demo/backup.info  |",
-                     "|  PUT   |  2026-07-16T10:52:31.899000+00:00  |  demo-repo/backup/demo/backup.info  |",
-                     "|  DELETE|  2026-07-16T10:52:47.493000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-20T00:43:25.103000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-20T00:43:41.347000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "|  DELETE|  2026-07-20T00:43:55.062000+00:00  |  demo-repo/backup/demo/backup.info  |",
                      "+--------+------------------------------------+-------------------------------------+"
                   ]
                }
@@ -10416,7 +10416,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 \\",
-                     "    --repo-target-time=\"2026-07-16 10:52:32+00\" info"
+                     "    --repo-target-time=\"2026-07-20 00:43:41+00\" info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -10436,8 +10436,8 @@
                      "       [filtered 5 lines of output]",
                      "        wal archive min/max (14): 00000005000000000000001C/00000005000000000000001D",
                      "",
-                     "        full backup: 20260716-105216F",
-                     "            timestamp start/stop: 2026-07-16 10:52:16+00 / 2026-07-16 10:52:31+00",
+                     "        full backup: 20260720-004325F",
+                     "            timestamp start/stop: 2026-07-20 00:43:25+00 / 2026-07-20 00:43:40+00",
                      "            wal start/stop: 00000005000000000000001C / 00000005000000000000001D",
                      "            repo3: backup set size: 4.2MB, backup size: 4.2MB"
                   ]
@@ -10448,7 +10448,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 --delta \\",
-                     "    --repo-target-time=\"2026-07-16 10:52:32+00\" --log-level-console=info restore"
+                     "    --repo-target-time=\"2026-07-20 00:43:41+00\" --log-level-console=info restore"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -10465,8 +10465,8 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=5686-7accf33e --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-16 10:52:32+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
-                     "P00   INFO: repo3: restore backup set 20260716-105216F, recovery will start at 2026-07-16 10:52:16",
+                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=5676-62516a6c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-20 00:43:41+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
+                     "P00   INFO: repo3: restore backup set 20260720-004325F, recovery will start at 2026-07-20 00:43:25",
                      "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/14/data'",
                      "P00   INFO: write updated /var/lib/pgsql/14/data/postgresql.auto.conf",
                      "       [filtered 2 lines of output]"
@@ -11314,14 +11314,14 @@
                      "    db (current)",
                      "        wal archive min/max (14): 000000070000000000000023/000000070000000000000025",
                      "",
-                     "        full backup: 20260716-105347F",
-                     "            timestamp start/stop: 2026-07-16 10:53:47+00 / 2026-07-16 10:53:51+00",
+                     "        full backup: 20260720-004457F",
+                     "            timestamp start/stop: 2026-07-20 00:44:57+00 / 2026-07-20 00:45:01+00",
                      "            wal start/stop: 000000070000000000000023 / 000000070000000000000023",
                      "            database size: 33.5MB, database backup size: 33.5MB",
                      "            repo1: backup set size: 4.2MB, backup size: 4.2MB",
                      "",
-                     "        full backup: 20260716-105352F",
-                     "            timestamp start/stop: 2026-07-16 10:53:52+00 / 2026-07-16 10:53:55+00",
+                     "        full backup: 20260720-004502F",
+                     "            timestamp start/stop: 2026-07-20 00:45:02+00 / 2026-07-20 00:45:06+00",
                      "            wal start/stop: 000000070000000000000024 / 000000070000000000000025",
                      "            database size: 33.5MB, database backup size: 33.5MB",
                      "            repo1: backup set size: 4.2MB, backup size: 4.2MB"
@@ -11839,24 +11839,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:50:39",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:41:50",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:10",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:42:19",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:42:47",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_time = '2026-07-16 10:51:29.006147+00'",
-                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:44:06 # recovery_target_time = '2026-07-20 00:42:38.14485+00'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:44:06 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:52:54",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 10:52:32+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:44:06",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-20 00:43:41+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:53:42",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:44:52",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:54:22",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:45:31",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
                }
@@ -11965,7 +11965,7 @@
                   "output" : [
                      "       [filtered 4 lines of output]",
                      "LOG:  listening on Unix socket \"/tmp/.s.PGSQL.5432\"",
-                     "LOG:  database system was interrupted; last known up at 2026-07-16 10:53:52 UTC",
+                     "LOG:  database system was interrupted; last known up at 2026-07-20 00:45:02 UTC",
                      "LOG:  entering standby mode",
                      "LOG:  restored log file \"00000007.history\" from archive",
                      "LOG:  restored log file \"000000070000000000000024\" from archive",
@@ -12051,7 +12051,7 @@
                   "output" : [
                      " pg_switch_wal |       current_timestamp       ",
                      "---------------+-------------------------------",
-                     " 0/2601E7C0    | 2026-07-16 10:54:29.129238+00",
+                     " 0/2601E7C0    | 2026-07-20 00:45:38.037413+00",
                      "(1 row)"
                   ]
                }
@@ -12080,7 +12080,7 @@
                   "output" : [
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-07-16 10:54:30.556907+00",
+                     " Important Data | 2026-07-20 00:45:39.220085+00",
                      "(1 row)"
                   ]
                }
@@ -12106,7 +12106,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=1222-8ec4a8d8 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1181-02efd7d6 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -12265,24 +12265,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:50:39",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:41:50",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:10",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:42:19",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:42:47",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_time = '2026-07-16 10:51:29.006147+00'",
-                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:44:06 # recovery_target_time = '2026-07-20 00:42:38.14485+00'",
+                     "# Removed by pgBackRest restore on 2026-07-20 00:44:06 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:52:54",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 10:52:32+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:44:06",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-20 00:43:41+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:53:42",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:44:52",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:54:36",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-20 00:45:45",
                      "primary_conninfo = 'host=172.17.0.6 port=5432 user=replicator'",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
@@ -12404,7 +12404,7 @@
                      "       [filtered 4 lines of output]",
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-07-16 10:54:42.888569+00",
+                     " Important Data | 2026-07-20 00:45:51.481518+00",
                      "(1 row)"
                   ]
                }
@@ -12433,7 +12433,7 @@
                   "output" : [
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-07-16 10:54:43.369563+00",
+                     " Important Data | 2026-07-20 00:45:51.896045+00",
                      "(1 row)"
                   ]
                }
@@ -12938,7 +12938,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=936-0a6d0cc2 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=928-613b418d --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -12965,11 +12965,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=969-1a7da4d4 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=961-0c86a782 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000001-7dee2bb959c5be5ae636ac3f122495d19d92becf.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000001-3148a34e7fa88aa437af38678ddbab2590adb628.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12995,15 +12995,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=1388-0e4fe3d8 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1379-a0628038 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
                      "P00   INFO: check stanza 'demo'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/000000070000000000000027-403e6652852b2a1791ee185cbf2d0c92e2d13ffd.gz' on repo1",
+                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/000000070000000000000027-2137d43223a1bec901a46c8eb8feea0d77addf33.gz' on repo1",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000002-9a37b9e945d0105bb14116929b3577931634351e.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000002-0103254ce8b2225563e6b0ae03e3e580335f0a05.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -13252,10 +13252,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.59.0: --exec-id=6866-b55d2b1c --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=6853-b3bcef41 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/00000007000000000000002D-8ef1a778d36fa7df713c5036d27d2e03ae113b59.gz' on repo1",
+                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/00000007000000000000002D-7234f698378e4ca6cdfc7270f97a766cfda99fbd.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -13282,20 +13282,20 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6830-f85d124f --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6817-01bf97bf --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 000000070000000000000028",
                      "P01 DETAIL: pushed WAL file '000000070000000000000028' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6868-3a6c97a8 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6855-8e4b8e04 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 5 WAL file(s) to archive: 000000070000000000000029...00000007000000000000002D",
-                     "P01 DETAIL: pushed WAL file '000000070000000000000029' to the archive",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002A' to the archive",
-                     "P01 DETAIL: pushed WAL file '00000007000000000000002B' to the archive",
-                     "P02 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
-                     "P01 DETAIL: pushed WAL file '00000007000000000000002D' to the archive",
+                     "P01 DETAIL: pushed WAL file '000000070000000000000029' to the archive",
+                     "P02 DETAIL: pushed WAL file '00000007000000000000002B' to the archive",
+                     "P01 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
+                     "P02 DETAIL: pushed WAL file '00000007000000000000002D' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "P00   INFO: archive-push:async command end: completed successfully"
                   ]
@@ -13336,23 +13336,23 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=1890-fcc5901d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=1847-b6ebf0f1 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000024...00000007000000000000002B",
-                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 14-1 archive",
                      "P02 DETAIL: found 000000070000000000000025 in the repo1: 14-1 archive",
-                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 14-1 archive",
-                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 000000070000000000000026 in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 000000070000000000000027 in the repo1: 14-1 archive",
                      "P00 DETAIL: unable to find 000000070000000000000028 in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
-                     "       [filtered 17 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=1943-b62d9f85 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "       [filtered 24 lines of output]",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=1902-6e53470d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000028...00000007000000000000002F",
                      "P02 DETAIL: found 000000070000000000000029 in the repo1: 14-1 archive",
                      "P01 DETAIL: found 000000070000000000000028 in the repo1: 14-1 archive",
                      "P02 DETAIL: found 00000007000000000000002A in the repo1: 14-1 archive",
                      "P01 DETAIL: found 00000007000000000000002B in the repo1: 14-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002C in the repo1: 14-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002D in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002C in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002D in the repo1: 14-1 archive",
                      "P00 DETAIL: unable to find 00000007000000000000002E in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "       [filtered 7 lines of output]"
@@ -13475,8 +13475,8 @@
                      "P00   INFO: wait for replay on the standby to reach 0/2F000028",
                      "P00   INFO: replay on the standby reached 0/2F000028",
                      "P00   INFO: check archive for prior segment 00000007000000000000002E",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/log/postgresql.log (11.1KB, 0.43%) checksum c2a8826ce5db6a9e6f3a94f058eb63e7e78759bd",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/global/pg_control (8KB, 0.74%) checksum 2a8e0d508836afd1b5246d5f4abf6db77f43d87f",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/log/postgresql.log (11.1KB, 0.43%) checksum ec93a5e8f2619b8c7d8b8d42b2b30b4e175784da",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/global/pg_control (8KB, 0.74%) checksum 9e61a174e615df1f2f754dfff187f4661733973f",
                      "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/pg_hba.conf (4.5KB, 0.91%) checksum cfa97af1dab1b130f0a921fa2d10d76fe0c5f630",
                      "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/14/data/current_logfiles (26B, 0.91%) checksum 78a9f5c10960f0d91fcd313937469824861795a2",
                      "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/14/data/pg_logical/replorigin_checkpoint (8B, 0.91%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
@@ -13778,7 +13778,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=7455-37174a6b --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/15/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=7440-cc015b23 --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/15/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]

--- a/doc/resource/exe.cache
+++ b/doc/resource/exe.cache
@@ -156,7 +156,7 @@
                      "            ",
                      "P00   INFO: P1-T1/1 - vm=none, module=common, test=wait",
                      "            ",
-                     "    P00   INFO: test command begin 2.58.0: [common/wait] --log-level=info --no-log-timestamp --repo-path=/home/vagrant/test/repo --scale=1 --test-path=/home/vagrant/test --vm=none --vm-id=0",
+                     "    P00   INFO: test command begin 2.59.0: [common/wait] --log-level=info --no-log-timestamp --repo-path=/home/vagrant/test/repo --scale=1 --test-path=/home/vagrant/test --vm=none --vm-id=0",
                      "    P00   INFO: test command end: completed successfully",
                      "    run 1 - waitNew(), waitMore, and waitFree()",
                      "                  L0018     expect AssertError: assertion 'waitTime <= 999999000' failed",
@@ -258,8 +258,9 @@
                "value" : {
                   "output" : [
                      "P00   INFO: test begin on x86_64 - log level info",
-                     "P00   INFO: Using cached pgbackrest/test:u22-base-x86_64-20260119A image (8ee008aecbcf21b205116969db4000838c989a4a) ...",
-                     "P00   INFO: Building pgbackrest/test:u22-test-x86_64 image ...",
+                     "P00   INFO: Checking cache ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 ...",
+                     "P00   INFO: Using cached ghcr.io/pgbackrest/test:u22-base-x86_64-20260710A-49f5ab617257 image",
+                     "P00   INFO: Building ghcr.io/pgbackrest/test:u22-test-x86_64 image ...",
                      "P00   INFO: Build Complete"
                   ]
                }
@@ -310,11 +311,11 @@
             {
                "key" : {
                   "id" : "s3",
-                  "image" : "minio/minio",
+                  "image" : "quay.io/ceph/ceph:v19",
                   "name" : "s3-server",
-                  "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/s3-server.crt:/root/.minio/certs/public.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/s3-server.key:/root/.minio/certs/private.key:ro -e MINIO_REGION=us-east-1 -e MINIO_DOMAIN=s3.us-east-1.amazonaws.com -e MINIO_BROWSER=off -e MINIO_ACCESS_KEY=accessKey1 -e MINIO_SECRET_KEY=verySecretKey1",
+                  "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/s3-server.crt:/root/s3-server.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/s3-server.key:/root/s3-server.key:ro -v {[host-repo-path]}/doc/resource/ceph/bootstrap.sh:/bootstrap.sh:ro -e RGW_DNS_NAME=s3.us-east-1.amazonaws.com -e S3_ACCESS_KEY=accessKey1 -e S3_SECRET_KEY=verySecretKey1",
                   "os" : "debian",
-                  "param" : "server /data --address :443",
+                  "param" : "bash /bootstrap.sh",
                   "update-hosts" : false
                },
                "type" : "host",
@@ -352,45 +353,6 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo mkdir -p /build/pgbackrest-release-2.58.0"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
-                     "sudo cp -r /pgbackrest/* /build/pgbackrest-release-2.58.0"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
-                     "sudo chown -R vagrant /build"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
                      "sudo apt-get update"
                   ],
                   "host" : "build",
@@ -405,7 +367,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo apt-get install python3-distutils meson gcc libpq-dev libssl-dev libxml2-dev \\",
-                     "    pkg-config liblz4-dev libzstd-dev libbz2-dev libz-dev libyaml-dev libssh2-1-dev"
+                     "    pkg-config liblz4-dev libzstd-dev libbz2-dev libz-dev libssh2-1-dev libsystemd-dev"
                   ],
                   "cmd-extra" : "-y 2>&1",
                   "host" : "build",
@@ -419,7 +381,86 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "meson setup /build/pgbackrest /build/pgbackrest-release-2.58.0"
+                     "mkdir -p /build/pgbackrest-2.59.0-tmp && \\",
+                     "    chown -R vagrant /build"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "git config --global --add safe.directory /pgbackrest && \\",
+                     "    git -C /pgbackrest ls-files -c --others --exclude-standard | \\",
+                     "    grep -v '^doc/resource/exe\\.cache$' | \\",
+                     "    tar -C /pgbackrest -cf - -T - | tar -C /build/pgbackrest-2.59.0-tmp -xf -"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "git config --global user.name \"test\" && \\",
+                     "    git config --global user.email \"test@test.com\" && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp init 2>&1 && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp add . && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp commit -a -m \"test\""
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson setup /build/pgbackrest /build/pgbackrest-2.59.0-tmp && \\",
+                     "    ninja -C /build/pgbackrest src/build-code && \\",
+                     "    mkdir -p /build/pgbackrest-2.59.0-tmp/doc/output/html && \\",
+                     "    mkdir -p /build/pgbackrest-2.59.0-tmp/doc/output/man && \\",
+                     "    PYTHONWARNINGS=ignore meson dist -C /build/pgbackrest --formats gztar && \\",
+                     "    tar zx -C /build -f /build/pgbackrest/meson-dist/pgbackrest-2.59.0.tar.gz && \\",
+                     "    rm -rf /build/pgbackrest"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "sudo apt-get remove -y libyaml-dev 2>&1"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson setup /build/pgbackrest /build/pgbackrest-2.59.0"
                   ],
                   "host" : "build",
                   "load-env" : true,
@@ -440,6 +481,36 @@
                   "run-as-user" : null
                },
                "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson test -C /build/pgbackrest --suite smoke"
+                  ],
+                  "highlight" : {
+                     "filter" : true,
+                     "filter-context" : 2,
+                     "list" : [
+                        "smoke OK"
+                     ]
+                  },
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : true,
+                  "run-as-user" : null
+               },
+               "type" : "exe",
+               "value" : {
+                  "output" : [
+                     "ninja: Entering directory `/build/pgbackrest'",
+                     "ninja: no work to do.",
+                     "1/1 smoke OK               13.27s",
+                     "",
+                     "",
+                     "       [filtered 7 lines of output]"
+                  ]
+               }
             },
             {
                "key" : {
@@ -601,7 +672,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "pgBackRest 2.58.0 - General help",
+                     "pgBackRest 2.59.0 - General help",
                      "",
                      "Usage:",
                      "    pgbackrest [options] [command]",
@@ -636,8 +707,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/16/bin/initdb \\",
-                     "    -D /var/lib/postgresql/16/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/17/bin/initdb \\",
+                     "    -D /var/lib/postgresql/17/demo -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -650,7 +721,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 16 demo"
+                     "sudo pg_createcluster 17 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -660,9 +731,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Configuring already existing cluster (configuration: /etc/postgresql/16/demo, data: /var/lib/postgresql/16/demo, owner: 102:103)",
+                     "Configuring already existing cluster (configuration: /etc/postgresql/17/demo, data: /var/lib/postgresql/17/demo, owner: 102:103)",
                      "Ver Cluster Port Status Owner    Data directory              Log file",
-                     "16  demo    5432 down   postgres /var/lib/postgresql/16/demo /var/log/postgresql/postgresql-16-demo.log"
+                     "17  demo    5432 down   postgres /var/lib/postgresql/17/demo /var/log/postgresql/postgresql-17-demo.log"
                   ]
                }
             },
@@ -670,7 +741,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/17/demo/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -686,7 +757,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -700,7 +771,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo"
+                     "pg1-path=/var/lib/postgresql/17/demo"
                   ]
                }
             },
@@ -727,7 +798,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "pgBackRest 2.58.0 - 'backup' command - 'log-path' option help",
+                     "pgBackRest 2.59.0 - 'backup' command - 'log-path' option help",
                      "",
                      "Path where log files are stored.",
                      "",
@@ -794,7 +865,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest"
@@ -803,7 +874,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -826,7 +897,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo restart"
+                     "sudo pg_ctlcluster 17 demo restart"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -889,7 +960,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -915,7 +986,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -945,7 +1016,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -979,7 +1050,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=1060-8b7025bb --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=416-8d9d3f53 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -1006,10 +1077,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1069-d864650d --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=425-d4d91767 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/16-1/0000000100000000/000000010000000000000001-b2bbfb2253a998ecb763348c553b8d2c8a31ca0b.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000100000000/000000010000000000000001-6d2c90e42839a6548583657daf286adff240b4b8.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -1030,7 +1101,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -1066,16 +1137,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=1097-1bd2b5f6 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=452-8587e630 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000002:000000010000000000000003",
-                     "P00   INFO: new backup label = 20260119-092813F",
+                     "P00   INFO: new backup label = 20260716-105931F",
                      "P00   INFO: full backup size = 22MB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1097-1bd2b5f6 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=452-8587e630 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -1093,7 +1164,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092813F"
+                     "20260716-105931F"
                   ]
                }
             },
@@ -1121,10 +1192,10 @@
                   "output" : [
                      "       [filtered 7 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000004:000000010000000000000005",
-                     "P00   INFO: new backup label = 20260119-092813F_20260119-092815D",
+                     "P00   INFO: new backup label = 20260716-105931F_20260716-105934D",
                      "P00   INFO: diff backup size = 8.3KB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1124-89578f42 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=479-21b56bef --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -1154,19 +1225,19 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (16): 000000010000000000000001/000000010000000000000005",
+                     "        wal archive min/max (17): 000000010000000000000001/000000010000000000000005",
                      "",
-                     "        full backup: 20260119-092813F",
-                     "            timestamp start/stop: 2026-01-19 09:28:13+00 / 2026-01-19 09:28:15+00",
+                     "        full backup: 20260716-105931F",
+                     "            timestamp start/stop: 2026-07-16 10:59:31+00 / 2026-07-16 10:59:33+00",
                      "            wal start/stop: 000000010000000000000002 / 000000010000000000000003",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup set size: 2.9MB, backup size: 2.9MB",
                      "",
-                     "        diff backup: 20260119-092813F_20260119-092815D",
-                     "            timestamp start/stop: 2026-01-19 09:28:15+00 / 2026-01-19 09:28:16+00",
+                     "        diff backup: 20260716-105931F_20260716-105934D",
+                     "            timestamp start/stop: 2026-07-16 10:59:34+00 / 2026-07-16 10:59:35+00",
                      "            wal start/stop: 000000010000000000000004 / 000000010000000000000005",
                      "            database size: 22MB, database backup size: 8.3KB",
-                     "            repo1: backup set size: 2.9MB, backup size: 448B",
+                     "            repo1: backup set size: 2.9MB, backup size: 464B",
                      "            backup reference total: 1 full"
                   ]
                }
@@ -1175,7 +1246,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1188,7 +1259,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres rm /var/lib/postgresql/16/demo/global/pg_control"
+                     "sudo -u postgres rm /var/lib/postgresql/17/demo/global/pg_control"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1201,7 +1272,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "err-expect" : "1",
                   "highlight" : {
@@ -1219,10 +1290,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Error: /usr/lib/postgresql/16/bin/pg_ctl /usr/lib/postgresql/16/bin/pg_ctl start -D /var/lib/postgresql/16/demo -l /var/log/postgresql/postgresql-16-demo.log -s -o  -c config_file=\"/etc/postgresql/16/demo/postgresql.conf\"  exited with status 1: ",
+                     "Error: /usr/lib/postgresql/17/bin/pg_ctl /usr/lib/postgresql/17/bin/pg_ctl start -D /var/lib/postgresql/17/demo -l /var/log/postgresql/postgresql-17-demo.log -s -o  -c config_file=\"/etc/postgresql/17/demo/postgresql.conf\"  exited with status 1: ",
                      "postgres: could not find the database system",
-                     "Expected to find it in the directory \"/var/lib/postgresql/16/demo\",",
-                     "but could not open file \"/var/lib/postgresql/16/demo/global/pg_control\": No such file or directory",
+                     "Expected to find it in the directory \"/var/lib/postgresql/17/demo\",",
+                     "but could not open file \"/var/lib/postgresql/17/demo/global/pg_control\": No such file or directory",
                      "Examine the log output."
                   ]
                }
@@ -1231,7 +1302,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres find /var/lib/postgresql/16/demo -mindepth 1 -delete"
+                     "sudo -u postgres find /var/lib/postgresql/17/demo -mindepth 1 -delete"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1257,7 +1328,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -1420,7 +1491,7 @@
                   "output" : [
                      "  name  | last_successful_backup |    last_archived_wal     ",
                      "--------+------------------------+--------------------------",
-                     " \"demo\" | 2026-01-19 09:28:16+00 | 000000010000000000000005",
+                     " \"demo\" | 2026-07-16 10:59:35+00 | 000000010000000000000005",
                      "(1 row)"
                   ]
                }
@@ -1454,7 +1525,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "1768814896"
+                     "1784199575"
                   ]
                }
             },
@@ -1493,7 +1564,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-bundle=y",
@@ -1555,7 +1626,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1599,7 +1670,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092829F"
+                     "20260716-105951F"
                   ]
                }
             },
@@ -1607,7 +1678,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092829F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -1629,12 +1700,12 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (16): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (17): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260119-092829F",
-                     "            timestamp start/stop: 2026-01-19 09:28:29+00 / 2026-01-19 09:28:30+00",
+                     "        full backup: 20260716-105951F",
+                     "            timestamp start/stop: 2026-07-16 10:59:51+00 / 2026-07-16 10:59:54+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
-                     "            lsn start/stop: 0/8000028 / 0/9000050",
+                     "            lsn start/stop: 0/8000028 / 0/9000088",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup size: 2.9MB",
                      "            database list: postgres (5)",
@@ -1648,7 +1719,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092829F \\",
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F \\",
                      "    --annotation=key= --annotation=new_key=new_value annotate"
                   ],
                   "host" : "pg-primary",
@@ -1662,7 +1733,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092829F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105951F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -1684,12 +1755,12 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (16): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (17): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260119-092829F",
-                     "            timestamp start/stop: 2026-01-19 09:28:29+00 / 2026-01-19 09:28:30+00",
+                     "        full backup: 20260716-105951F",
+                     "            timestamp start/stop: 2026-07-16 10:59:51+00 / 2026-07-16 10:59:54+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
-                     "            lsn start/stop: 0/8000028 / 0/9000050",
+                     "            lsn start/stop: 0/8000028 / 0/9000088",
                      "            database size: 22MB, database backup size: 22MB",
                      "            repo1: backup size: 2.9MB",
                      "            database list: postgres (5)",
@@ -1715,7 +1786,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1742,7 +1813,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260119-092813F|remove archive"
+                        "archive retention on backup 20260716-105931F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1754,9 +1825,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 975 lines of output]",
-                     "P00   INFO: repo1: remove expired backup 20260119-092827F",
-                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20260119-092829F, start = 000000020000000000000008",
-                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
+                     "P00   INFO: repo1: remove expired backup 20260716-105949F",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105951F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1775,7 +1846,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092831F"
+                     "20260716-105955F"
                   ]
                }
             },
@@ -1790,7 +1861,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire full backup set 20260119-092813F|archive retention on backup 20260119-092831F|remove archive"
+                        "expire full backup set 20260716-105931F|archive retention on backup 20260716-105955F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1802,9 +1873,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 11 lines of output]",
-                     "P00   INFO: repo1: expire full backup 20260119-092829F",
-                     "P00   INFO: repo1: remove expired backup 20260119-092829F",
-                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
+                     "P00   INFO: repo1: expire full backup 20260716-105951F",
+                     "P00   INFO: repo1: remove expired backup 20260716-105951F",
+                     "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1825,7 +1896,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1869,7 +1940,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092833F_20260119-092835D"
+                     "20260716-105957F_20260716-105959D"
                   ]
                }
             },
@@ -1897,7 +1968,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire diff backup set 20260119-092833F_20260119-092835D"
+                        "expire diff backup set 20260716-105957F_20260716-105959D"
                      ]
                   },
                   "host" : "pg-primary",
@@ -1910,10 +1981,10 @@
                   "output" : [
                      "       [filtered 10 lines of output]",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1601-86e69e59 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
-                     "P00   INFO: repo1: expire diff backup set 20260119-092833F_20260119-092835D, 20260119-092833F_20260119-092836I",
-                     "P00   INFO: repo1: remove expired backup 20260119-092833F_20260119-092836I",
-                     "P00   INFO: repo1: remove expired backup 20260119-092833F_20260119-092835D",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=952-974c432c --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
+                     "P00   INFO: repo1: expire diff backup set 20260716-105957F_20260716-105959D, 20260716-105957F_20260716-110000I",
+                     "P00   INFO: repo1: remove expired backup 20260716-105957F_20260716-110000I",
+                     "P00   INFO: repo1: remove expired backup 20260716-105957F_20260716-105959D",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -1934,7 +2005,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -1965,7 +2036,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092833F_20260119-092837D"
+                     "20260716-105957F_20260716-110001D"
                   ]
                }
             },
@@ -2009,7 +2080,7 @@
                      "       [filtered 6 lines of output]",
                      "P00   INFO: backup stop archive = 000000020000000000000017, lsn = 0/17000050",
                      "P00   INFO: check archive for segment(s) 000000020000000000000016:000000020000000000000017",
-                     "P00   INFO: new backup label = 20260119-092833F_20260119-092839D",
+                     "P00   INFO: new backup label = 20260716-105957F_20260716-110004D",
                      "P00   INFO: diff backup size = 8.3KB, file total = 963",
                      "P00   INFO: backup command end: completed successfully",
                      "       [filtered 2 lines of output]"
@@ -2030,7 +2101,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092833F_20260119-092839D"
+                     "20260716-105957F_20260716-110004D"
                   ]
                }
             },
@@ -2045,7 +2116,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260119-092833F_20260119-092837D|remove archive"
+                        "archive retention on backup 20260716-105957F_20260716-110001D|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -2056,13 +2127,13 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1685-5edd5b29 --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20260119-092831F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20260119-092833F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20260119-092833F_20260119-092837D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 16-1 archive retention on backup 20260119-092833F_20260119-092839D, start = 000000020000000000000016",
-                     "P00   INFO: repo1: 16-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
-                     "P00   INFO: repo1: 16-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1035-060f721b --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105955F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F_20260716-110001D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 17-1 archive retention on backup 20260716-105957F_20260716-110004D, start = 000000020000000000000016",
+                     "P00   INFO: repo1: 17-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
+                     "P00   INFO: repo1: 17-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -2071,7 +2142,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2103,18 +2174,18 @@
                "value" : {
                   "output" : [
                      "       [filtered 2 lines of output]",
-                     "P00 DETAIL: check '/var/lib/postgresql/16/demo' exists",
+                     "P00 DETAIL: check '/var/lib/postgresql/17/demo' exists",
                      "P00 DETAIL: remove 'global/pg_control' so cluster will not start if restore does not complete",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/16/demo'",
-                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/16/demo/backup_label.old'",
-                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/16/demo/base/1/pg_internal.init'",
-                     "       [filtered 769 lines of output]",
-                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/base/1/113 - exists and matches backup (bundle 20260119-092833F/1/2736168, 8KB, 88.04%) checksum 9bbd4f25b106d88a2c938f5c0d57c390e7ca9d63",
-                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/base/1/112 - exists and matches backup (bundle 20260119-092833F/1/2736256, 8KB, 88.08%) checksum 482d3ba07134400f1f78d634db79caf025cbd7a5",
-                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/PG_VERSION - exists and matches backup (bundle 20260119-092833F/1/2736344, 3B, 88.08%) checksum 3596ea087bfdaf52380eae441077572ed289d657",
-                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/base/5/2608_fsm - exists and matches backup (bundle 20260119-092833F/1/2736368, 24KB, 88.18%) checksum cd30d4d0be58b99bf5929fb2c3afc2550f710741",
-                     "P01 DETAIL: restore file /var/lib/postgresql/16/demo/postgresql.auto.conf - exists and matches backup (bundle 20260119-092833F/1/2736608, 229B, 88.18%) checksum abe90322c61a48f660b6b471e0bc12fc9aa21780",
-                     "       [filtered 232 lines of output]"
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/17/demo'",
+                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/backup_label.old'",
+                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/base/1/pg_internal.init'",
+                     "       [filtered 13 lines of output]",
+                     "P00 DETAIL: remove invalid file '/var/lib/postgresql/17/demo/postmaster.opts'",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/backup_label (260B, 0.00%) checksum 3d708d165060df9b75bc052ca22668cfb52b7440",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/PG_VERSION - exists and matches backup (bundle 20260716-105957F/1/0, 3B, 0.00%) checksum ad48103e4fc71796e9708cafc43adeed0d1076b7",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/pg_multixact/members/0000 - exists and matches backup (bundle 20260716-105957F/1/24, 8KB, 0.04%) checksum 0631457264ff7f8d5fb1edc2c0211992a67c73e6",
+                     "P01 DETAIL: restore file /var/lib/postgresql/17/demo/global/pg_filenode.map - exists and matches backup (bundle 20260716-105957F/1/64, 524B, 0.04%) checksum 3de878cf56cdb80345e88da11f91bc6d46f9f804",
+                     "       [filtered 989 lines of output]"
                   ]
                }
             },
@@ -2122,7 +2193,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2255,7 +2326,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/postgresql/16/demo/base/32768"
+                     "sudo -u postgres du -sh /var/lib/postgresql/17/demo/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2265,7 +2336,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "7.4M\t/var/lib/postgresql/16/demo/base/32768"
+                     "7.4M\t/var/lib/postgresql/17/demo/base/32768"
                   ]
                }
             },
@@ -2283,7 +2354,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092833F_20260119-092846I"
+                     "20260716-105957F_20260716-110012I"
                   ]
                }
             },
@@ -2292,7 +2363,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo \\",
-                     "    --set=20260119-092833F_20260119-092846I info"
+                     "    --set=20260716-105957F_20260716-110012I info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2310,8 +2381,8 @@
                "value" : {
                   "output" : [
                      "       [filtered 12 lines of output]",
-                     "            repo1: backup size: 2MB",
-                     "            backup reference list: 20260119-092833F, 20260119-092833F_20260119-092839D",
+                     "            repo1: backup size: 1.9MB",
+                     "            backup reference list: 20260716-105957F, 20260716-105957F_20260716-110004D",
                      "            database list: postgres (5), test1 (32768), test2 (32769)"
                   ]
                }
@@ -2320,7 +2391,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2347,7 +2418,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2420,7 +2491,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/postgresql/16/demo/base/32768"
+                     "sudo -u postgres du -sh /var/lib/postgresql/17/demo/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2430,7 +2501,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "8.0K\t/var/lib/postgresql/16/demo/base/32768"
+                     "8.0K\t/var/lib/postgresql/17/demo/base/32768"
                   ]
                }
             },
@@ -2543,7 +2614,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-01-19 09:28:56.893848+00"
+                     "2026-07-16 11:00:24.130959+00"
                   ]
                }
             },
@@ -2620,7 +2691,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092833F_20260119-092858I"
+                     "20260716-105957F_20260716-110025I"
                   ]
                }
             },
@@ -2634,7 +2705,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "20260119-092833F_20260119-092858I"
+                        "20260716-105957F_20260716-110025I"
                      ]
                   },
                   "host" : "pg-primary",
@@ -2648,8 +2719,8 @@
                      "       [filtered 38 lines of output]",
                      "            backup reference total: 1 full, 1 diff",
                      "",
-                     "        incr backup: 20260119-092833F_20260119-092858I",
-                     "            timestamp start/stop: 2026-01-19 09:28:58+00 / 2026-01-19 09:28:59+00",
+                     "        incr backup: 20260716-105957F_20260716-110025I",
+                     "            timestamp start/stop: 2026-07-16 11:00:25+00 / 2026-07-16 11:00:27+00",
                      "            wal start/stop: 00000004000000000000001A / 00000004000000000000001A",
                      "       [filtered 2 lines of output]"
                   ]
@@ -2659,7 +2730,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2673,8 +2744,8 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --set=20260119-092833F_20260119-092858I --target-timeline=current \\",
-                     "    --type=time \"--target=2026-01-19 09:28:56.893848+00\" --target-action=promote restore"
+                     "    --set=20260716-105957F_20260716-110025I --target-timeline=current \\",
+                     "    --type=time \"--target=2026-07-16 11:00:24.130959+00\" --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2687,7 +2758,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2700,7 +2771,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "err-expect" : "1",
                   "highlight" : {
@@ -2720,9 +2791,9 @@
                   "output" : [
                      "       [filtered 13 lines of output]",
                      "LOG:  database system is ready to accept read-only connections",
-                     "LOG:  redo done at 0/1A000100 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.02 s",
+                     "LOG:  redo done at 0/1A000120 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.03 s",
                      "FATAL:  recovery ended before configured recovery target was reached",
-                     "LOG:  startup process (PID 2087) exited with exit code 1",
+                     "LOG:  startup process (PID 1434) exited with exit code 1",
                      "LOG:  terminating any other active server processes",
                      "       [filtered 3 lines of output]"
                   ]
@@ -2733,7 +2804,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --type=time \"--target=2026-01-19 09:28:56.893848+00\" \\",
+                     "    --type=time \"--target=2026-07-16 11:00:24.130959+00\" \\",
                      "    --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
@@ -2747,7 +2818,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2760,7 +2831,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/17/demo/postgresql.auto.conf"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2778,9 +2849,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 9 lines of output]",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:01",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "recovery_target_time = '2026-01-19 09:28:56.893848+00'",
+                     "recovery_target_time = '2026-07-16 11:00:24.130959+00'",
                      "recovery_target_action = 'promote'"
                   ]
                }
@@ -2789,7 +2860,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2843,7 +2914,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -2860,18 +2931,18 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "       [filtered 4 lines of output]",
-                     "LOG:  database system was interrupted; last known up at 2026-01-19 09:28:46 UTC",
+                     "       [filtered 7 lines of output]",
                      "LOG:  restored log file \"00000004.history\" from archive",
-                     "LOG:  starting point-in-time recovery to 2026-01-19 09:28:56.893848+00",
-                     "LOG:  starting backup recovery with redo LSN 0/19000028, checkpoint LSN 0/19000060, on timeline ID 3",
-                     "LOG:  restored log file \"00000004.history\" from archive",
-                     "       [filtered 5 lines of output]",
+                     "LOG:  restored log file \"000000040000000000000019\" from archive",
+                     "LOG:  starting point-in-time recovery to 2026-07-16 11:00:24.130959+00",
+                     "LOG:  restored log file \"00000003.history\" from archive",
+                     "LOG:  redo starts at 0/19000028",
+                     "       [filtered 2 lines of output]",
                      "LOG:  database system is ready to accept read-only connections",
                      "LOG:  restored log file \"00000004000000000000001A\" from archive",
-                     "LOG:  recovery stopping before commit of transaction 740, time 2026-01-19 09:28:58.178129+00",
-                     "LOG:  redo done at 0/19026050 system usage: CPU: user: 0.00 s, system: 0.01 s, elapsed: 0.08 s",
-                     "LOG:  last completed transaction was at log time 2026-01-19 09:28:55.619384+00",
+                     "LOG:  recovery stopping before commit of transaction 748, time 2026-07-16 11:00:25.574422+00",
+                     "LOG:  redo done at 0/1901CC00 system usage: CPU: user: 0.00 s, system: 0.02 s, elapsed: 0.10 s",
+                     "LOG:  last completed transaction was at log time 2026-07-16 11:00:22.732209+00",
                      "LOG:  restored log file \"000000040000000000000019\" from archive",
                      "LOG:  selected new timeline ID: 5",
                      "       [filtered 5 lines of output]"
@@ -2882,7 +2953,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2912,7 +2983,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stop command begin 2.58.0: --exec-id=2218-8ca4f1b4 --log-level-console=info --no-log-timestamp --stanza=demo",
+                     "P00   INFO: stop command begin 2.59.0: --exec-id=1564-85de7e3e --log-level-console=info --no-log-timestamp --stanza=demo",
                      "P00   INFO: stop command end: completed successfully"
                   ]
                }
@@ -2939,7 +3010,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.58.0: --exec-id=2226-48f6922d --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=1572-6d1c9f33 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -2948,7 +3019,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -2988,7 +3059,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -3060,7 +3131,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=2308-b4d7b69d --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1653-117c526b --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -3089,16 +3160,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=2317-4e42a3a2 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1662-722fcb35 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001B, lsn = 0/1B000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001B:00000005000000000000001B",
-                     "P00   INFO: new backup label = 20260119-092914F",
+                     "P00   INFO: new backup label = 20260716-110042F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=2317-4e42a3a2 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1662-722fcb35 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
                   ]
                }
             },
@@ -3139,7 +3210,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -3187,9 +3258,9 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc --insecure alias set s3 https://127.0.0.1 accessKey1 verySecretKey1"
+                     "aws configure set aws_access_key_id accessKey1"
                   ],
-                  "host" : "s3-server",
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : false,
                   "run-as-user" : "root"
@@ -3200,9 +3271,48 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc --insecure mb --with-versioning s3/demo-bucket"
+                     "aws configure set aws_secret_access_key verySecretKey1"
                   ],
-                  "host" : "s3-server",
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws configure set region us-east-1"
+                  ],
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws --endpoint-url https://s3.us-east-1.amazonaws.com s3 mb s3://demo-bucket"
+                  ],
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws --endpoint-url https://s3.us-east-1.amazonaws.com s3api put-bucket-versioning --bucket demo-bucket --versioning-configuration Status=Enabled"
+                  ],
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : false,
                   "run-as-user" : "root"
@@ -3259,16 +3369,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=2369-53f55626 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1765-94bfc14c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
-                     "P00   INFO: backup start archive = 00000005000000000000001C, lsn = 0/1C000028",
+                     "P00   INFO: backup start archive = 00000005000000000000001D, lsn = 0/1D000028",
                      "       [filtered 3 lines of output]",
-                     "P00   INFO: check archive for segment(s) 00000005000000000000001C:00000005000000000000001D",
-                     "P00   INFO: new backup label = 20260119-092920F",
+                     "P00   INFO: check archive for segment(s) 00000005000000000000001D:00000005000000000000001D",
+                     "P00   INFO: new backup label = 20260716-110102F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=2369-53f55626 --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1765-94bfc14c --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
                   ]
                }
             },
@@ -3286,7 +3396,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-01-19 09:29:25+00"
+                     "2026-07-16 11:01:20+00"
                   ]
                }
             },
@@ -3330,7 +3440,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3513,18 +3623,18 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=2456-cb9d7447 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1856-dc7abe2f --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
-                     "P00   INFO: backup start archive = 00000005000000000000001E, lsn = 0/1E000028",
+                     "P00   INFO: backup start archive = 00000005000000000000001F, lsn = 0/1F000028",
                      "       [filtered 3 lines of output]",
-                     "P00   INFO: check archive for segment(s) 00000005000000000000001E:00000005000000000000001F",
-                     "P00   INFO: new backup label = 20260119-092928F",
+                     "P00   INFO: check archive for segment(s) 00000005000000000000001F:00000005000000000000001F",
+                     "P00   INFO: new backup label = 20260716-110123F",
                      "P00   INFO: full backup size = 29.2MB, file total = 1265",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=2456-cb9d7447 --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1856-dc7abe2f --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -3554,7 +3664,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "process-max=4",
@@ -3602,7 +3712,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -3660,7 +3770,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "missing stanza data"
+                        "missing stanza path"
                      ]
                   },
                   "host" : "pg-primary",
@@ -3672,8 +3782,7 @@
                "value" : {
                   "output" : [
                      "stanza: demo",
-                     "    status: error (missing stanza data)",
-                     "    cipher: none"
+                     "    status: error (missing stanza path)"
                   ]
                }
             },
@@ -3681,17 +3790,16 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc ls --versions s3/demo-bucket/demo-repo/backup/demo/backup.info"
+                     "key=demo-repo/backup/demo/backup.info; \\",
+                     "    aws s3api list-object-versions --bucket demo-bucket \\",
+                     "    --prefix $key --output table \\",
+                     "    --query \"sort_by([Versions[?Key=='$key'].{Action:'PUT', \\",
+                     "    Modified:LastModified,Object:Key}, \\",
+                     "    DeleteMarkers[?Key=='$key'].{Action:'DELETE', \\",
+                     "    Modified:LastModified,Object:Key}][],&Modified)\""
                   ],
-                  "cmd-extra" : "--insecure",
-                  "highlight" : {
-                     "filter" : true,
-                     "filter-context" : 2,
-                     "list" : [
-                        "backup\\.info$"
-                     ]
-                  },
-                  "host" : "s3-server",
+                  "cmd-extra" : "--endpoint-url https://s3.us-east-1.amazonaws.com",
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : true,
                   "run-as-user" : "root"
@@ -3699,11 +3807,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "[2026-01-19 09:29:33 UTC]     0B STANDARD e60f13be-eb40-4101-a5f4-a733ec515b72 v3 DEL backup.info",
-                     "[2026-01-19 09:29:25 UTC] 1.0KiB STANDARD 6c12779b-6620-4c0d-b185-9d4a73fa76e3 v2 PUT backup.info",
-                     "[2026-01-19 09:29:20 UTC]   372B STANDARD cd7d190f-8734-4fd7-a188-cfab6ed47edc v1 PUT backup.info",
-                     "[2026-01-19 09:29:33 UTC]     0B STANDARD 90efc3d6-9b35-424a-bc43-63ec11104bba v3 DEL backup.info.copy",
-                     "[2026-01-19 09:29:25 UTC] 1.0KiB STANDARD a1929d2f-d190-4b23-b528-234df9f367cc v2 PUT backup.info.copy"
+                     "-----------------------------------------------------------------------------",
+                     "|                            ListObjectVersions                             |",
+                     "+--------+----------------------------+-------------------------------------+",
+                     "| Action |         Modified           |               Object                |",
+                     "+--------+----------------------------+-------------------------------------+",
+                     "|  PUT   |  2026-07-16T11:01:02.464Z  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-16T11:01:19.990Z  |  demo-repo/backup/demo/backup.info  |",
+                     "|  DELETE|  2026-07-16T11:01:29.959Z  |  demo-repo/backup/demo/backup.info  |",
+                     "+--------+----------------------------+-------------------------------------+"
                   ]
                }
             },
@@ -3712,7 +3824,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 \\",
-                     "    --repo-target-time=\"2026-01-19 09:29:25+00\" info"
+                     "    --repo-target-time=\"2026-07-16 11:01:20+00\" info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -3730,12 +3842,12 @@
                "value" : {
                   "output" : [
                      "       [filtered 5 lines of output]",
-                     "        wal archive min/max (16): 00000005000000000000001C/00000005000000000000001D",
+                     "        wal archive min/max (17): 00000005000000000000001C/00000005000000000000001D",
                      "",
-                     "        full backup: 20260119-092920F",
-                     "            timestamp start/stop: 2026-01-19 09:29:20+00 / 2026-01-19 09:29:25+00",
-                     "            wal start/stop: 00000005000000000000001C / 00000005000000000000001D",
-                     "            repo3: backup set size: 3.9MB, backup size: 3.9MB"
+                     "        full backup: 20260716-110102F",
+                     "            timestamp start/stop: 2026-07-16 11:01:02+00 / 2026-07-16 11:01:19+00",
+                     "            wal start/stop: 00000005000000000000001D / 00000005000000000000001D",
+                     "            repo3: backup set size: 3.8MB, backup size: 3.8MB"
                   ]
                }
             },
@@ -3744,7 +3856,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 --delta \\",
-                     "    --repo-target-time=\"2026-01-19 09:29:25+00\" --log-level-console=info restore"
+                     "    --repo-target-time=\"2026-07-16 11:01:20+00\" --log-level-console=info restore"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -3761,10 +3873,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: restore command begin 2.58.0: --delta --exec-id=2539-eda692fe --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-01-19 09:29:25+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
-                     "P00   INFO: repo3: restore backup set 20260119-092920F, recovery will start at 2026-01-19 09:29:20",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/16/demo'",
-                     "P00   INFO: write updated /var/lib/postgresql/16/demo/postgresql.auto.conf",
+                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=1950-39d23b15 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/postgresql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-16 11:01:20+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
+                     "P00   INFO: repo3: restore backup set 20260716-110102F, recovery will start at 2026-07-16 11:01:02",
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/postgresql/17/demo'",
+                     "P00   INFO: write updated /var/lib/postgresql/17/demo/postgresql.auto.conf",
                      "       [filtered 2 lines of output]"
                   ]
                }
@@ -3773,7 +3885,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4124,7 +4236,7 @@
                            "value" : "pg-primary"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -4145,7 +4257,7 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -4161,7 +4273,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -4182,7 +4294,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -4251,7 +4363,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4277,7 +4389,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -4329,7 +4441,7 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "process-max=3",
@@ -4378,19 +4490,19 @@
                      "    cipher: none",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (16): 000000070000000000000023/000000070000000000000025",
+                     "        wal archive min/max (17): 000000070000000000000023/000000070000000000000025",
                      "",
-                     "        full backup: 20260119-093003F",
-                     "            timestamp start/stop: 2026-01-19 09:30:03+00 / 2026-01-19 09:30:06+00",
+                     "        full backup: 20260716-110213F",
+                     "            timestamp start/stop: 2026-07-16 11:02:13+00 / 2026-07-16 11:02:17+00",
                      "            wal start/stop: 000000070000000000000023 / 000000070000000000000023",
                      "            database size: 29.2MB, database backup size: 29.2MB",
-                     "            repo1: backup set size: 3.9MB, backup size: 3.9MB",
+                     "            repo1: backup set size: 3.8MB, backup size: 3.8MB",
                      "",
-                     "        full backup: 20260119-093007F",
-                     "            timestamp start/stop: 2026-01-19 09:30:07+00 / 2026-01-19 09:30:11+00",
+                     "        full backup: 20260716-110219F",
+                     "            timestamp start/stop: 2026-07-16 11:02:19+00 / 2026-07-16 11:02:24+00",
                      "            wal start/stop: 000000070000000000000024 / 000000070000000000000025",
                      "            database size: 29.2MB, database backup size: 29.2MB",
-                     "            repo1: backup set size: 3.9MB, backup size: 3.9MB"
+                     "            repo1: backup set size: 3.8MB, backup size: 3.8MB"
                   ]
                }
             },
@@ -4760,7 +4872,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -4780,7 +4892,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -4792,7 +4904,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 16 demo"
+                     "sudo pg_createcluster 17 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4818,7 +4930,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/17/demo/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4831,24 +4943,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:28:18",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:59:37",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:28:41",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:06",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:01",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:29:35 # recovery_target_time = '2026-01-19 09:28:56.893848+00'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:29:35 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_time = '2026-07-16 11:00:24.130959+00'",
+                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:35",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-01-19 09:29:25+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:01:35",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 11:01:20+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:57",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:06",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:30:25",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:42",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
                }
@@ -4857,7 +4969,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/17/demo/postgresql.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4868,7 +4980,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "archive_command" : {
@@ -4895,7 +5007,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4908,7 +5020,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -4934,7 +5046,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -4951,13 +5063,13 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "       [filtered 3 lines of output]",
-                     "LOG:  listening on Unix socket \"/var/run/postgresql/.s.PGSQL.5432\"",
-                     "LOG:  database system was interrupted; last known up at 2026-01-19 09:30:07 UTC",
-                     "LOG:  entering standby mode",
-                     "LOG:  starting backup recovery with redo LSN 0/24000028, checkpoint LSN 0/24000060, on timeline ID 7",
+                     "       [filtered 6 lines of output]",
                      "LOG:  restored log file \"00000007.history\" from archive",
-                     "       [filtered 6 lines of output]"
+                     "LOG:  restored log file \"000000070000000000000024\" from archive",
+                     "LOG:  entering standby mode",
+                     "LOG:  redo starts at 0/24000028",
+                     "LOG:  restored log file \"000000070000000000000025\" from archive",
+                     "       [filtered 3 lines of output]"
                   ]
                }
             },
@@ -5039,7 +5151,7 @@
                   "output" : [
                      " pg_switch_wal |       current_timestamp       ",
                      "---------------+-------------------------------",
-                     " 0/2601A870    | 2026-01-19 09:30:32.338412+00",
+                     " 0/260195C8    | 2026-07-16 11:02:51.131426+00",
                      "(1 row)"
                   ]
                }
@@ -5068,7 +5180,7 @@
                   "output" : [
                      "    message     |      current_timestamp       ",
                      "----------------+------------------------------",
-                     " Important Data | 2026-01-19 09:30:33.80566+00",
+                     " Important Data | 2026-07-16 11:02:52.92811+00",
                      "(1 row)"
                   ]
                }
@@ -5094,7 +5206,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1159-e47628bc --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=488-6d9cbe16 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -5126,7 +5238,7 @@
                   "cmd" : [
                      "sudo -u postgres sh -c 'echo \\",
                      "    \"host    replication     replicator      172.17.0.8/32           md5\" \\",
-                     "    >> /etc/postgresql/16/demo/pg_hba.conf'"
+                     "    >> /etc/postgresql/17/demo/pg_hba.conf'"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -5139,7 +5251,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo reload"
+                     "sudo pg_ctlcluster 17 demo reload"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -5164,7 +5276,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -5205,7 +5317,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5231,7 +5343,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/postgresql/16/demo/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/postgresql/17/demo/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5244,24 +5356,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:28:18",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:59:37",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:28:41",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:06",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:01",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:00:29",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:29:35 # recovery_target_time = '2026-01-19 09:28:56.893848+00'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:29:35 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_time = '2026-07-16 11:00:24.130959+00'",
+                     "# Removed by pgBackRest restore on 2026-07-16 11:01:35 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:35",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-01-19 09:29:25+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:01:35",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 11:01:20+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:29:57",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:06",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:30:36",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 11:02:56",
                      "primary_conninfo = 'host=172.17.0.6 port=5432 user=replicator'",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
@@ -5271,7 +5383,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo rm /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5284,7 +5396,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo start"
+                     "sudo pg_ctlcluster 17 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -5310,7 +5422,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/log/postgresql/postgresql-16-demo.log"
+                     "sudo -u postgres cat /var/log/postgresql/postgresql-17-demo.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -5328,7 +5440,7 @@
                "value" : {
                   "output" : [
                      "       [filtered 13 lines of output]",
-                     "LOG:  consistent recovery state reached at 0/25000050",
+                     "LOG:  consistent recovery state reached at 0/25000088",
                      "LOG:  database system is ready to accept read-only connections",
                      "LOG:  started streaming WAL from primary at 0/27000000 on timeline 7"
                   ]
@@ -5363,7 +5475,7 @@
                      "       [filtered 4 lines of output]",
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-01-19 09:30:43.211099+00",
+                     " Important Data | 2026-07-16 11:03:03.936939+00",
                      "(1 row)"
                   ]
                }
@@ -5392,7 +5504,7 @@
                   "output" : [
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-01-19 09:30:43.388694+00",
+                     " Important Data | 2026-07-16 11:03:04.365141+00",
                      "(1 row)"
                   ]
                }
@@ -5637,7 +5749,7 @@
                   "option" : {
                      "demo-alt" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -5657,7 +5769,7 @@
                "value" : {
                   "config" : [
                      "[demo-alt]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -5675,7 +5787,7 @@
                            "value" : "pg-alt"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      }
                   }
@@ -5685,11 +5797,11 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "process-max=3",
@@ -5703,8 +5815,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/16/bin/initdb \\",
-                     "    -D /var/lib/postgresql/16/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/17/bin/initdb \\",
+                     "    -D /var/lib/postgresql/17/demo -k -A peer"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5717,7 +5829,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 16 demo"
+                     "sudo pg_createcluster 17 demo"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5727,9 +5839,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "Configuring already existing cluster (configuration: /etc/postgresql/16/demo, data: /var/lib/postgresql/16/demo, owner: 102:103)",
+                     "Configuring already existing cluster (configuration: /etc/postgresql/17/demo, data: /var/lib/postgresql/17/demo, owner: 102:103)",
                      "Ver Cluster Port Status Owner    Data directory              Log file",
-                     "16  demo    5432 down   postgres /var/lib/postgresql/16/demo /var/log/postgresql/postgresql-16-demo.log"
+                     "17  demo    5432 down   postgres /var/lib/postgresql/17/demo /var/log/postgresql/postgresql-17-demo.log"
                   ]
                }
             },
@@ -5737,7 +5849,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/16/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/17/demo/postgresql.conf"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5748,7 +5860,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/16/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
                   "host" : "pg-alt",
                   "option" : {
                      "archive_command" : {
@@ -5771,7 +5883,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo restart"
+                     "sudo pg_ctlcluster 17 demo restart"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -5814,7 +5926,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=1027-863103d1 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=383-bcf8f14c --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -5841,11 +5953,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1037-dcb84d90 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=393-113428ec --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/16-1/0000000100000000/000000010000000000000001-d581f9c024aa57fd11caaf7b1d0142d6eb7e6c98.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000001-25ac74677469a7daae1d1da6a7865d53a8fe2d04.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -5871,15 +5983,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1919-952717d9 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1257-09213903 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
                      "P00   INFO: check stanza 'demo'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/16-1/0000000700000000/000000070000000000000027-943c372700ab056ed6f01bd2fe5cc4b05f22be52.gz' on repo1",
+                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/000000070000000000000027-9575963e3d490c9850a005702d908a3a356a6024.gz' on repo1",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/16-1/0000000100000000/000000010000000000000002-74201c5f0512a2313d44b325bc97b774ada813e2.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/17-1/0000000100000000/000000010000000000000002-7f91d707821a5537890cc0ca6368265776662e45.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -5965,7 +6077,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -6010,7 +6122,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -6049,7 +6161,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo restart"
+                     "sudo pg_ctlcluster 17 demo restart"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6110,10 +6222,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=3183-d3ffb6cd --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=2584-4848adfa --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/16-1/0000000700000000/00000007000000000000002D-b22834a2d3306ded7a39c8982af40c38d01d1595.gz' on repo1",
+                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/17-1/0000000700000000/00000007000000000000002D-b80ba4b534c54d64c41bd71d7c11fabd0a56eb81.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -6140,19 +6252,19 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.58.0: [/var/lib/postgresql/16/demo/pg_wal] --archive-async --exec-id=3169-08eec32e --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2570-9158d236 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 000000070000000000000028",
                      "P01 DETAIL: pushed WAL file '000000070000000000000028' to the archive",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.58.0: [/var/lib/postgresql/16/demo/pg_wal] --archive-async --exec-id=3187-9a196906 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/postgresql/17/demo/pg_wal] --archive-async --exec-id=2588-ee199f71 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 5 WAL file(s) to archive: 000000070000000000000029...00000007000000000000002D",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002A' to the archive",
                      "P01 DETAIL: pushed WAL file '000000070000000000000029' to the archive",
-                     "P01 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002B' to the archive",
-                     "P01 DETAIL: pushed WAL file '00000007000000000000002D' to the archive",
+                     "P01 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
+                     "P02 DETAIL: pushed WAL file '00000007000000000000002D' to the archive",
                      "P00   INFO: archive-push:async command end: completed successfully"
                   ]
                }
@@ -6192,26 +6304,31 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.58.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=1380-8760a6e0 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=706-a65da116 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000024...00000007000000000000002B",
-                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 16-1 archive",
-                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 16-1 archive",
-                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 16-1 archive",
-                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 16-1 archive",
+                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 17-1 archive",
+                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 17-1 archive",
+                     "P02 DETAIL: found 000000070000000000000026 in the repo1: 17-1 archive",
+                     "P01 DETAIL: found 000000070000000000000027 in the repo1: 17-1 archive",
                      "P00 DETAIL: unable to find 000000070000000000000028 in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
                      "       [filtered 14 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.58.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=1431-a78c4f0a --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/16/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=750-e74eda5d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000028...00000007000000000000002F",
-                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 16-1 archive",
-                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 16-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002A in the repo1: 16-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002B in the repo1: 16-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002C in the repo1: 16-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002D in the repo1: 16-1 archive",
+                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 17-1 archive",
+                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 17-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002A in the repo1: 17-1 archive",
+                     "P00 DETAIL: unable to find 00000007000000000000002B in the archive",
+                     "P00   INFO: archive-get:async command end: completed successfully",
+                     "       [filtered 2 lines of output]",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F, 000000070000000000000030, 000000070000000000000031] --archive-async --exec-id=759-456c780e --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/postgresql/17/demo --process-max=2 --repo1-host=repository --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: get 7 WAL file(s) from archive: 00000007000000000000002B...000000070000000000000031",
+                     "P02 DETAIL: found 00000007000000000000002C in the repo1: 17-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002B in the repo1: 17-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002D in the repo1: 17-1 archive",
                      "P00 DETAIL: unable to find 00000007000000000000002E in the archive",
                      "P00   INFO: archive-get:async command end: completed successfully",
-                     "       [filtered 11 lines of output]"
+                     "       [filtered 17 lines of output]"
                   ]
                }
             },
@@ -6243,7 +6360,7 @@
                            "value" : "pg-standby"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/postgresql/16/demo"
+                           "value" : "/var/lib/postgresql/17/demo"
                         }
                      },
                      "global" : {
@@ -6258,13 +6375,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/16/demo",
+                     "pg2-path=/var/lib/postgresql/17/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -6302,9 +6419,9 @@
                      "P00   INFO: wait for replay on the standby to reach 0/2F000028",
                      "P00   INFO: replay on the standby reached 0/2F000028",
                      "P00   INFO: check archive for prior segment 00000007000000000000002E",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/16/demo/global/pg_control (8KB, 0.53%) checksum c9b694b7e3af23be6834c24b23bb1a43d8fb22f4",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/postgresql/16/demo/pg_logical/replorigin_checkpoint (8B, 0.53%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
-                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/16/demo/base/5/1249 (464KB, 31.38%) checksum c32e73e05783bcad1a0107e7b5462117b2906d5e",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/postgresql/17/demo/global/pg_control (8KB, 0.53%) checksum 02201a29953e5ea33614ba0ceb95b6f603142eec",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/postgresql/17/demo/pg_logical/replorigin_checkpoint (8B, 0.53%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
+                     "P02 DETAIL: backup file pg-standby:/var/lib/postgresql/17/demo/base/5/1249 (448KB, 30.16%) checksum 42ae0e3b251da996bdcbaf9d012ca13ea8c4d01f",
                      "       [filtered 1278 lines of output]"
                   ]
                }
@@ -6313,7 +6430,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6326,7 +6443,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 16 demo stop"
+                     "sudo pg_ctlcluster 17 demo stop"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6339,8 +6456,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/lib/postgresql/17/bin/initdb \\",
-                     "    -D /var/lib/postgresql/17/demo -k -A peer"
+                     "sudo -u postgres /usr/lib/postgresql/18/bin/initdb \\",
+                     "    -D /var/lib/postgresql/18/demo -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6353,7 +6470,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 17 demo"
+                     "sudo pg_createcluster 18 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6367,13 +6484,13 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres sh -c 'cd /var/lib/postgresql && \\",
-                     "    /usr/lib/postgresql/17/bin/pg_upgrade \\",
-                     "    --old-bindir=/usr/lib/postgresql/16/bin \\",
-                     "    --new-bindir=/usr/lib/postgresql/17/bin \\",
-                     "    --old-datadir=/var/lib/postgresql/16/demo \\",
-                     "    --new-datadir=/var/lib/postgresql/17/demo \\",
-                     "    --old-options=\" -c config_file=/etc/postgresql/16/demo/postgresql.conf\" \\",
-                     "    --new-options=\" -c config_file=/etc/postgresql/17/demo/postgresql.conf\"'"
+                     "    /usr/lib/postgresql/18/bin/pg_upgrade \\",
+                     "    --old-bindir=/usr/lib/postgresql/17/bin \\",
+                     "    --new-bindir=/usr/lib/postgresql/18/bin \\",
+                     "    --old-datadir=/var/lib/postgresql/17/demo \\",
+                     "    --new-datadir=/var/lib/postgresql/18/demo \\",
+                     "    --old-options=\" -c config_file=/etc/postgresql/17/demo/postgresql.conf\" \\",
+                     "    --new-options=\" -c config_file=/etc/postgresql/18/demo/postgresql.conf\"'"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -6390,13 +6507,13 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "       [filtered 41 lines of output]",
+                     "       [filtered 44 lines of output]",
                      "Checking for extension updates                                ok",
                      "",
                      "Upgrade Complete",
                      "----------------",
-                     "Optimizer statistics are not transferred by pg_upgrade.",
-                     "       [filtered 3 lines of output]"
+                     "Some statistics are not transferred by pg_upgrade.",
+                     "       [filtered 4 lines of output]"
                   ]
                }
             },
@@ -6404,7 +6521,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /etc/postgresql/17/demo/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /etc/postgresql/18/demo/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6415,7 +6532,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/18/demo/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -6441,7 +6558,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/17/demo"
+                           "value" : "/var/lib/postgresql/18/demo"
                         }
                      }
                   }
@@ -6450,7 +6567,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/17/demo",
+                     "pg1-path=/var/lib/postgresql/18/demo",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -6473,7 +6590,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/17/demo"
+                           "value" : "/var/lib/postgresql/18/demo"
                         }
                      }
                   }
@@ -6482,7 +6599,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/postgresql/17/demo",
+                     "pg1-path=/var/lib/postgresql/18/demo",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -6506,10 +6623,10 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/postgresql/17/demo"
+                           "value" : "/var/lib/postgresql/18/demo"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/postgresql/17/demo"
+                           "value" : "/var/lib/postgresql/18/demo"
                         }
                      },
                      "global" : {
@@ -6524,13 +6641,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/17/demo",
+                     "pg1-path=/var/lib/postgresql/18/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/17/demo",
+                     "pg2-path=/var/lib/postgresql/18/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "backup-standby=n",
@@ -6545,8 +6662,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo cp /etc/postgresql/16/demo/pg_hba.conf \\",
-                     "    /etc/postgresql/17/demo/pg_hba.conf"
+                     "sudo cp /etc/postgresql/17/demo/pg_hba.conf \\",
+                     "    /etc/postgresql/18/demo/pg_hba.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6577,7 +6694,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.58.0: --exec-id=3590-c2882bfe --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/17/demo --repo1-host=repository --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=3008-0c8086a0 --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/postgresql/18/demo --repo1-host=repository --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]
@@ -6587,7 +6704,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 17 demo start"
+                     "sudo pg_ctlcluster 18 demo start"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6626,7 +6743,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_dropcluster 16 demo"
+                     "sudo pg_dropcluster 17 demo"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -6639,7 +6756,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_dropcluster 16 demo"
+                     "sudo pg_dropcluster 17 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6652,7 +6769,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_createcluster 17 demo"
+                     "sudo pg_createcluster 18 demo"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6708,7 +6825,7 @@
             },
             {
                "key" : {
-                  "file" : "/etc/postgresql/17/demo/postgresql.conf",
+                  "file" : "/etc/postgresql/18/demo/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -6727,7 +6844,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo pg_ctlcluster 17 demo start"
+                     "sudo pg_ctlcluster 18 demo start"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -6779,13 +6896,13 @@
                   "config" : [
                      "[demo]",
                      "pg1-host=pg-primary",
-                     "pg1-path=/var/lib/postgresql/17/demo",
+                     "pg1-path=/var/lib/postgresql/18/demo",
                      "pg2-host=pg-standby",
-                     "pg2-path=/var/lib/postgresql/17/demo",
+                     "pg2-path=/var/lib/postgresql/18/demo",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
-                     "pg1-path=/var/lib/postgresql/16/demo",
+                     "pg1-path=/var/lib/postgresql/17/demo",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -6820,11 +6937,11 @@
             {
                "key" : {
                   "id" : "s3",
-                  "image" : "minio/minio",
+                  "image" : "quay.io/ceph/ceph:v19",
                   "name" : "s3-server",
-                  "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/s3-server.crt:/root/.minio/certs/public.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/s3-server.key:/root/.minio/certs/private.key:ro -e MINIO_REGION=us-east-1 -e MINIO_DOMAIN=s3.us-east-1.amazonaws.com -e MINIO_BROWSER=off -e MINIO_ACCESS_KEY=accessKey1 -e MINIO_SECRET_KEY=verySecretKey1",
+                  "option" : "-v {[host-repo-path]}/doc/resource/fake-cert/s3-server.crt:/root/s3-server.crt:ro -v {[host-repo-path]}/doc/resource/fake-cert/s3-server.key:/root/s3-server.key:ro -v {[host-repo-path]}/doc/resource/ceph/bootstrap.sh:/bootstrap.sh:ro -e RGW_DNS_NAME=s3.us-east-1.amazonaws.com -e S3_ACCESS_KEY=accessKey1 -e S3_SECRET_KEY=verySecretKey1",
                   "os" : "rhel",
-                  "param" : "server /data --address :443",
+                  "param" : "bash /bootstrap.sh",
                   "update-hosts" : false
                },
                "type" : "host",
@@ -6862,47 +6979,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo mkdir -p /build/pgbackrest-release-2.58.0"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
-                     "sudo cp -r /pgbackrest/* /build/pgbackrest-release-2.58.0"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
-                     "sudo chown -R vagrant /build"
-                  ],
-                  "host" : "build",
-                  "load-env" : true,
-                  "output" : false,
-                  "run-as-user" : null
-               },
-               "type" : "exe"
-            },
-            {
-               "key" : {
-                  "bash-wrap" : true,
-                  "cmd" : [
-                     "sudo yum install meson gcc postgresql13-devel openssl-devel \\",
-                     "    libxml2-devel lz4-devel libzstd-devel bzip2-devel libyaml-devel libssh2-devel"
+                     "sudo yum install meson gcc postgresql14-devel openssl-devel libxml2-devel \\",
+                     "    lz4-devel libzstd-devel bzip2-devel libssh2-devel systemd-devel"
                   ],
                   "cmd-extra" : "-y 2>&1",
                   "host" : "build",
@@ -6916,7 +6994,86 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "meson setup /build/pgbackrest /build/pgbackrest-release-2.58.0"
+                     "mkdir -p /build/pgbackrest-2.59.0-tmp && \\",
+                     "    chown -R vagrant /build"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "git config --global --add safe.directory /pgbackrest && \\",
+                     "    git -C /pgbackrest ls-files -c --others --exclude-standard | \\",
+                     "    grep -v '^doc/resource/exe\\.cache$' | \\",
+                     "    tar -C /pgbackrest -cf - -T - | tar -C /build/pgbackrest-2.59.0-tmp -xf -"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "git config --global user.name \"test\" && \\",
+                     "    git config --global user.email \"test@test.com\" && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp init 2>&1 && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp add . && \\",
+                     "    git -C /build/pgbackrest-2.59.0-tmp commit -a -m \"test\""
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson setup /build/pgbackrest /build/pgbackrest-2.59.0-tmp && \\",
+                     "    ninja -C /build/pgbackrest src/build-code && \\",
+                     "    mkdir -p /build/pgbackrest-2.59.0-tmp/doc/output/html && \\",
+                     "    mkdir -p /build/pgbackrest-2.59.0-tmp/doc/output/man && \\",
+                     "    PYTHONWARNINGS=ignore meson dist -C /build/pgbackrest --formats gztar && \\",
+                     "    tar zx -C /build -f /build/pgbackrest/meson-dist/pgbackrest-2.59.0.tar.gz && \\",
+                     "    rm -rf /build/pgbackrest"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "sudo yum remove -y libyaml-devel 2>&1"
+                  ],
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : null
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson setup /build/pgbackrest /build/pgbackrest-2.59.0"
                   ],
                   "host" : "build",
                   "load-env" : true,
@@ -6937,6 +7094,36 @@
                   "run-as-user" : null
                },
                "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "meson test -C /build/pgbackrest --suite smoke"
+                  ],
+                  "highlight" : {
+                     "filter" : true,
+                     "filter-context" : 2,
+                     "list" : [
+                        "smoke OK"
+                     ]
+                  },
+                  "host" : "build",
+                  "load-env" : true,
+                  "output" : true,
+                  "run-as-user" : null
+               },
+               "type" : "exe",
+               "value" : {
+                  "output" : [
+                     "ninja: Entering directory `/build/pgbackrest'",
+                     "ninja: no work to do.",
+                     "1/1 smoke OK               13.99s",
+                     "",
+                     "Ok:                 1   ",
+                     "       [filtered 6 lines of output]"
+                  ]
+               }
             },
             {
                "key" : {
@@ -7098,7 +7285,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "pgBackRest 2.58.0 - General help",
+                     "pgBackRest 2.59.0 - General help",
                      "",
                      "Usage:",
                      "    pgbackrest [options] [command]",
@@ -7133,8 +7320,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-13/bin/initdb \\",
-                     "    -D /var/lib/pgsql/13/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-14/bin/initdb \\",
+                     "    -D /var/lib/pgsql/14/data -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7147,7 +7334,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/14/data/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7158,7 +7345,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "log_filename" : {
@@ -7180,7 +7367,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -7194,7 +7381,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data"
+                     "pg1-path=/var/lib/pgsql/14/data"
                   ]
                }
             },
@@ -7221,7 +7408,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "pgBackRest 2.58.0 - 'backup' command - 'log-path' option help",
+                     "pgBackRest 2.59.0 - 'backup' command - 'log-path' option help",
                      "",
                      "Path where log files are stored.",
                      "",
@@ -7288,7 +7475,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest"
@@ -7297,7 +7484,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -7321,7 +7508,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-13.service"
+                     "sudo systemctl restart postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7384,7 +7571,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -7410,7 +7597,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -7440,7 +7627,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -7474,7 +7661,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=1001-c0a11b26 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=1208-4eada09d --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -7501,10 +7688,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1029-7fad2b46 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1240-b29634f2 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000100000000/000000010000000000000001-7f6faa2bdee862515d964b0dac87805c5f762965.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000100000000/000000010000000000000001-cad1c3b733b4b4f3327ed758790c5de8a9d33814.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -7525,7 +7712,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-cipher-pass=zWaf6XtpjIVZC5444yXB+cgFDFl7MxGlgkZSaoPvTGirhPygu4jOKOXf9LO4vjfO",
@@ -7561,16 +7748,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=1102-82fc2007 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=1332-07a8c4d0 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 000000010000000000000002, lsn = 0/2000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000002:000000010000000000000003",
-                     "P00   INFO: new backup label = 20260119-092100F",
-                     "P00   INFO: full backup size = 23.2MB, file total = 936",
+                     "P00   INFO: new backup label = 20260716-105029F",
+                     "P00   INFO: full backup size = 25.2MB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1102-82fc2007 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1332-07a8c4d0 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -7588,7 +7775,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092100F"
+                     "20260716-105029F"
                   ]
                }
             },
@@ -7616,10 +7803,10 @@
                   "output" : [
                      "       [filtered 7 lines of output]",
                      "P00   INFO: check archive for segment(s) 000000010000000000000004:000000010000000000000005",
-                     "P00   INFO: new backup label = 20260119-092100F_20260119-092102D",
-                     "P00   INFO: diff backup size = 9.1KB, file total = 936",
+                     "P00   INFO: new backup label = 20260716-105029F_20260716-105032D",
+                     "P00   INFO: diff backup size = 9.2KB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=1163-a7659621 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=1403-ee6f5158 --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-full=2 --stanza=demo"
                   ]
                }
             },
@@ -7649,19 +7836,19 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (13): 000000010000000000000001/000000010000000000000005",
+                     "        wal archive min/max (14): 000000010000000000000001/000000010000000000000005",
                      "",
-                     "        full backup: 20260119-092100F",
-                     "            timestamp start/stop: 2026-01-19 09:21:00+00 / 2026-01-19 09:21:02+00",
+                     "        full backup: 20260716-105029F",
+                     "            timestamp start/stop: 2026-07-16 10:50:29+00 / 2026-07-16 10:50:31+00",
                      "            wal start/stop: 000000010000000000000002 / 000000010000000000000003",
-                     "            database size: 23.2MB, database backup size: 23.2MB",
-                     "            repo1: backup set size: 2.9MB, backup size: 2.9MB",
+                     "            database size: 25.2MB, database backup size: 25.2MB",
+                     "            repo1: backup set size: 3.2MB, backup size: 3.2MB",
                      "",
-                     "        diff backup: 20260119-092100F_20260119-092102D",
-                     "            timestamp start/stop: 2026-01-19 09:21:02+00 / 2026-01-19 09:21:03+00",
+                     "        diff backup: 20260716-105029F_20260716-105032D",
+                     "            timestamp start/stop: 2026-07-16 10:50:32+00 / 2026-07-16 10:50:33+00",
                      "            wal start/stop: 000000010000000000000004 / 000000010000000000000005",
-                     "            database size: 23.2MB, database backup size: 9.1KB",
-                     "            repo1: backup set size: 2.9MB, backup size: 880B",
+                     "            database size: 25.2MB, database backup size: 9.2KB",
+                     "            repo1: backup set size: 3.2MB, backup size: 864B",
                      "            backup reference total: 1 full"
                   ]
                }
@@ -7670,7 +7857,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7683,7 +7870,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres rm /var/lib/pgsql/13/data/global/pg_control"
+                     "sudo -u postgres rm /var/lib/pgsql/14/data/global/pg_control"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7696,7 +7883,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "err-expect" : "1",
                   "host" : "pg-primary",
@@ -7710,7 +7897,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl status postgresql-13.service"
+                     "sudo systemctl status postgresql-14.service"
                   ],
                   "err-expect" : "3",
                   "highlight" : {
@@ -7728,8 +7915,8 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "postgresql-13.service - PostgreSQL 13 database server",
-                     "    Loaded: loaded (/usr/lib/systemd/system/postgresql-13.service, disabled)",
+                     "postgresql-14.service - PostgreSQL 14 database server",
+                     "    Loaded: loaded (/usr/lib/systemd/system/postgresql-14.service, disabled)",
                      "    Active: failed (failed)"
                   ]
                }
@@ -7738,7 +7925,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres find /var/lib/pgsql/13/data -mindepth 1 -delete"
+                     "sudo -u postgres find /var/lib/pgsql/14/data -mindepth 1 -delete"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7764,7 +7951,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -7927,7 +8114,7 @@
                   "output" : [
                      "  name  | last_successful_backup |    last_archived_wal     ",
                      "--------+------------------------+--------------------------",
-                     " \"demo\" | 2026-01-19 09:21:03+00 | 000000010000000000000005",
+                     " \"demo\" | 2026-07-16 10:50:33+00 | 000000010000000000000005",
                      "(1 row)"
                   ]
                }
@@ -7948,7 +8135,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-bundle=y",
@@ -8010,7 +8197,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8054,7 +8241,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092115F"
+                     "20260716-105049F"
                   ]
                }
             },
@@ -8062,7 +8249,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092115F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -8084,15 +8271,15 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (13): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (14): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260119-092115F",
-                     "            timestamp start/stop: 2026-01-19 09:21:15+00 / 2026-01-19 09:21:16+00",
+                     "        full backup: 20260716-105049F",
+                     "            timestamp start/stop: 2026-07-16 10:50:49+00 / 2026-07-16 10:50:51+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
                      "            lsn start/stop: 0/8000028 / 0/9000050",
-                     "            database size: 23.2MB, database backup size: 23.2MB",
-                     "            repo1: backup size: 2.9MB",
-                     "            database list: postgres (13383)",
+                     "            database size: 25.2MB, database backup size: 25.2MB",
+                     "            repo1: backup size: 3.2MB",
+                     "            database list: postgres (13755)",
                      "            annotation(s)",
                      "                key: value",
                      "                source: demo backup"
@@ -8103,7 +8290,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092115F \\",
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F \\",
                      "    --annotation=key= --annotation=new_key=new_value annotate"
                   ],
                   "host" : "pg-primary",
@@ -8117,7 +8304,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres pgbackrest --stanza=demo --set=20260119-092115F info"
+                     "sudo -u postgres pgbackrest --stanza=demo --set=20260716-105049F info"
                   ],
                   "highlight" : {
                      "filter" : false,
@@ -8139,15 +8326,15 @@
                      "    cipher: aes-256-cbc",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (13): 000000020000000000000007/000000020000000000000009",
+                     "        wal archive min/max (14): 000000020000000000000007/000000020000000000000009",
                      "",
-                     "        full backup: 20260119-092115F",
-                     "            timestamp start/stop: 2026-01-19 09:21:15+00 / 2026-01-19 09:21:16+00",
+                     "        full backup: 20260716-105049F",
+                     "            timestamp start/stop: 2026-07-16 10:50:49+00 / 2026-07-16 10:50:51+00",
                      "            wal start/stop: 000000020000000000000008 / 000000020000000000000009",
                      "            lsn start/stop: 0/8000028 / 0/9000050",
-                     "            database size: 23.2MB, database backup size: 23.2MB",
-                     "            repo1: backup size: 2.9MB",
-                     "            database list: postgres (13383)",
+                     "            database size: 25.2MB, database backup size: 25.2MB",
+                     "            repo1: backup size: 3.2MB",
+                     "            database list: postgres (13755)",
                      "            annotation(s)",
                      "                new_key: new_value",
                      "                source: demo backup"
@@ -8170,7 +8357,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8197,7 +8384,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260119-092100F|remove archive"
+                        "archive retention on backup 20260716-105029F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8208,10 +8395,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "       [filtered 948 lines of output]",
-                     "P00   INFO: repo1: remove expired backup 20260119-092113F",
-                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20260119-092115F, start = 000000020000000000000008",
-                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
+                     "       [filtered 963 lines of output]",
+                     "P00   INFO: repo1: remove expired backup 20260716-105046F",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105049F, start = 000000020000000000000008",
+                     "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000007, stop = 000000020000000000000007",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8230,7 +8417,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092118F"
+                     "20260716-105053F"
                   ]
                }
             },
@@ -8245,7 +8432,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire full backup set 20260119-092100F|archive retention on backup 20260119-092118F|remove archive"
+                        "expire full backup set 20260716-105029F|archive retention on backup 20260716-105053F|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8257,9 +8444,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 11 lines of output]",
-                     "P00   INFO: repo1: expire full backup 20260119-092115F",
-                     "P00   INFO: repo1: remove expired backup 20260119-092115F",
-                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
+                     "P00   INFO: repo1: expire full backup 20260716-105049F",
+                     "P00   INFO: repo1: remove expired backup 20260716-105049F",
+                     "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000008, stop = 000000020000000000000009",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8280,7 +8467,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8324,7 +8511,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092120F_20260119-092122D"
+                     "20260716-105056F_20260716-105059D"
                   ]
                }
             },
@@ -8352,7 +8539,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "expire diff backup set 20260119-092120F_20260119-092122D"
+                        "expire diff backup set 20260716-105056F_20260716-105059D"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8365,10 +8552,10 @@
                   "output" : [
                      "       [filtered 10 lines of output]",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=2196-f736765b --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
-                     "P00   INFO: repo1: expire diff backup set 20260119-092120F_20260119-092122D, 20260119-092120F_20260119-092123I",
-                     "P00   INFO: repo1: remove expired backup 20260119-092120F_20260119-092123I",
-                     "P00   INFO: repo1: remove expired backup 20260119-092120F_20260119-092122D",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=2645-c0b45b6a --log-level-console=info --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-diff=1 --repo1-retention-full=2 --stanza=demo",
+                     "P00   INFO: repo1: expire diff backup set 20260716-105056F_20260716-105059D, 20260716-105056F_20260716-105101I",
+                     "P00   INFO: repo1: remove expired backup 20260716-105056F_20260716-105101I",
+                     "P00   INFO: repo1: remove expired backup 20260716-105056F_20260716-105059D",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8389,7 +8576,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -8420,7 +8607,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092120F_20260119-092124D"
+                     "20260716-105056F_20260716-105102D"
                   ]
                }
             },
@@ -8464,8 +8651,8 @@
                      "       [filtered 6 lines of output]",
                      "P00   INFO: backup stop archive = 000000020000000000000017, lsn = 0/17000050",
                      "P00   INFO: check archive for segment(s) 000000020000000000000016:000000020000000000000017",
-                     "P00   INFO: new backup label = 20260119-092120F_20260119-092126D",
-                     "P00   INFO: diff backup size = 11.6KB, file total = 936",
+                     "P00   INFO: new backup label = 20260716-105056F_20260716-105105D",
+                     "P00   INFO: diff backup size = 11.5KB, file total = 951",
                      "P00   INFO: backup command end: completed successfully",
                      "       [filtered 2 lines of output]"
                   ]
@@ -8485,7 +8672,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092120F_20260119-092126D"
+                     "20260716-105056F_20260716-105105D"
                   ]
                }
             },
@@ -8500,7 +8687,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "archive retention on backup 20260119-092120F_20260119-092124D|remove archive"
+                        "archive retention on backup 20260716-105056F_20260716-105102D|remove archive"
                      ]
                   },
                   "host" : "pg-primary",
@@ -8511,13 +8698,14 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=2392-b81327e6 --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
-                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20260119-092118F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
-                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20260119-092120F, start = 00000002000000000000000C, stop = 00000002000000000000000D",
-                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20260119-092120F_20260119-092124D, start = 000000020000000000000012, stop = 000000020000000000000013",
-                     "P00 DETAIL: repo1: 13-1 archive retention on backup 20260119-092120F_20260119-092126D, start = 000000020000000000000016",
-                     "P00   INFO: repo1: 13-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
-                     "P00   INFO: repo1: 13-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=2881-cbaf3136 --log-level-console=detail --no-log-timestamp --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo1-retention-archive=1 --repo1-retention-archive-type=diff --repo1-retention-diff=2 --repo1-retention-full=2 --stanza=demo",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105053F, start = 00000002000000000000000A, stop = 00000002000000000000000B",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F, start = 00000002000000000000000D, stop = 00000002000000000000000D",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F_20260716-105102D, start = 000000020000000000000012, stop = 000000020000000000000013",
+                     "P00 DETAIL: repo1: 14-1 archive retention on backup 20260716-105056F_20260716-105105D, start = 000000020000000000000016",
+                     "P00   INFO: repo1: 14-1 remove archive, start = 00000002000000000000000C, stop = 00000002000000000000000C",
+                     "P00   INFO: repo1: 14-1 remove archive, start = 00000002000000000000000E, stop = 000000020000000000000011",
+                     "P00   INFO: repo1: 14-1 remove archive, start = 000000020000000000000014, stop = 000000020000000000000015",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -8526,7 +8714,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8558,12 +8746,12 @@
                "value" : {
                   "output" : [
                      "       [filtered 2 lines of output]",
-                     "P00 DETAIL: check '/var/lib/pgsql/13/data' exists",
+                     "P00 DETAIL: check '/var/lib/pgsql/14/data' exists",
                      "P00 DETAIL: remove 'global/pg_control' so cluster will not start if restore does not complete",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/13/data'",
-                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/13/data/backup_label.old'",
-                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/13/data/base/13383/pg_internal.init'",
-                     "       [filtered 981 lines of output]"
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/14/data'",
+                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/14/data/backup_label.old'",
+                     "P00 DETAIL: remove invalid file '/var/lib/pgsql/14/data/base/13755/pg_internal.init'",
+                     "       [filtered 996 lines of output]"
                   ]
                }
             },
@@ -8571,7 +8759,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8644,6 +8832,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
+                     "CREATE TABLE",
                      "INSERT 0 1"
                   ]
                }
@@ -8663,6 +8852,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
+                     "CREATE TABLE",
                      "INSERT 0 1"
                   ]
                }
@@ -8702,7 +8892,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/pgsql/13/data/base/32768"
+                     "sudo -u postgres du -sh /var/lib/pgsql/14/data/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8712,7 +8902,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "7.8M\t/var/lib/pgsql/13/data/base/32768"
+                     "8.4M\t/var/lib/pgsql/14/data/base/32768"
                   ]
                }
             },
@@ -8730,7 +8920,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092120F_20260119-092135I"
+                     "20260716-105056F_20260716-105116I"
                   ]
                }
             },
@@ -8739,7 +8929,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo \\",
-                     "    --set=20260119-092120F_20260119-092135I info"
+                     "    --set=20260716-105056F_20260716-105116I info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -8757,9 +8947,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 12 lines of output]",
-                     "            repo1: backup size: 1.9MB",
-                     "            backup reference list: 20260119-092120F, 20260119-092120F_20260119-092126D",
-                     "            database list: postgres (13383), test1 (32768), test2 (32769)"
+                     "            repo1: backup size: 2.1MB",
+                     "            backup reference list: 20260716-105056F, 20260716-105056F_20260716-105105D",
+                     "            database list: postgres (13755), test1 (32768), test2 (32769)"
                   ]
                }
             },
@@ -8767,7 +8957,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8794,7 +8984,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8867,7 +9057,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres du -sh /var/lib/pgsql/13/data/base/32768"
+                     "sudo -u postgres du -sh /var/lib/pgsql/14/data/base/32768"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -8877,7 +9067,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "8.0K\t/var/lib/pgsql/13/data/base/32768"
+                     "8.0K\t/var/lib/pgsql/14/data/base/32768"
                   ]
                }
             },
@@ -8923,8 +9113,8 @@
                      "  oid  |  datname  ",
                      "-------+-----------",
                      "     1 | template1",
-                     " 13382 | template0",
-                     " 13383 | postgres",
+                     " 13754 | template0",
+                     " 13755 | postgres",
                      " 32769 | test2",
                      "(4 rows)"
                   ]
@@ -8955,6 +9145,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
+                     "       [filtered 4 lines of output]",
                      "    message     ",
                      "----------------",
                      " Important Data",
@@ -8989,7 +9180,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-01-19 09:21:46.275227+00"
+                     "2026-07-16 10:51:29.006147+00"
                   ]
                }
             },
@@ -9031,7 +9222,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "ERROR:  relation \"important_table\" does not exist",
+                     "BEGIN",
+                     "DROP TABLE",
+                     "COMMITERROR:  relation \"important_table\" does not exist",
                      "LINE 1: ...le important_table;     commit;     select * from important_...",
                      "                                                             ^"
                   ]
@@ -9064,7 +9257,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "20260119-092120F_20260119-092147I"
+                     "20260716-105056F_20260716-105130I"
                   ]
                }
             },
@@ -9078,7 +9271,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "20260119-092120F_20260119-092147I"
+                        "20260716-105056F_20260716-105130I"
                      ]
                   },
                   "host" : "pg-primary",
@@ -9092,8 +9285,8 @@
                      "       [filtered 38 lines of output]",
                      "            backup reference total: 1 full, 1 diff",
                      "",
-                     "        incr backup: 20260119-092120F_20260119-092147I",
-                     "            timestamp start/stop: 2026-01-19 09:21:47+00 / 2026-01-19 09:21:48+00",
+                     "        incr backup: 20260716-105056F_20260716-105130I",
+                     "            timestamp start/stop: 2026-07-16 10:51:30+00 / 2026-07-16 10:51:31+00",
                      "            wal start/stop: 00000004000000000000001A / 00000004000000000000001A",
                      "       [filtered 2 lines of output]"
                   ]
@@ -9103,7 +9296,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9117,8 +9310,8 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --set=20260119-092120F_20260119-092147I --target-timeline=current \\",
-                     "    --type=time \"--target=2026-01-19 09:21:46.275227+00\" --target-action=promote restore"
+                     "    --set=20260716-105056F_20260716-105130I --target-timeline=current \\",
+                     "    --type=time \"--target=2026-07-16 10:51:29.006147+00\" --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9131,7 +9324,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9144,7 +9337,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "err-expect" : "1",
                   "host" : "pg-primary",
@@ -9158,7 +9351,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9176,11 +9369,12 @@
                "value" : {
                   "output" : [
                      "       [filtered 11 lines of output]",
-                     "LOG:  database system is ready to accept read only connections",
-                     "LOG:  redo done at 0/1A000100",
+                     "LOG:  database system is ready to accept read-only connections",
+                     "LOG:  redo done at 0/1A000100 system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.02 s",
                      "FATAL:  recovery ended before configured recovery target was reached",
-                     "LOG:  startup process (PID 3390) exited with exit code 1",
-                     "LOG:  terminating any other active server processes"
+                     "LOG:  startup process (PID 4046) exited with exit code 1",
+                     "LOG:  terminating any other active server processes",
+                     "LOG:  database system is shut down"
                   ]
                }
             },
@@ -9189,7 +9383,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --delta \\",
-                     "    --type=time \"--target=2026-01-19 09:21:46.275227+00\" \\",
+                     "    --type=time \"--target=2026-07-16 10:51:29.006147+00\" \\",
                      "    --target-action=promote restore"
                   ],
                   "host" : "pg-primary",
@@ -9203,7 +9397,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9216,7 +9410,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/postgresql.auto.conf"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9234,9 +9428,9 @@
                "value" : {
                   "output" : [
                      "       [filtered 9 lines of output]",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:53",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "recovery_target_time = '2026-01-19 09:21:46.275227+00'",
+                     "recovery_target_time = '2026-07-16 10:51:29.006147+00'",
                      "recovery_target_action = 'promote'"
                   ]
                }
@@ -9245,7 +9439,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9299,7 +9493,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -9317,17 +9511,17 @@
                "value" : {
                   "output" : [
                      "       [filtered 5 lines of output]",
-                     "LOG:  database system was interrupted; last known up at 2026-01-19 09:21:35 UTC",
+                     "LOG:  database system was interrupted; last known up at 2026-07-16 10:51:16 UTC",
                      "LOG:  restored log file \"00000004.history\" from archive",
-                     "LOG:  starting point-in-time recovery to 2026-01-19 09:21:46.275227+00",
+                     "LOG:  starting point-in-time recovery to 2026-07-16 10:51:29.006147+00",
                      "LOG:  restored log file \"00000004.history\" from archive",
                      "LOG:  restored log file \"000000040000000000000019\" from archive",
                      "       [filtered 2 lines of output]",
                      "LOG:  consistent recovery state reached at 0/19000100",
-                     "LOG:  database system is ready to accept read only connections",
-                     "LOG:  recovery stopping before commit of transaction 495, time 2026-01-19 09:21:47.553454+00",
-                     "LOG:  redo done at 0/1901E348",
-                     "LOG:  last completed transaction was at log time 2026-01-19 09:21:44.998203+00",
+                     "LOG:  database system is ready to accept read-only connections",
+                     "LOG:  recovery stopping before commit of transaction 743, time 2026-07-16 10:51:30.460687+00",
+                     "LOG:  redo done at 0/1901E6C0 system usage: CPU: user: 0.00 s, system: 0.01 s, elapsed: 0.02 s",
+                     "LOG:  last completed transaction was at log time 2026-07-16 10:51:27.53862+00",
                      "LOG:  selected new timeline ID: 5",
                      "LOG:  archive recovery complete",
                      "LOG:  database system is ready to accept connections"
@@ -9338,7 +9532,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9368,7 +9562,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stop command begin 2.58.0: --exec-id=3691-ad85dcc9 --log-level-console=info --no-log-timestamp --stanza=demo",
+                     "P00   INFO: stop command begin 2.59.0: --exec-id=4397-b746451f --log-level-console=info --no-log-timestamp --stanza=demo",
                      "P00   INFO: stop command end: completed successfully"
                   ]
                }
@@ -9395,7 +9589,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-delete command begin 2.58.0: --exec-id=3718-4fafd9b4 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
+                     "P00   INFO: stanza-delete command begin 2.59.0: --exec-id=4429-40e2682c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=1 --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --stanza=demo",
                      "P00   INFO: stanza-delete command end: completed successfully"
                   ]
                }
@@ -9404,7 +9598,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -9444,7 +9638,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -9516,7 +9710,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=3889-dc76115c --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=4635-40bf54af --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo2-type=azure --stanza=demo",
                      "P00   INFO: stanza-create for stanza 'demo' on repo1",
                      "P00   INFO: stanza-create for stanza 'demo' on repo2",
                      "P00   INFO: stanza-create command end: completed successfully"
@@ -9545,16 +9739,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=3917-455d2c05 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=4668-274a601a --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001B, lsn = 0/1B000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001B:00000005000000000000001B",
-                     "P00   INFO: new backup label = 20260119-092208F",
-                     "P00   INFO: full backup size = 30.8MB, file total = 1229",
+                     "P00   INFO: new backup label = 20260716-105155F",
+                     "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=3917-455d2c05 --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=4668-274a601a --log-level-console=info --no-log-timestamp --repo=2 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo2-type=azure --stanza=demo"
                   ]
                }
             },
@@ -9595,7 +9789,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-block=y",
@@ -9643,9 +9837,9 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc --insecure alias set s3 https://127.0.0.1 accessKey1 verySecretKey1"
+                     "aws configure set aws_access_key_id accessKey1"
                   ],
-                  "host" : "s3-server",
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : false,
                   "run-as-user" : "root"
@@ -9656,9 +9850,61 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc --insecure mb --with-versioning s3/demo-bucket"
+                     "aws configure set aws_secret_access_key verySecretKey1"
                   ],
-                  "host" : "s3-server",
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws configure set region us-east-1"
+                  ],
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws configure set ca_bundle /etc/pki/ca-trust/source/anchors/pgbackrest-ca.crt"
+                  ],
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws --endpoint-url https://s3.us-east-1.amazonaws.com s3 mb s3://demo-bucket"
+                  ],
+                  "host" : "pg-primary",
+                  "load-env" : true,
+                  "output" : false,
+                  "run-as-user" : "root"
+               },
+               "type" : "exe"
+            },
+            {
+               "key" : {
+                  "bash-wrap" : true,
+                  "cmd" : [
+                     "aws --endpoint-url https://s3.us-east-1.amazonaws.com s3api put-bucket-versioning --bucket demo-bucket --versioning-configuration Status=Enabled"
+                  ],
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : false,
                   "run-as-user" : "root"
@@ -9715,16 +9961,16 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=4045-563092b9 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=5061-d0e8ad62 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo --start-fast",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
                      "P00   INFO: backup start archive = 00000005000000000000001C, lsn = 0/1C000028",
                      "       [filtered 3 lines of output]",
                      "P00   INFO: check archive for segment(s) 00000005000000000000001C:00000005000000000000001D",
-                     "P00   INFO: new backup label = 20260119-092215F",
-                     "P00   INFO: full backup size = 30.8MB, file total = 1229",
+                     "P00   INFO: new backup label = 20260716-105216F",
+                     "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=4045-563092b9 --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=5061-d0e8ad62 --log-level-console=info --no-log-timestamp --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo2-type=azure --repo3-type=s3 --stanza=demo"
                   ]
                }
             },
@@ -9742,7 +9988,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "2026-01-19 09:22:20+00"
+                     "2026-07-16 10:52:32+00"
                   ]
                }
             },
@@ -9786,7 +10032,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -9969,18 +10215,18 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: backup command begin 2.58.0: --exec-id=4286-e118cc78 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
+                     "P00   INFO: backup command begin 2.59.0: --exec-id=5361-d61f2c4a --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-block --repo1-bundle --repo4-bundle --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo --start-fast",
                      "P00   WARN: option 'repo4-retention-full' is not set for 'repo4-retention-full-type=count', the repository may run out of space",
                      "            HINT: to retain full backups indefinitely (without warning), set option 'repo4-retention-full' to the maximum.",
                      "P00   WARN: no prior backup exists, incr backup has been changed to full",
                      "P00   INFO: execute backup start: backup begins after the requested immediate checkpoint completes",
-                     "P00   INFO: backup start archive = 00000005000000000000001E, lsn = 0/1E000028",
+                     "P00   INFO: backup start archive = 00000005000000000000001F, lsn = 0/1F000028",
                      "       [filtered 3 lines of output]",
-                     "P00   INFO: check archive for segment(s) 00000005000000000000001E:00000005000000000000001F",
-                     "P00   INFO: new backup label = 20260119-092223F",
-                     "P00   INFO: full backup size = 30.8MB, file total = 1229",
+                     "P00   INFO: check archive for segment(s) 00000005000000000000001F:00000005000000000000001F",
+                     "P00   INFO: new backup label = 20260716-105236F",
+                     "P00   INFO: full backup size = 33.5MB, file total = 1249",
                      "P00   INFO: backup command end: completed successfully",
-                     "P00   INFO: expire command begin 2.58.0: --exec-id=4286-e118cc78 --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
+                     "P00   INFO: expire command begin 2.59.0: --exec-id=5361-d61f2c4a --log-level-console=info --no-log-timestamp --repo=4 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo1-retention-diff=2 --repo1-retention-full=2 --repo2-retention-full=4 --repo3-retention-full=4 --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --stanza=demo",
                      "P00   INFO: expire command end: completed successfully"
                   ]
                }
@@ -10010,7 +10256,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "process-max=4",
@@ -10058,7 +10304,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -10116,7 +10362,7 @@
                      "filter" : true,
                      "filter-context" : 2,
                      "list" : [
-                        "missing stanza data"
+                        "missing stanza path"
                      ]
                   },
                   "host" : "pg-primary",
@@ -10128,8 +10374,7 @@
                "value" : {
                   "output" : [
                      "stanza: demo",
-                     "    status: error (missing stanza data)",
-                     "    cipher: none"
+                     "    status: error (missing stanza path)"
                   ]
                }
             },
@@ -10137,17 +10382,16 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "mc ls --versions s3/demo-bucket/demo-repo/backup/demo/backup.info"
+                     "key=demo-repo/backup/demo/backup.info; \\",
+                     "    aws s3api list-object-versions --bucket demo-bucket \\",
+                     "    --prefix $key --output table \\",
+                     "    --query \"sort_by([Versions[?Key=='$key'].{Action:'PUT', \\",
+                     "    Modified:LastModified,Object:Key}, \\",
+                     "    DeleteMarkers[?Key=='$key'].{Action:'DELETE', \\",
+                     "    Modified:LastModified,Object:Key}][],&Modified)\""
                   ],
-                  "cmd-extra" : "--insecure",
-                  "highlight" : {
-                     "filter" : true,
-                     "filter-context" : 2,
-                     "list" : [
-                        "backup\\.info$"
-                     ]
-                  },
-                  "host" : "s3-server",
+                  "cmd-extra" : "--endpoint-url https://s3.us-east-1.amazonaws.com",
+                  "host" : "pg-primary",
                   "load-env" : true,
                   "output" : true,
                   "run-as-user" : "root"
@@ -10155,11 +10399,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "[2026-01-19 09:22:30 UTC]     0B STANDARD 7933eae9-2226-4dc3-aa14-02cc52e0fb4f v3 DEL backup.info",
-                     "[2026-01-19 09:22:20 UTC] 1.0KiB STANDARD 78f325bc-a340-4c8b-b423-8409b3a1cc91 v2 PUT backup.info",
-                     "[2026-01-19 09:22:15 UTC]   372B STANDARD 6e6603b7-b30b-4aab-a3ef-42f95184034a v1 PUT backup.info",
-                     "[2026-01-19 09:22:30 UTC]     0B STANDARD fa5ded47-c1e2-4672-b5d9-2874e4841d91 v3 DEL backup.info.copy",
-                     "[2026-01-19 09:22:20 UTC] 1.0KiB STANDARD 69453b85-7d97-4e61-81d0-d8a3ad6cfea6 v2 PUT backup.info.copy"
+                     "-------------------------------------------------------------------------------------",
+                     "|                                ListObjectVersions                                 |",
+                     "+--------+------------------------------------+-------------------------------------+",
+                     "| Action |             Modified               |               Object                |",
+                     "+--------+------------------------------------+-------------------------------------+",
+                     "|  PUT   |  2026-07-16T10:52:16.238000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "|  PUT   |  2026-07-16T10:52:31.899000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "|  DELETE|  2026-07-16T10:52:47.493000+00:00  |  demo-repo/backup/demo/backup.info  |",
+                     "+--------+------------------------------------+-------------------------------------+"
                   ]
                }
             },
@@ -10168,7 +10416,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 \\",
-                     "    --repo-target-time=\"2026-01-19 09:22:20+00\" info"
+                     "    --repo-target-time=\"2026-07-16 10:52:32+00\" info"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -10186,12 +10434,12 @@
                "value" : {
                   "output" : [
                      "       [filtered 5 lines of output]",
-                     "        wal archive min/max (13): 00000005000000000000001C/00000005000000000000001D",
+                     "        wal archive min/max (14): 00000005000000000000001C/00000005000000000000001D",
                      "",
-                     "        full backup: 20260119-092215F",
-                     "            timestamp start/stop: 2026-01-19 09:22:15+00 / 2026-01-19 09:22:20+00",
+                     "        full backup: 20260716-105216F",
+                     "            timestamp start/stop: 2026-07-16 10:52:16+00 / 2026-07-16 10:52:31+00",
                      "            wal start/stop: 00000005000000000000001C / 00000005000000000000001D",
-                     "            repo3: backup set size: 3.8MB, backup size: 3.8MB"
+                     "            repo3: backup set size: 4.2MB, backup size: 4.2MB"
                   ]
                }
             },
@@ -10200,7 +10448,7 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres pgbackrest --stanza=demo --repo=3 --delta \\",
-                     "    --repo-target-time=\"2026-01-19 09:22:20+00\" --log-level-console=info restore"
+                     "    --repo-target-time=\"2026-07-16 10:52:32+00\" --log-level-console=info restore"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -10217,10 +10465,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: restore command begin 2.58.0: --delta --exec-id=4527-3f625708 --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-01-19 09:22:20+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
-                     "P00   INFO: repo3: restore backup set 20260119-092215F, recovery will start at 2026-01-19 09:22:15",
-                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/13/data'",
-                     "P00   INFO: write updated /var/lib/pgsql/13/data/postgresql.auto.conf",
+                     "P00   INFO: restore command begin 2.59.0: --delta --exec-id=5686-7accf33e --log-level-console=info --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=4 --repo=3 --repo2-azure-account=<redacted> --repo2-azure-container=demo-container --repo2-azure-key=<redacted> --repo1-cipher-pass=<redacted> --repo1-cipher-type=aes-256-cbc --repo5-gcs-bucket=demo-bucket --repo5-gcs-key=<redacted> --repo1-path=/var/lib/pgbackrest --repo2-path=/demo-repo --repo3-path=/demo-repo --repo4-path=/demo-repo --repo5-path=/demo-repo --repo3-s3-bucket=demo-bucket --repo3-s3-endpoint=s3.us-east-1.amazonaws.com --repo3-s3-key=<redacted> --repo3-s3-key-secret=<redacted> --repo3-s3-region=us-east-1 --repo4-sftp-host=sftp-server --repo4-sftp-host-key-hash-type=sha1 --repo4-sftp-host-user=pgbackrest --repo4-sftp-private-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp --repo4-sftp-public-key-file=/var/lib/pgsql/.ssh/id_rsa_sftp.pub --repo-target-time=\"2026-07-16 10:52:32+00\" --repo2-type=azure --repo3-type=s3 --repo4-type=sftp --repo5-type=gcs --stanza=demo",
+                     "P00   INFO: repo3: restore backup set 20260716-105216F, recovery will start at 2026-07-16 10:52:16",
+                     "P00   INFO: remove invalid files/links/paths from '/var/lib/pgsql/14/data'",
+                     "P00   INFO: write updated /var/lib/pgsql/14/data/postgresql.auto.conf",
                      "       [filtered 2 lines of output]"
                   ]
                }
@@ -10229,7 +10477,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -10491,7 +10739,7 @@
                            "value" : "tls"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -10531,7 +10779,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "repo1-path=/var/lib/pgbackrest",
@@ -10552,7 +10800,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -10600,7 +10848,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -10662,7 +10910,7 @@
                      "    echo 'StartLimitIntervalSec=0' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '[Service]' | tee -a /etc/systemd/system/pgbackrest.service && \\",
-                     "    echo 'Type=simple' | tee -a /etc/systemd/system/pgbackrest.service && \\",
+                     "    echo 'Type=notify' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'Restart=always' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'RestartSec=1' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'User=pgbackrest' | tee -a /etc/systemd/system/pgbackrest.service && \\",
@@ -10701,7 +10949,7 @@
                      "StartLimitIntervalSec=0",
                      "",
                      "[Service]",
-                     "Type=simple",
+                     "Type=notify",
                      "Restart=always",
                      "RestartSec=1",
                      "User=pgbackrest",
@@ -10787,7 +11035,7 @@
                      "    echo 'StartLimitIntervalSec=0' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '[Service]' | tee -a /etc/systemd/system/pgbackrest.service && \\",
-                     "    echo 'Type=simple' | tee -a /etc/systemd/system/pgbackrest.service && \\",
+                     "    echo 'Type=notify' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'Restart=always' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'RestartSec=1' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'User=postgres' | tee -a /etc/systemd/system/pgbackrest.service && \\",
@@ -10826,7 +11074,7 @@
                      "StartLimitIntervalSec=0",
                      "",
                      "[Service]",
-                     "Type=simple",
+                     "Type=notify",
                      "Restart=always",
                      "RestartSec=1",
                      "User=postgres",
@@ -10928,7 +11176,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -10954,7 +11202,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -11010,7 +11258,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "process-max=3",
@@ -11064,19 +11312,19 @@
                      "    cipher: none",
                      "",
                      "    db (current)",
-                     "        wal archive min/max (13): 000000070000000000000023/000000070000000000000025",
+                     "        wal archive min/max (14): 000000070000000000000023/000000070000000000000025",
                      "",
-                     "        full backup: 20260119-092306F",
-                     "            timestamp start/stop: 2026-01-19 09:23:06+00 / 2026-01-19 09:23:08+00",
+                     "        full backup: 20260716-105347F",
+                     "            timestamp start/stop: 2026-07-16 10:53:47+00 / 2026-07-16 10:53:51+00",
                      "            wal start/stop: 000000070000000000000023 / 000000070000000000000023",
-                     "            database size: 30.8MB, database backup size: 30.8MB",
-                     "            repo1: backup set size: 3.8MB, backup size: 3.8MB",
+                     "            database size: 33.5MB, database backup size: 33.5MB",
+                     "            repo1: backup set size: 4.2MB, backup size: 4.2MB",
                      "",
-                     "        full backup: 20260119-092309F",
-                     "            timestamp start/stop: 2026-01-19 09:23:09+00 / 2026-01-19 09:23:11+00",
+                     "        full backup: 20260716-105352F",
+                     "            timestamp start/stop: 2026-07-16 10:53:52+00 / 2026-07-16 10:53:55+00",
                      "            wal start/stop: 000000070000000000000024 / 000000070000000000000025",
-                     "            database size: 30.8MB, database backup size: 30.8MB",
-                     "            repo1: backup set size: 3.8MB, backup size: 3.8MB"
+                     "            database size: 33.5MB, database backup size: 33.5MB",
+                     "            repo1: backup set size: 4.2MB, backup size: 4.2MB"
                   ]
                }
             },
@@ -11359,7 +11607,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -11406,7 +11654,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -11468,7 +11716,7 @@
                      "    echo 'StartLimitIntervalSec=0' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '[Service]' | tee -a /etc/systemd/system/pgbackrest.service && \\",
-                     "    echo 'Type=simple' | tee -a /etc/systemd/system/pgbackrest.service && \\",
+                     "    echo 'Type=notify' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'Restart=always' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'RestartSec=1' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'User=postgres' | tee -a /etc/systemd/system/pgbackrest.service && \\",
@@ -11507,7 +11755,7 @@
                      "StartLimitIntervalSec=0",
                      "",
                      "[Service]",
-                     "Type=simple",
+                     "Type=notify",
                      "Restart=always",
                      "RestartSec=1",
                      "User=postgres",
@@ -11552,7 +11800,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres mkdir -p -m 700 /var/lib/pgsql/13/data"
+                     "sudo -u postgres mkdir -p -m 700 /var/lib/pgsql/14/data"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11578,7 +11826,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11591,24 +11839,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:08",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:50:39",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:29",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:10",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:53",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:22:32 # recovery_target_time = '2026-01-19 09:21:46.275227+00'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:22:32 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_time = '2026-07-16 10:51:29.006147+00'",
+                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:22:32",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-01-19 09:22:20+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:52:54",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 10:52:32+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:23:01",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:53:42",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:23:27",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:54:22",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
                }
@@ -11617,7 +11865,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/14/data/postgresql.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11628,7 +11876,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "archive_command" : {
@@ -11659,7 +11907,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11672,7 +11920,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -11698,7 +11946,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -11717,14 +11965,11 @@
                   "output" : [
                      "       [filtered 4 lines of output]",
                      "LOG:  listening on Unix socket \"/tmp/.s.PGSQL.5432\"",
-                     "LOG:  database system was interrupted; last known up at 2026-01-19 09:23:09 UTC",
+                     "LOG:  database system was interrupted; last known up at 2026-07-16 10:53:52 UTC",
                      "LOG:  entering standby mode",
                      "LOG:  restored log file \"00000007.history\" from archive",
                      "LOG:  restored log file \"000000070000000000000024\" from archive",
-                     "LOG:  redo starts at 0/24000028",
-                     "LOG:  restored log file \"000000070000000000000025\" from archive",
-                     "LOG:  consistent recovery state reached at 0/25000050",
-                     "LOG:  database system is ready to accept read only connections"
+                     "       [filtered 3 lines of output]"
                   ]
                }
             },
@@ -11754,6 +11999,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
+                     "       [filtered 4 lines of output]",
                      "    message     ",
                      "----------------",
                      " Important Data",
@@ -11805,7 +12051,7 @@
                   "output" : [
                      " pg_switch_wal |       current_timestamp       ",
                      "---------------+-------------------------------",
-                     " 0/26017738    | 2026-01-19 09:23:33.308165+00",
+                     " 0/2601E7C0    | 2026-07-16 10:54:29.129238+00",
                      "(1 row)"
                   ]
                }
@@ -11834,7 +12080,7 @@
                   "output" : [
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-01-19 09:23:34.570736+00",
+                     " Important Data | 2026-07-16 10:54:30.556907+00",
                      "(1 row)"
                   ]
                }
@@ -11860,7 +12106,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1105-680ac4e9 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1222-8ec4a8d8 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 (standby)",
                      "P00   INFO: switch wal not performed because this is a standby",
                      "P00   INFO: check command end: completed successfully"
@@ -11892,7 +12138,7 @@
                   "cmd" : [
                      "sudo -u postgres sh -c 'echo \\",
                      "    \"host    replication     replicator      172.17.0.8/32           md5\" \\",
-                     "    >> /var/lib/pgsql/13/data/pg_hba.conf'"
+                     "    >> /var/lib/pgsql/14/data/pg_hba.conf'"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -11905,7 +12151,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl reload postgresql-13.service"
+                     "sudo systemctl reload postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -11930,7 +12176,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -11980,7 +12226,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12006,7 +12252,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/postgresql.auto.conf"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/postgresql.auto.conf"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12019,24 +12265,24 @@
                      "# Do not edit this file manually!",
                      "# It will be overwritten by the ALTER SYSTEM command.",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:08",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:50:39",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:29",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:10",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:21:53",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:51:38",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:22:32 # recovery_target_time = '2026-01-19 09:21:46.275227+00'",
-                     "# Removed by pgBackRest restore on 2026-01-19 09:22:32 # recovery_target_action = 'promote'",
+                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_time = '2026-07-16 10:51:29.006147+00'",
+                     "# Removed by pgBackRest restore on 2026-07-16 10:52:54 # recovery_target_action = 'promote'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:22:32",
-                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-01-19 09:22:20+00\" --stanza=demo archive-get %f \"%p\"'",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:52:54",
+                     "restore_command = 'pgbackrest --repo=3 --repo-target-time=\"2026-07-16 10:52:32+00\" --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:23:01",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:53:42",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'",
                      "",
-                     "# Recovery settings generated by pgBackRest restore on 2026-01-19 09:23:39",
+                     "# Recovery settings generated by pgBackRest restore on 2026-07-16 10:54:36",
                      "primary_conninfo = 'host=172.17.0.6 port=5432 user=replicator'",
                      "restore_command = 'pgbackrest --stanza=demo archive-get %f \"%p\"'"
                   ]
@@ -12044,7 +12290,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -12066,7 +12312,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo rm /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12079,7 +12325,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-13.service"
+                     "sudo systemctl start postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -12105,7 +12351,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres cat /var/lib/pgsql/13/data/log/postgresql.log"
+                     "sudo -u postgres cat /var/lib/pgsql/14/data/log/postgresql.log"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -12123,7 +12369,7 @@
                "value" : {
                   "output" : [
                      "       [filtered 12 lines of output]",
-                     "LOG:  database system is ready to accept read only connections",
+                     "LOG:  database system is ready to accept read-only connections",
                      "LOG:  restored log file \"000000070000000000000026\" from archive",
                      "LOG:  started streaming WAL from primary at 0/27000000 on timeline 7"
                   ]
@@ -12155,9 +12401,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
+                     "       [filtered 4 lines of output]",
                      "    message     |       current_timestamp       ",
                      "----------------+-------------------------------",
-                     " Important Data | 2026-01-19 09:23:44.896378+00",
+                     " Important Data | 2026-07-16 10:54:42.888569+00",
                      "(1 row)"
                   ]
                }
@@ -12184,9 +12431,9 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "    message     |      current_timestamp       ",
-                     "----------------+------------------------------",
-                     " Important Data | 2026-01-19 09:23:45.09247+00",
+                     "    message     |       current_timestamp       ",
+                     "----------------+-------------------------------",
+                     " Important Data | 2026-07-16 10:54:43.369563+00",
                      "(1 row)"
                   ]
                }
@@ -12344,7 +12591,7 @@
                   "option" : {
                      "demo-alt" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -12391,7 +12638,7 @@
                "value" : {
                   "config" : [
                      "[demo-alt]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "log-level-file=detail",
@@ -12430,7 +12677,7 @@
                            "value" : "tls"
                         },
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      }
                   }
@@ -12444,7 +12691,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -12452,7 +12699,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "process-max=3",
@@ -12512,7 +12759,7 @@
                      "    echo 'StartLimitIntervalSec=0' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo '[Service]' | tee -a /etc/systemd/system/pgbackrest.service && \\",
-                     "    echo 'Type=simple' | tee -a /etc/systemd/system/pgbackrest.service && \\",
+                     "    echo 'Type=notify' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'Restart=always' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'RestartSec=1' | tee -a /etc/systemd/system/pgbackrest.service && \\",
                      "    echo 'User=postgres' | tee -a /etc/systemd/system/pgbackrest.service && \\",
@@ -12551,7 +12798,7 @@
                      "StartLimitIntervalSec=0",
                      "",
                      "[Service]",
-                     "Type=simple",
+                     "Type=notify",
                      "Restart=always",
                      "RestartSec=1",
                      "User=postgres",
@@ -12596,8 +12843,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-13/bin/initdb \\",
-                     "    -D /var/lib/pgsql/13/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-14/bin/initdb \\",
+                     "    -D /var/lib/pgsql/14/data -k -A peer"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12610,7 +12857,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/13/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/14/data/postgresql.conf"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12621,7 +12868,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/13/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
                   "host" : "pg-alt",
                   "option" : {
                      "archive_command" : {
@@ -12648,7 +12895,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-13.service"
+                     "sudo systemctl restart postgresql-14.service"
                   ],
                   "host" : "pg-alt",
                   "load-env" : true,
@@ -12691,7 +12938,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-create command begin 2.58.0: --exec-id=808-80d5cc1a --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
+                     "P00   INFO: stanza-create command begin 2.59.0: --exec-id=936-0a6d0cc2 --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo-alt",
                      "P00   INFO: stanza-create for stanza 'demo-alt' on repo1",
                      "P00   INFO: stanza-create command end: completed successfully"
                   ]
@@ -12718,11 +12965,11 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=836-0d0cd439 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=969-1a7da4d4 --log-level-console=info --log-level-file=detail --no-log-timestamp --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/13-1/0000000100000000/000000010000000000000001-6682d48b9456c97a63b86fb052e926912686d78a.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000001 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000001-7dee2bb959c5be5ae636ac3f122495d19d92becf.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12748,15 +12995,15 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=1188-a5806db7 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=1388-0e4fe3d8 --log-level-console=info --no-log-timestamp --repo1-path=/var/lib/pgbackrest",
                      "P00   INFO: check stanza 'demo'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000700000000/000000070000000000000027-ab9de60f70c5f849d29e55b1104aae9c6dfee0dc.gz' on repo1",
+                     "P00   INFO: WAL segment 000000070000000000000027 successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/000000070000000000000027-403e6652852b2a1791ee185cbf2d0c92e2d13ffd.gz' on repo1",
                      "P00   INFO: check stanza 'demo-alt'",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/13-1/0000000100000000/000000010000000000000002-1cfb636b14b524bd3cf014e32ec3211fcf7ea48e.gz' on repo1",
+                     "P00   INFO: WAL segment 000000010000000000000002 successfully archived to '/var/lib/pgbackrest/archive/demo-alt/14-1/0000000100000000/000000010000000000000002-9a37b9e945d0105bb14116929b3577931634351e.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -12842,7 +13089,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -12896,7 +13143,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -12944,7 +13191,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl restart postgresql-13.service"
+                     "sudo systemctl restart postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13005,10 +13252,10 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: check command begin 2.58.0: --exec-id=5533-a10d780a --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: check command begin 2.59.0: --exec-id=6866-b55d2b1c --log-level-console=info --log-level-file=detail --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: check repo1 configuration (primary)",
                      "P00   INFO: check repo1 archive for WAL (primary)",
-                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/13-1/0000000700000000/00000007000000000000002D-68fdc910d7c6f88b37ea66c55abbb15619fc23e4.gz' on repo1",
+                     "P00   INFO: WAL segment 00000007000000000000002D successfully archived to '/var/lib/pgbackrest/archive/demo/14-1/0000000700000000/00000007000000000000002D-8ef1a778d36fa7df713c5036d27d2e03ae113b59.gz' on repo1",
                      "P00   INFO: check command end: completed successfully"
                   ]
                }
@@ -13035,25 +13282,19 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.58.0: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5499-311a72c4 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6830-f85d124f --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: push 1 WAL file(s) to archive: 000000070000000000000028",
                      "P01 DETAIL: pushed WAL file '000000070000000000000028' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "P00   INFO: archive-push:async command end: completed successfully",
                      "",
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.58.0: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5522-2bee2531 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
-                     "P00   INFO: push 4 WAL file(s) to archive: 000000070000000000000029...00000007000000000000002C",
+                     "P00   INFO: archive-push:async command begin 2.59.0: [/var/lib/pgsql/14/data/pg_wal] --archive-async --exec-id=6868-3a6c97a8 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: push 5 WAL file(s) to archive: 000000070000000000000029...00000007000000000000002D",
                      "P01 DETAIL: pushed WAL file '000000070000000000000029' to the archive",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002A' to the archive",
                      "P01 DETAIL: pushed WAL file '00000007000000000000002B' to the archive",
                      "P02 DETAIL: pushed WAL file '00000007000000000000002C' to the archive",
-                     "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
-                     "P00   INFO: archive-push:async command end: completed successfully",
-                     "",
-                     "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-push:async command begin 2.58.0: [/var/lib/pgsql/13/data/pg_wal] --archive-async --exec-id=5540-4b5e5f9b --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
-                     "P00   INFO: push 1 WAL file(s) to archive: 00000007000000000000002D",
                      "P01 DETAIL: pushed WAL file '00000007000000000000002D' to the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "P00   INFO: archive-push:async command end: completed successfully"
@@ -13095,23 +13336,23 @@
                "value" : {
                   "output" : [
                      "-------------------PROCESS START-------------------",
-                     "P00   INFO: archive-get:async command begin 2.58.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=1655-39b5c501 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000024, 000000070000000000000025, 000000070000000000000026, 000000070000000000000027, 000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B] --archive-async --exec-id=1890-fcc5901d --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000024...00000007000000000000002B",
-                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 13-1 archive",
-                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 13-1 archive",
-                     "P02 DETAIL: found 000000070000000000000026 in the repo1: 13-1 archive",
-                     "P01 DETAIL: found 000000070000000000000027 in the repo1: 13-1 archive",
+                     "P01 DETAIL: found 000000070000000000000024 in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 000000070000000000000025 in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 000000070000000000000027 in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 000000070000000000000026 in the repo1: 14-1 archive",
                      "P00 DETAIL: unable to find 000000070000000000000028 in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
-                     "       [filtered 24 lines of output]",
-                     "P00   INFO: archive-get:async command begin 2.58.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=1705-617957e3 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/13/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
+                     "       [filtered 17 lines of output]",
+                     "P00   INFO: archive-get:async command begin 2.59.0: [000000070000000000000028, 000000070000000000000029, 00000007000000000000002A, 00000007000000000000002B, 00000007000000000000002C, 00000007000000000000002D, 00000007000000000000002E, 00000007000000000000002F] --archive-async --exec-id=1943-b62d9f85 --log-level-console=off --log-level-file=detail --log-level-stderr=off --no-log-timestamp --pg1-path=/var/lib/pgsql/14/data --process-max=2 --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --spool-path=/var/spool/pgbackrest --stanza=demo",
                      "P00   INFO: get 8 WAL file(s) from archive: 000000070000000000000028...00000007000000000000002F",
-                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 13-1 archive",
-                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 13-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002A in the repo1: 13-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002B in the repo1: 13-1 archive",
-                     "P02 DETAIL: found 00000007000000000000002C in the repo1: 13-1 archive",
-                     "P01 DETAIL: found 00000007000000000000002D in the repo1: 13-1 archive",
+                     "P02 DETAIL: found 000000070000000000000029 in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 000000070000000000000028 in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002A in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002B in the repo1: 14-1 archive",
+                     "P02 DETAIL: found 00000007000000000000002C in the repo1: 14-1 archive",
+                     "P01 DETAIL: found 00000007000000000000002D in the repo1: 14-1 archive",
                      "P00 DETAIL: unable to find 00000007000000000000002E in the archive",
                      "P00 DETAIL: statistics: {\"socket.client\":{\"total\":1},\"socket.session\":{\"total\":1},\"tls.client\":{\"total\":1},\"tls.session\":{\"total\":1}}",
                      "       [filtered 7 lines of output]"
@@ -13158,7 +13399,7 @@
                            "value" : "tls"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/pgsql/13/data"
+                           "value" : "/var/lib/pgsql/14/data"
                         }
                      },
                      "global" : {
@@ -13177,13 +13418,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/13/data",
+                     "pg2-path=/var/lib/pgsql/14/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -13191,7 +13432,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "backup-standby=y",
@@ -13234,12 +13475,12 @@
                      "P00   INFO: wait for replay on the standby to reach 0/2F000028",
                      "P00   INFO: replay on the standby reached 0/2F000028",
                      "P00   INFO: check archive for prior segment 00000007000000000000002E",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/log/postgresql.log (11KB, 0.48%) checksum c9e618ab29ad21e5a3e14a5c02cead1a9506adc5",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/global/pg_control (8KB, 0.83%) checksum 8f43c919dede7e23f0a104a7ad769cf5ff365daa",
-                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/13/data/pg_hba.conf (4.5KB, 1.02%) checksum 65e54ae24bda87b2542351cb16a7fecc7e5aceeb",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/13/data/current_logfiles (26B, 1.02%) checksum 78a9f5c10960f0d91fcd313937469824861795a2",
-                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/13/data/pg_logical/replorigin_checkpoint (8B, 1.02%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
-                     "       [filtered 1243 lines of output]"
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/log/postgresql.log (11.1KB, 0.43%) checksum c2a8826ce5db6a9e6f3a94f058eb63e7e78759bd",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/global/pg_control (8KB, 0.74%) checksum 2a8e0d508836afd1b5246d5f4abf6db77f43d87f",
+                     "P01 DETAIL: backup file pg-primary:/var/lib/pgsql/14/data/pg_hba.conf (4.5KB, 0.91%) checksum cfa97af1dab1b130f0a921fa2d10d76fe0c5f630",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/14/data/current_logfiles (26B, 0.91%) checksum 78a9f5c10960f0d91fcd313937469824861795a2",
+                     "P01 DETAIL: match file from prior backup pg-primary:/var/lib/pgsql/14/data/pg_logical/replorigin_checkpoint (8B, 0.91%) checksum 347fc8f2df71bd4436e38bd1516ccd7ea0d46532",
+                     "       [filtered 1263 lines of output]"
                   ]
                }
             },
@@ -13247,7 +13488,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13260,7 +13501,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl stop postgresql-13.service"
+                     "sudo systemctl stop postgresql-14.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13273,8 +13514,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres /usr/pgsql-14/bin/initdb \\",
-                     "    -D /var/lib/pgsql/14/data -k -A peer"
+                     "sudo -u postgres /usr/pgsql-15/bin/initdb \\",
+                     "    -D /var/lib/pgsql/15/data -k -A peer"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13288,13 +13529,13 @@
                   "bash-wrap" : true,
                   "cmd" : [
                      "sudo -u postgres sh -c 'cd /var/lib/pgsql && \\",
-                     "    /usr/pgsql-14/bin/pg_upgrade \\",
-                     "    --old-bindir=/usr/pgsql-13/bin \\",
-                     "    --new-bindir=/usr/pgsql-14/bin \\",
-                     "    --old-datadir=/var/lib/pgsql/13/data \\",
-                     "    --new-datadir=/var/lib/pgsql/14/data \\",
-                     "    --old-options=\" -c config_file=/var/lib/pgsql/13/data/postgresql.conf\" \\",
-                     "    --new-options=\" -c config_file=/var/lib/pgsql/14/data/postgresql.conf\"'"
+                     "    /usr/pgsql-15/bin/pg_upgrade \\",
+                     "    --old-bindir=/usr/pgsql-14/bin \\",
+                     "    --new-bindir=/usr/pgsql-15/bin \\",
+                     "    --old-datadir=/var/lib/pgsql/14/data \\",
+                     "    --new-datadir=/var/lib/pgsql/15/data \\",
+                     "    --old-options=\" -c config_file=/var/lib/pgsql/14/data/postgresql.conf\" \\",
+                     "    --new-options=\" -c config_file=/var/lib/pgsql/15/data/postgresql.conf\"'"
                   ],
                   "highlight" : {
                      "filter" : true,
@@ -13311,7 +13552,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "       [filtered 69 lines of output]",
+                     "       [filtered 41 lines of output]",
                      "Checking for extension updates                              ok",
                      "",
                      "Upgrade Complete",
@@ -13325,7 +13566,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/14/data/postgresql.conf"
+                     "cat /root/postgresql.common.conf >> /var/lib/pgsql/15/data/postgresql.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13336,7 +13577,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/15/data/postgresql.conf",
                   "host" : "pg-primary",
                   "option" : {
                      "archive_command" : {
@@ -13366,7 +13607,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/14/data"
+                           "value" : "/var/lib/pgsql/15/data"
                         }
                      }
                   }
@@ -13375,7 +13616,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/14/data",
+                     "pg1-path=/var/lib/pgsql/15/data",
                      "",
                      "[global]",
                      "archive-async=y",
@@ -13407,7 +13648,7 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/14/data"
+                           "value" : "/var/lib/pgsql/15/data"
                         }
                      }
                   }
@@ -13416,7 +13657,7 @@
                "value" : {
                   "config" : [
                      "[demo]",
-                     "pg1-path=/var/lib/pgsql/14/data",
+                     "pg1-path=/var/lib/pgsql/15/data",
                      "recovery-option=primary_conninfo=host=172.17.0.6 port=5432 user=replicator",
                      "",
                      "[global]",
@@ -13449,10 +13690,10 @@
                   "option" : {
                      "demo" : {
                         "pg1-path" : {
-                           "value" : "/var/lib/pgsql/14/data"
+                           "value" : "/var/lib/pgsql/15/data"
                         },
                         "pg2-path" : {
-                           "value" : "/var/lib/pgsql/14/data"
+                           "value" : "/var/lib/pgsql/15/data"
                         }
                      },
                      "global" : {
@@ -13471,13 +13712,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/14/data",
+                     "pg1-path=/var/lib/pgsql/15/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/14/data",
+                     "pg2-path=/var/lib/pgsql/15/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -13485,7 +13726,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "backup-standby=n",
@@ -13505,8 +13746,8 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo cp /var/lib/pgsql/13/data/pg_hba.conf \\",
-                     "    /var/lib/pgsql/14/data/pg_hba.conf"
+                     "sudo cp /var/lib/pgsql/14/data/pg_hba.conf \\",
+                     "    /var/lib/pgsql/15/data/pg_hba.conf"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13537,7 +13778,7 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   INFO: stanza-upgrade command begin 2.58.0: --exec-id=6060-3d1ec838 --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/14/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
+                     "P00   INFO: stanza-upgrade command begin 2.59.0: --exec-id=7455-37174a6b --log-level-console=info --log-level-file=detail --no-log-timestamp --no-online --pg1-path=/var/lib/pgsql/15/data --repo1-host=repository --repo1-host-ca-file=/etc/pgbackrest/cert/ca.crt --repo1-host-cert-file=/etc/pgbackrest/cert/client.crt --repo1-host-key-file=/etc/pgbackrest/cert/client.key --repo1-host-type=tls --stanza=demo",
                      "P00   INFO: stanza-upgrade for stanza 'demo' on repo1",
                      "P00   INFO: stanza-upgrade command end: completed successfully"
                   ]
@@ -13547,7 +13788,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-14.service"
+                     "sudo systemctl start postgresql-15.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13560,7 +13801,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl status postgresql-14.service"
+                     "sudo systemctl status postgresql-15.service"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13586,7 +13827,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm -rf /var/lib/pgsql/13/data"
+                     "sudo rm -rf /var/lib/pgsql/14/data"
                   ],
                   "host" : "pg-primary",
                   "load-env" : true,
@@ -13599,7 +13840,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo rm -rf /var/lib/pgsql/13/data"
+                     "sudo rm -rf /var/lib/pgsql/14/data"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13612,7 +13853,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo -u postgres mkdir -p -m 700 /usr/pgsql-14/bin"
+                     "sudo -u postgres mkdir -p -m 700 /usr/pgsql-15/bin"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13635,9 +13876,8 @@
                "type" : "exe",
                "value" : {
                   "output" : [
-                     "P00   WARN: unable to check pg2: [DbConnectError] raised from remote-0 tls protocol on 'pg-standby': unable to connect to 'dbname='postgres' port=5432': could not connect to server: No such file or directory",
-                     "            \tIs the server running locally and accepting",
-                     "            \tconnections on Unix domain socket \"/run/postgresql/.s.PGSQL.5432\"?"
+                     "P00   WARN: unable to check pg2: [DbConnectError] raised from remote-0 tls protocol on 'pg-standby': unable to connect to 'dbname='postgres' port=5432': connection to server on socket \"/run/postgresql/.s.PGSQL.5432\" failed: No such file or directory",
+                     "            \tIs the server running locally and accepting connections on that socket?"
                   ]
                }
             },
@@ -13669,7 +13909,7 @@
             },
             {
                "key" : {
-                  "file" : "/var/lib/pgsql/14/data/postgresql.conf",
+                  "file" : "/var/lib/pgsql/15/data/postgresql.conf",
                   "host" : "pg-standby",
                   "option" : {
                      "hot_standby" : {
@@ -13688,7 +13928,7 @@
                "key" : {
                   "bash-wrap" : true,
                   "cmd" : [
-                     "sudo systemctl start postgresql-14.service"
+                     "sudo systemctl start postgresql-15.service"
                   ],
                   "host" : "pg-standby",
                   "load-env" : true,
@@ -13744,13 +13984,13 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/14/data",
+                     "pg1-path=/var/lib/pgsql/15/data",
                      "pg2-host=pg-standby",
                      "pg2-host-ca-file=/etc/pgbackrest/cert/ca.crt",
                      "pg2-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg2-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg2-host-type=tls",
-                     "pg2-path=/var/lib/pgsql/14/data",
+                     "pg2-path=/var/lib/pgsql/15/data",
                      "",
                      "[demo-alt]",
                      "pg1-host=pg-alt",
@@ -13758,7 +13998,7 @@
                      "pg1-host-cert-file=/etc/pgbackrest/cert/client.crt",
                      "pg1-host-key-file=/etc/pgbackrest/cert/client.key",
                      "pg1-host-type=tls",
-                     "pg1-path=/var/lib/pgsql/13/data",
+                     "pg1-path=/var/lib/pgsql/14/data",
                      "",
                      "[global]",
                      "backup-standby=y",

--- a/doc/resource/git-history.cache
+++ b/doc/resource/git-history.cache
@@ -1,5 +1,966 @@
 [
     {
+        "commit": "d24d1edfbd46936f78177aec48ddf30ecb07da2f",
+        "date": "2026-07-18 18:36:19 +0700",
+        "subject": "Resolve markdown cross-page section links to the website.",
+        "body": "A markdown link that specified both a page and a section failed to render when the target page was itself rendered as markdown, because markdown cannot reliably anchor into another generated file.\n\nResolve these links to the website URL with the section anchor, matching how links to pages that are not rendered as markdown already behave, so a markdown document can link to a section of another."
+    },
+    {
+        "commit": "42db536fa7f33c4af1817939df0d71e4b1442139",
+        "date": "2026-07-18 18:30:01 +0700",
+        "subject": "Update the project URL to https://pgbackrest.org.",
+        "body": "The site now serves over HTTPS at the apex domain, so switch from http://www.pgbackrest.org to https://pgbackrest.org.\n\nChange the backrest-url-base variable that generates the documentation links and the URL hardcoded in the man page SEE ALSO section, then regenerate README.md and CONTRIBUTING.md and update the doc build test to match."
+    },
+    {
+        "commit": "cb911bbcf1e534bbeb3c5ec341208f3cff1c3e49",
+        "date": "2026-07-18 18:22:44 +0700",
+        "subject": "Remove NEWS.md in favor of generating it from news.xml.",
+        "body": "NEWS.md is the release announcement copied to a postgresql.org news item. It was maintained by hand for each release, but that content now lives in news.xml and is rendered to NEWS.md by the documentation build.\n\nRemove the committed file and add it to .gitignore so it is treated as generated output and regenerated when an announcement is needed."
+    },
+    {
+        "commit": "8a0d856d64f3c634d097d97533836f167b1938a1",
+        "date": "2026-07-18 15:17:18 +0700",
+        "subject": "Build and smoke test the distribution tarball on many distributions.",
+        "body": "The distribution tarball ships the generated source and the rendered documentation so it builds without the code generation or documentation tooling that a git checkout requires. Add a workflow that exercises this contract: build the tarball, then on a range of distributions build and smoke test it in a fresh container that has only the required packages, which is both a test and a record of what a packager needs on each.\n\nThe tarball is built once, since it is distribution-independent by design, and uploaded as an artifact; a matrix job then consumes it per distribution and drives the built binary through a full backup, restore, and verify cycle against that distribution's native PostgreSQL. The containers are run with docker directly rather than as job containers because the runner's glibc Node.js cannot execute the checkout and artifact actions inside a musl container, which keeps one path for glibc and musl alike.\n\nDebian, Ubuntu, Rocky, Fedora, and Alpine are covered, and the tarball is built with -Dwerror so a compiler warning on any of them fails the build. A separate check confirms the tarball ships exactly the expected generated and rendered files and that none of them is empty, catching a broken code generation or documentation render before it is uploaded.\n\nAlso remove the smoke job from the misc workflow, since building and smoke testing the tarball now covers the check a packager would run, and move its format check for smoke.py, the only Python file, into the code-format job with the other formatting checks."
+    },
+    {
+        "commit": "94f82ea9cfcd60a94a696ccb1ffb11f6edff9b0b",
+        "date": "2026-07-18 12:13:22 +0700",
+        "subject": "Run the smoke test on MacOS and FreeBSD.",
+        "body": "The bsd test group cannot run the integration tests because there are no containers available, but the smoke test drives a backup/restore cycle against each installed PostgreSQL and so provides basic coverage on these platforms. Teach the smoke test the Homebrew and FreeBSD bin paths so it can find the installations there.\n\nDiscover the PostgreSQL versions to test at install time rather than naming them so the tests do not break when a version becomes unavailable. Read the supported versions from the generated header, intersect them with what the platform offers, and test the oldest and newest of the result.\n\nOn MacOS only keg-only formulae that are neither deprecated nor disabled are considered since the binaries in a formula that is not keg-only load libpq from the linked prefix and fail unless the formula is linked.\n\nOn FreeBSD the ports all install into the same prefix and conflict, so only one version can be installed at a time and the oldest goes on the older OS while the newest goes on the newer OS. Install the versioned client and server packages instead of postgresql-libpqxx, which depends on the default PostgreSQL version."
+    },
+    {
+        "commit": "de0d746c244bfa8e6c1bd64ef23127d6041c107d",
+        "date": "2026-07-18 12:07:25 +0700",
+        "subject": "Run more tests on the emulated architectures.",
+        "body": "Now that a persistent ccache has made compiling under emulation affordable, broaden the tests run there to better check that checksums are correct on big-endian. Add the command restore, archive-get, archive-push, and verify tests alongside backup, and the common type-pack, crypto, and compress tests, which exercise the serialization, checksum, and compression code that a byte-order bug would break.\n\nAlso add a smoke test that drives a real PostgreSQL through a full backup, restore, and verify cycle, checking checksums end-to-end rather than against synthetic harness data. This needs a PostgreSQL server, so install a single version in the base image for these architectures; the full version matrix is skipped to keep the emulated build fast."
+    },
+    {
+        "commit": "0bd9eee889617c3a95225dedbbae9e13b24d2075",
+        "date": "2026-07-18 11:58:33 +0700",
+        "subject": "Persist the ccache across CI runs using a container registry.",
+        "body": "Consolidate the per-vm and per-vm-index ccache directories into a single cache shared by the host and every container, passed with CCACHE_DIR instead of mounted at ~/.ccache. A file compiled in one place is then a hit in the others, e.g. test-pgbackrest is built both on the host and in the build container, and since ccache is safe for concurrent access there is no need to split the cache. It stays in the test path so --clean removes it.\n\nStore and restore that cache in GHCR via a new composite action. Unlike actions/cache a registry is not branch-scoped, so a short-lived branch starts warm from the last run on the fork rather than cold, which matters most for the emulated architecture jobs where compiling is slow. The action pulls the fork's own cache first and falls back to the canonical pgbackrest cache for a fork that has not run yet; the push is best effort so pull requests from forks that cannot write just use what they built."
+    },
+    {
+        "commit": "084b202ca1b8b85c8da61e29b0b86e71643ca665",
+        "date": "2026-07-18 11:28:41 +0700",
+        "subject": "Output the architecture in the smoke test.",
+        "body": "The smoke test now reads the ELF header of the pgbackrest binary being tested and prints its machine architecture and endianness, e.g. \"s390x (64-bit big-endian)\", right after the user it runs as. This makes it easy to confirm which architecture is actually being exercised, which matters when a binary built for a foreign architecture is run under emulation."
+    },
+    {
+        "commit": "1055287f4962465659609f5a0b6f769f53f7578b",
+        "date": "2026-07-17 17:17:23 +0700",
+        "subject": "Split the test workflow into reusable workflows.",
+        "body": "test.yml had grown large enough to be awkward to navigate, but splitting it into independent workflows would have produced a separate run in the Actions UI for each file and required the push/pull_request trigger to be duplicated in every one.\n\nInstead test.yml becomes a dispatcher that calls reusable workflows, so it remains a readable index of what runs while still producing a single run. Only test.yml has a trigger and the called workflows are all on: workflow_call. Permissions are granted in the dispatcher since a called workflow can only maintain or reduce the permissions of the token it is given, never elevate them.\n\nThe jobs are grouped by platform into linux, arch, and bsd, with doc for the documentation builds and misc for the checks that do not fit any of them.\n\nThe documentation builds are worth separating because they have little in common with the tests they were mixed in with. They do not use the test containers, so they need no GHCR login or packages: write permission to maintain the container cache, and they generate no coverage, so there is no report to upload on failure. The build-max parameter was already ignored for doc since ci.pl only passes parameters through on the test path, so it is not carried over.\n\nJob names gain the calling job as a prefix, e.g. linux / test, which is the cost of getting a single run.\n\nAlso move symbol.out into a data directory since it is not a workflow and GitHub only scans the top level of .github/workflows."
+    },
+    {
+        "commit": "aaec9bad64eb464d1b4ed0faa655a8e903f07035",
+        "date": "2026-07-17 13:02:34 +0700",
+        "subject": "Remove out-of-date instructions for building documentation.",
+        "body": "These instructions are long out of date and it does not seem worth updating them since packagers should now be using the pre-generated documentation in the distribution tarball introduced in 8fcfef5d."
+    },
+    {
+        "commit": "db9552c16d70ef8d86f16d6ddcb4d943130fdd21",
+        "date": "2026-07-17 12:55:44 +0700",
+        "subject": "Download the distribution tarball rather than the source archive.",
+        "body": "The user guide build section demonstrates building from the distribution tarball but the download command still points at the GitHub source archive url for the release tag. That tarball is just the repository contents, so it has neither the generated files nor the dist marker, and building it requires the code generation tooling that the documented dependencies do not include. It also unpacks to pgbackrest-release-<version> rather than the pgbackrest-<version> path that build-br-path has used since the distribution tarball was introduced.\n\nPoint github-url-release at the distribution tarball attached to the release instead. The release tag contains a slash, e.g. release/2.59.0, which must be percent-encoded as %2F in the asset download path.\n\nThe url renders on a single line of 110 characters, which is why the download command carries a cmd-line-len override.\n\nThis was missed in 8fcfef5d."
+    },
+    {
+        "commit": "0951013d74ba6c570b81701a4b9686c9e168f41b",
+        "date": "2026-07-17 12:51:18 +0700",
+        "subject": "Allow cmd-line-len to be overridden per command.",
+        "body": "The documentation build errors when a rendered command has a line longer than cmd-line-len, which is configured per document and defaults to 80. The check keeps commands readable in the rendered output, but a command containing a single token longer than the limit cannot satisfy it no matter where the line is broken, e.g. a url.\n\nAdd a cmd-line-len parameter to execute that overrides the document setting for a single command so the limit continues to apply to every other command."
+    },
+    {
+        "commit": "a32211aef80f803aa2d81900de89bd5a9e534669",
+        "date": "2026-07-17 12:10:38 +0700",
+        "subject": "Use curl instead of wget.",
+        "body": "curl is already used elsewhere in the documentation and is preinstalled on the container images, while wget is not installed on any of them by default. Standardize on curl.\n\nUpdate the systemctl replacement and release tarball downloads in the user guide to use curl -fsSL. This is equivalent to the wget flags it replaces, except that -f makes curl fail on an HTTP error rather than piping the error page into tar.\n\nRemove wget from the RHEL documentation container instead of replacing it with curl, since curl is already provided by curl-minimal. Installing the curl package there would fail because it conflicts with curl-minimal.\n\nRemove wget from the test containers entirely. Nothing has invoked it since the lcov, nodejs, pip, minio, and s3 server downloads that needed it were removed. The PGDG repository keys it once fetched are now retrieved by rpm/dnf directly on RHEL, and on Debian the key is shipped with postgresql-common."
+    },
+    {
+        "commit": "4b90ff9a790c17fdb56d42e2ade523ee7bb3eed6",
+        "date": "2026-07-17 11:56:14 +0700",
+        "subject": "Update the systemctl replacement to 1.5.9063.",
+        "body": "Move to the last release of the 1.5 branch to pick up a year of fixes.\n\nThe 1.7 branch is where upstream development continues, but it lowered the default log level from ERROR to NOTE, which surfaces a warning about postgresql-{[pg-version]}.service using /bin/kill for ExecReload. The warning is not new, it was simply below the log level before, and 1.7 offers no way to suppress it since --no-warn is accepted but ignored and -c is applied after the log level is set."
+    },
+    {
+        "commit": "8c9712e81cb8ba929d82e33c84c400788230b933",
+        "date": "2026-07-17 11:52:10 +0700",
+        "subject": "Run the smoke test in a container rather than on the runner.",
+        "body": "The runner image comes with a large amount of preinstalled software that cannot be controlled, which makes it a poor stand-in for the environment a packager builds in. Run the job in a minimal ubuntu:24.04 container instead so the smoke test runs with nothing but the build environment that the job explicitly installs.\n\nInstall the build environment before checkout since the container does not include git, which checkout requires in order to clone rather than download the code via the GitHub API. Also add build-essential for the compiler and ca-certificates/curl/gnupg/lsb-release for the PGDG script, all of which were previously provided by the runner image.\n\nSince the container runs as root, the smoke test now drops to the postgres user, which exercises a path that was not covered when the job ran as the runner user."
+    },
+    {
+        "commit": "d856595643966328cd059faa1ab7ed43722f35a0",
+        "date": "2026-07-17 10:57:29 +0700",
+        "subject": "Untap non-official taps in the MacOS test job.",
+        "body": "The GitHub runner image adds taps such as aws/tap but never trusts them, so Homebrew 6.0 tap trust emits a warning on every brew command that auto-updates. Untap everything except the official Homebrew taps since no formula used in test comes from a third-party tap.\n\nUninstall the packages provided by a tap before untapping it. The runner image installs packer from hashicorp/tap and bicep from azure/bicep, and untapping a tap that still has packages installed warns just as the trust check does."
+    },
+    {
+        "commit": "77c832927caa1e76fe187538dc7ba6b4a54ae325",
+        "date": "2026-07-17 10:35:34 +0700",
+        "subject": "Use the custom shell to run FreeBSD tests in the VM.",
+        "body": "The run parameter of cross-platform-actions/action is deprecated in favor of starting the VM in one step and running commands in subsequent steps with the cpa.sh custom shell."
+    },
+    {
+        "commit": "2777395dacc35aec51572d3e75c621725e2f9d9c",
+        "date": "2026-07-17 09:06:10 +0700",
+        "subject": "PostgreSQL 19beta2 support.",
+        "body": "Bump the u22 revision on x86_64 and aarch64 so the base images are rebuilt and pick up the new beta from apt.postgresql.org. Key the revision by architecture rather than by VM so the ppc64le and s390x images, which do not install PostgreSQL 19, are not rebuilt under emulation for no reason.\n\nSince there are no code changes beta1 continues to work."
+    },
+    {
+        "commit": "2164336bece5711f40351c01e90db2e834b7792a",
+        "date": "2026-07-17 08:08:58 +0700",
+        "subject": "Log the full PostgreSQL version in the integration and smoke tests.",
+        "body": "Both tests only report the major version of PostgreSQL, which is not enough to identify the build. The integration test takes the major version from the test matrix and the smoke test parses it out of pg_ctl during discovery, so neither shows the minor version. This matters most during the beta period, where a rebuild of a container or a package update can move the installed version from one beta to the next without anything in the test output changing.\n\nLog the output of pg_ctl --version in both tests, e.g. \"pg_ctl (PostgreSQL) 19beta2\". The integration test logs it after the hosts are built, so the version is reported even when cluster creation fails. The smoke test logs it under the header for each version it tests.\n\nUse pg_ctl rather than postgres since the tests already require pg_ctl to run a cluster, so no error handling is needed when it cannot be found. The postmaster symlink is not an option because it was removed in PostgreSQL 16."
+    },
+    {
+        "commit": "fe59278f753a009ca804258dd66c9ec2bf142239",
+        "date": "2026-07-17 08:05:48 +0700",
+        "subject": "Allow container cache revisions to be set per architecture.",
+        "body": "A base image is built per VM and architecture but a revision could only be keyed by VM, so bumping one rebuilt every architecture. This is expensive for u22, which is built for x86_64, aarch64, ppc64le, and s390x, since the last two are built under emulation in CI and are very slow. A new PostgreSQL beta packaged for only some architectures does not change the others, so those rebuilds just reproduce identical images under a new tag.\n\nAllow a revision to be keyed by VM and architecture, e.g. u22-x86_64. A container uses the revision for its VM and architecture if it has one, else the revision for its VM, else the required \"all\" revision. Keying by VM alone is unchanged and still rebuilds every architecture.\n\nValidate the revision keys. Only the presence of \"all\" was checked before, so a key with a misspelled VM or architecture, or with no value at all, silently fell back to a less specific revision and the expected rebuild never happened. Add VM_ARCH_PPC64LE, VM_ARCH_S390X, and a list of valid architectures to support the check, since these architectures were previously named only in the CI workflow."
+    },
+    {
+        "commit": "f087c83845b86434829121b8075d1d0c4224cc61",
+        "date": "2026-07-16 17:38:05 +0700",
+        "subject": "Add a smoke test to verify a build against installed PostgreSQL.",
+        "body": "The test suite is too complex and time-consuming for packagers to run, so provide a basic smoke test that exercises major functionality to show that a build works. test/smoke.py searches the paths used by the test harness for each PostgreSQL installation and runs the built pgbackrest through a full cycle for every supported version found: initdb, stanza-create, check, full backup, incremental backup, restore, and verification that the restored data matches. Each version runs in a temporary directory with its own repository and a private unix socket, so a running cluster is not disturbed.\n\nRun the test with meson test --suite smoke. It uses only the Python standard library since meson already requires Python. The test fails rather than skips when there is no PostgreSQL to test against, since a test that silently does nothing does not verify the build. PostgreSQL will not run as root, so running as root drops to the postgres user and fails when that user does not exist.\n\nThe supported versions are read from the generated src/postgres/version.auto.h so that versions pgBackRest does not support are skipped rather than failing. The header is used rather than src/build/postgres/postgres.yaml because the latter is not shipped in the distribution.\n\nThe test is defined in test/meson.build rather than the root meson.build because unit test builds comment out all subdirs, which excludes the smoke test from them. .gitattributes ships test/smoke.py and test/meson.build in the distribution tarball, and DIST.md and the user guide document how to run it.\n\nAdd a CI job that builds on Ubuntu 24.04 and runs the smoke test against every supported version, installed from PGDG with a component added for versions that are not released yet. The version list comes from postgres.yaml so it does not need to be maintained in the workflow. The job also checks that smoke.py is formatted with black."
+    },
+    {
+        "commit": "30e1e279856b2398f1963cb45bd17e793ebd006e",
+        "date": "2026-07-16 17:12:07 +0700",
+        "subject": "Add a smoke test to verify a build against installed PostgreSQL.",
+        "body": "The test suite is too complex and time-consuming for packagers to run, so provide a basic smoke test that exercises major functionality to show that a build works. test/smoke.py searches the paths used by the test harness for each PostgreSQL installation and runs the built pgbackrest through a full cycle for every supported version found: initdb, stanza-create, check, full backup, incremental backup, restore, and verification that the restored data matches. Each version runs in a temporary directory with its own repository and a private unix socket, so a running cluster is not disturbed.\n\nRun the test with meson test --suite smoke. It uses only the Python standard library since meson already requires Python. The test fails rather than skips when there is no PostgreSQL to test against, since a test that silently does nothing does not verify the build. PostgreSQL will not run as root, so running as root drops to the postgres user and fails when that user does not exist.\n\nThe supported versions are read from the generated src/postgres/version.auto.h so that versions pgBackRest does not support are skipped rather than failing. The header is used rather than src/build/postgres/postgres.yaml because the latter is not shipped in the distribution.\n\nThe test is defined in test/meson.build rather than the root meson.build because unit test builds comment out all subdirs, which excludes the smoke test from them. .gitattributes ships test/smoke.py and test/meson.build in the distribution tarball, and DIST.md and the user guide document how to run it.\n\nAdd a CI job that builds on Ubuntu 24.04 and runs the smoke test against every supported version, installed from PGDG with a component added for versions that are not released yet. The version list comes from postgres.yaml so it does not need to be maintained in the workflow. The job also checks that smoke.py is formatted with black."
+    },
+    {
+        "commit": "74e858dbdb049a0597efa42a309b22f8a8feb2ba",
+        "date": "2026-07-16 16:19:11 +0700",
+        "subject": "Fix duplicated word in the file mode error message.",
+        "body": "The message read \"expected mode for '0644' for 'src/file.c' but found '0755'\", where the extra \"for\" made the expected mode read as a file name. Drop it so the message reads \"expected mode '0644' for 'src/file.c' but found '0755'\"."
+    },
+    {
+        "commit": "6e709faf2ca1b382ec11608d5a3fdea83c074a3f",
+        "date": "2026-07-16 13:34:04 +0700",
+        "subject": "Upload the coverage report as a CI artifact instead of logging it.",
+        "body": "On failure the coverage report was written to the job log with cat, which meant copying the HTML out of the log and into a file before it could be viewed. Upload it as an artifact instead so it can be downloaded directly from a failed run.\n\nThe upload ignores a missing report (most matrix jobs run with no coverage) and skips the zip archive since the report is a single HTML file."
+    },
+    {
+        "commit": "8fcfef5d8732055f9bc8e50224d5b7a988512e61",
+        "date": "2026-07-16 13:05:20 +0700",
+        "subject": "Provide a distribution tarball with generated code and documentation.",
+        "body": "meson dist produces the tarball via src/build/dist.sh, which regenerates help.auto.c.inc and interface.auto.c.inc, copies the man page and HTML into doc, and writes a dist marker to the root. When the marker is present the build uses the shipped files and skips build-code, libyaml, and the doc and test tools, so the tarball compiles and installs without the code generation or documentation tooling.\n\n.gitattributes export-ignore rules limit the tarball to what is needed to build: src (except the src/build code generation sources), meson.build, meson_options.txt, and LICENSE, plus the generated files, docs, marker, and a README copied from doc/DIST.md.\n\nRELEASE.md documents building the tarball, attaching it to a draft release, verifying it, and publishing. The user guides demonstrate building from the tarball."
+    },
+    {
+        "commit": "85ddcc94f9fe99731f3e018c4e0d1aa1cea6b153",
+        "date": "2026-07-16 10:51:00 +0700",
+        "subject": "Add logo, news, and sponsor toggles to the documentation.",
+        "body": "Add the logo, news, and sponsor document variables, all defaulting to y so the rendered documentation is unchanged. Setting a variable to n omits the corresponding content: logo omits the project logo file and its og:image link, news omits the news section, and sponsor omits the sponsor sections and their logos.\n\nThis allows the documentation to be rendered without the logo, news, and sponsor content that is only relevant to the website."
+    },
+    {
+        "commit": "b7fdb0d823fac1d22f9e3d39606977832ba37771",
+        "date": "2026-07-15 10:24:59 +0700",
+        "subject": "Move test harness files to test/src/harness and drop the prefix.",
+        "body": "The harness modules were the only files in test/src/common and each was named with a harness prefix, e.g. common/harnessLog.c. Move them to test/src/harness and drop the prefix so the file name matches the module it supports, e.g. harness/log.c.\n\nRenaming in place would leave harness headers such as log.h, lock.h, and time.h at the same include path (common/) as their real src/common counterparts. Because test/src precedes src on the include path, the harness header would shadow the real one, so the harness must live under a distinct harness/ path.\n\nAdjust the harness path construction in command/test/build.c, normalize the include guards to a TEST_HARNESS_ prefix (fixing blockIncr.h, which incorrectly used BLOCK_DELTA), and update the harness file references in the contributing documentation."
+    },
+    {
+        "commit": "43505fd82389fa65ec46c74eb37112e140cb9aa3",
+        "date": "2026-07-14 22:34:34 +0700",
+        "subject": "Store help data as a C string instead of a byte array.",
+        "body": "Write the compressed help data as a single C string literal rather than a list of byte values so it is much more compact, which will matter if help.auto.c.inc is checked in as an asset. Printable bytes are written directly, bytes with a short named escape are mapped through a lookup table, and the rest use three-digit octal escapes.\n\nPhysical lines are broken at a fixed width with a backslash-newline continuation, which the preprocessor removes before the string is tokenized. This lets an escape span a line break so every line stays the same width.\n\nThe data is not NUL-terminated, so the array is declared VR_NON_STRING and sized to exactly match the data."
+    },
+    {
+        "commit": "18b3857056360a8f6cb5c83412d6c9147557f6c4",
+        "date": "2026-07-14 15:09:28 +0700",
+        "subject": "Normalize harness definitions in define.yaml to YAML lists.",
+        "body": "Several test modules defined the harness key more than once in a single test, either a bare name alongside a map or multiple maps, which relies on the YAML parser accepting duplicate mapping keys. Combine these into a single YAML list per test so a test can declare multiple harnesses without duplicate keys, which a stricter parser rejects. Modules with a single bare name or map are left unchanged.\n\nUpdate the define parser to accept a harness sequence in addition to the existing bare name and single map forms; the parsed data structures are unchanged. Only the C parser consumes the harness and shim keys, so no other parsing is affected. Update the harness test fixture to the list form to cover the new sequence branch."
+    },
+    {
+        "commit": "276e701cfe1711b698448a69dfb509001defb365",
+        "date": "2026-07-13 11:07:16 +0700",
+        "subject": "Remove code count functionality from test.pl.",
+        "body": "The code counts were informational only and required ongoing upkeep of file-type.yaml, so remove the --code-count option, the CodeCountTest module, the generated file-type.yaml, and the related release steps. This can be restored later if it proves useful."
+    },
+    {
+        "commit": "baed942af0d61fcf3c2cb1f7d1bf1d6fe5bb6df9",
+        "date": "2026-07-10 15:18:09 +0700",
+        "subject": "Fix async archive-get failure during recovery across a timeline switch.",
+        "body": "During recovery PostgreSQL calls archive-get serially, once per WAL segment and each invocation with its own exec id. When async archive-get needs to fill the spool queue it takes the archive lock, releases it, and forks a detached async process that reacquires the lock at startup. The lock is released before the forked process has taken it.\n\nA main process returns to PostgreSQL as soon as it finds its segment in the spool, which happens immediately when a prior async process has already fetched it, so PostgreSQL starts the next archive-get before the just-forked async process has reacquired the lock. That next main process finds the lock free and forks an async process of its own. The two async processes race for the lock; one takes it and the other, holding a different exec id, fails to acquire it and dies before it can fetch the requested segment.\n\nThe main process that forked the failed async process waits out archive-timeout and returns an error to PostgreSQL. This is especially damaging on a timeline switch because the failed async process was the only one that would have fetched the requested segment; the surviving async process is filling a different timeline. A false timeout on a segment that actually exists can end recovery prematurely.\n\nWhen the requested segment is not in the spool queue and the archive lock is not held by our own async process, the segment will not be delivered: either a foreign async process holds the lock (spawned by a different main process, e.g. filling the queue for another timeline) or no async process is running because ours failed. In that case fetch the segment synchronously rather than waiting. The main process now waits for an async process only while its own async process holds the lock."
+    },
+    {
+        "commit": "37865f314f1f73db44fb223ee5768ab1bfee7f66",
+        "date": "2026-07-10 14:58:34 +0700",
+        "subject": "Add RHEL 9 and 10 tests and switch RHEL 8 to native PostgreSQL.",
+        "body": "Add RHEL 9 and RHEL 10 (Rocky Linux) as test VMs that run the unit and integration tests, and switch RHEL 8 to the older PostgreSQL that ships natively with the distribution via an application stream. The native packages install to /usr/bin rather than the PGDG path, which the psql-bin setting and the integration host harness now handle.\n\nRHEL 10 required several adjustments: its rpm-sequoia OpenPGP backend rejects the SHA-1 signature on the PGDG key (and the crypto policy that would allow it was removed), so the PGDG repository is installed without gpg checks; it dropped dnf modularity, so there is no postgresql module to disable; and its zlib-ng build trips a valgrind \"possibly lost\" false positive that is suppressed."
+    },
+    {
+        "commit": "c1f486000e57b2196a6266d3cfc5aff7e89e264b",
+        "date": "2026-07-10 14:23:07 +0700",
+        "subject": "Cache test container base images in GHCR.",
+        "body": "Base images were pulled from Docker Hub by looking up a hash of the generated Dockerfile in container.yaml, which required manually building the image, pushing it, and committing the new hash whenever the Dockerfile changed. Instead cache the base images in GHCR keyed by a hash of the Dockerfile and a revision, pulling on a hit and pushing after a build so the manual steps are no longer needed.\n\nImages are pulled from the pgbackrest cache first, then from the repository owner's own cache when running on a fork, and built locally if neither has them. A build is pushed back to the fork's own cache on a fork, otherwise to the pgbackrest cache, but the push is best effort and does nothing without write access, as when building locally or on a pull request from a fork. The image is always tagged in the pgbackrest namespace locally so the rest of the build and the integration harness reference a single name regardless of which cache supplied it.\n\nThe revision comes from container.yaml and forces a rebuild when the Dockerfile is unchanged but the upstream packages have changed, e.g. a new PostgreSQL beta. The required \"all\" revision applies to every container that does not set its own revision, so bumping it rebuilds those containers together, while a per-VM revision overrides \"all\" for that container and is bumped independently. The revision is also included in the image tag for reference.\n\nGrant package write permission and add a GHCR login to the CI jobs that build containers, and update the integration harness to reference the GHCR image name."
+    },
+    {
+        "commit": "36ed215a1600bd0a8a1d65b41ba2974124ed3df2",
+        "date": "2026-07-09 17:26:46 +0700",
+        "subject": "Replace strcpy() with memcpy() and ban strcpy()/strcat().",
+        "body": "Security scanners flag strcpy() as unsafe because it performs an unbounded write and silently overflows the destination when the source is longer than expected. Every remaining use already knows the exact length being copied, so replace each with a bounded memcpy() (or snprintf() in the test harness, matching the adjacent idiom).\n\nPoison strcpy() and strcat() in build.h so any future use is a compile-time error that will be caught by CI. There are no strcat() uses to remove, but ban it alongside strcpy() as it has the same unbounded-write hazard. string.h is included and the macros are undefined first for the same reason as strncpy(): fortify defines them as macros, and system headers must be processed before the identifier is poisoned."
+    },
+    {
+        "commit": "443df647b205d091af9ca2a15cc1990ee5f9306f",
+        "date": "2026-07-09 14:28:26 +0700",
+        "subject": "Replace sprintf() with snprintf() and ban it.",
+        "body": "Security scanners flag sprintf() as unsafe because it performs an unbounded write and silently overflows the destination when the formatted output exceeds it. There is a single use left, in the log test, so remove it to avoid the noise.\n\nThe stderr check builds an expected string into a fixed 4096-byte buffer; use snprintf() with sizeof(buffer), which is bounded and always null-terminates, matching the idiom already used elsewhere in the tests.\n\nPoison sprintf() in build.h so any future use is a compile-time error that will be caught by CI. stdio.h is included and the macro is undefined first for the same reason as strncpy(): fortify defines sprintf() as a macro, and system headers must be processed before the identifier is poisoned."
+    },
+    {
+        "commit": "2ec93c26b6543946bc6e7ac83a8afbb1507cd269",
+        "date": "2026-07-09 14:02:27 +0700",
+        "subject": "Add YAML helpers for the peek-type and empty-map idioms.",
+        "body": "yamlEventPeekIs() replaces the yamlEventPeek(yaml).type == X test and yamlMapEmpty() replaces the map-begin/map-end pair used to consume an empty map value. Apply them in the config, error, and postgres build parsers and the test define parser."
+    },
+    {
+        "commit": "92b38113eae0acecaa474e54c2d3d55d312f9d9b",
+        "date": "2026-07-09 13:34:01 +0700",
+        "subject": "Fix parsing of the parameter-allowed command definition.",
+        "body": "The value was assigned the result of strLower(strDup()), a non-NULL String pointer, into the boolean parameterAllowed field, so it was always true whenever the key was present regardless of the value. The expression was copied from the adjacent log-level-default definition (which is a string) and never changed to yamlBoolParse().\n\nThis does not change the generated output since config.yaml always sets parameter-allowed to true, but parameter-allowed of false would previously have been parsed as true."
+    },
+    {
+        "commit": "2ccacd46281164644d5af6e6d3cb110b40f49186",
+        "date": "2026-07-09 13:28:22 +0700",
+        "subject": "Simplify the build YAML parsers with iteration macros.",
+        "body": "The config, error, and postgres build parsers walked the libyaml event stream by hand, repeating the same begin/next/do-while scaffolding and empty-collection special cases in nearly every function. Reuse the YAML_MAP_BEGIN/YAML_SEQ_BEGIN iteration macros (already used by the test define parser) so each parser reads more like the structure it parses.\n\nRework the macros to test for the end event with a peek at the top of the loop rather than a do/while at the bottom. This makes empty maps and sequences zero-iteration and removes the manual empty-collection handling the config parser required, since config.yaml contains many empty {} maps while the other build YAML never does.\n\nAlso drop the braces around single-statement if/else branches in the parser dispatch chains, which did not match the surrounding style where braces are used only for multi-line bodies."
+    },
+    {
+        "commit": "85717992cadbfdabc571fb23914b62b08c7f6f44",
+        "date": "2026-07-09 12:23:40 +0700",
+        "subject": "Document that end-of-line comments are not supported in config files.",
+        "body": "End-of-line comments have never been supported by the INI parser, though they may appear to work for some option types by coincidence. Clarify in the documentation that only full-line comments are supported."
+    },
+    {
+        "commit": "bde2c509c923fbe2844c10b0f95c55973378d2ae",
+        "date": "2026-07-09 11:38:36 +0700",
+        "subject": "Document adjusting the logrotate su directive for a dedicated user.",
+        "body": "Packages may install a logrotate configuration that rotates the pgBackRest logs as a specific user (e.g. postgres) via the su directive. When a dedicated user owns the repository and logs, the su directive must be updated to match that user or logrotate will fail with a permission error."
+    },
+    {
+        "commit": "0daf53da03fb179b5771b6aaa559f9e0cc5842bb",
+        "date": "2026-07-09 10:59:03 +0700",
+        "subject": "Error when running as root unless allow-root is enabled.",
+        "body": "Running as the root user for commands other than restore can create files (e.g. backup.info in the repository) owned by root that the PostgreSQL user cannot access, causing later commands to fail.\n\nAdd the allow-root option to gate this. It defaults to false for all commands except restore, which is designed to run as root and manages file ownership carefully. The check applies to all command roles so a non-root command cannot run as root on a remote, and is skipped for help/version."
+    },
+    {
+        "commit": "31432ed3977302b5e183f2b592d85afb521b4f55",
+        "date": "2026-07-09 10:16:22 +0700",
+        "subject": "Fix use-after-free of parallel protocol client.",
+        "body": "When a client's job callback returned no more work, protocolParallelProcess() freed the client with protocolHelperFree() but left the now-dangling pointer in clientList and did not mark the slot done. Since process() keeps being called while other clients are still running, the same slot was revisited on a later call and protocolHelperFree() was invoked again on the freed client. At debug/trace log level the entry parameter log formatted the freed client via protocolClientToLog(), reading freed memory and segfaulting (reported during a parallel backup run with --log-level-file=trace).\n\nThis was introduced in 4a94b6b, which replaced protocolLocalFree(clientIdx + 1) (logging a scalar process id) with protocolHelperFree(client) (logging a dereferenced client pointer), turning the pre-existing repeated free into a use-after-free.\n\nClear the client reference after freeing so the exhausted client is neither queried nor freed a second time."
+    },
+    {
+        "commit": "7b0159c7dfd69763b63b1385fd564c18a4a5c1bc",
+        "date": "2026-07-09 09:54:56 +0700",
+        "subject": "Report archive-push spool path errors to the PostgreSQL log.",
+        "body": "In async mode the spool out path was created only by the async process. If it could not be created (e.g. permission denied) then the async process also could not write its error status file to the spool, so the foreground process never saw the error and failed only with a generic archive timeout that pointed at the async log. The operator then had to cross-reference a second log file to find the real cause.\n\nCreate the spool out path in the foreground before forking the async process, as archive-get already does. A permission error is now thrown in the process PostgreSQL invokes and appears in the PostgreSQL log immediately. Since the foreground always creates the path before the async process runs, the redundant create in archivePushProcessList() is removed."
+    },
+    {
+        "commit": "b0c57c280d727e743b72a6d86e2c3e413307e44b",
+        "date": "2026-07-09 09:36:35 +0700",
+        "subject": "Report the actual error when an S3 credential request fails.",
+        "body": "Web identity (web-id) and pod identity (pod-id) credential requests parsed the response as if it had succeeded, so an error from AWS was reported as a confusing failure to find AssumeRoleWithWebIdentityResult (web-id) or missing JSON keys (pod-id) rather than the actual error.\n\nReport the error returned by AWS using httpRequestError(), as the main request path already does. Redact the web identity token in the query and the pod identity token in the authorization header so they are not exposed when the request is logged."
+    },
+    {
+        "commit": "5a4646a7f8a7a5229f732c39103be8c83e186d8a",
+        "date": "2026-07-08 19:33:44 +0700",
+        "subject": "Update RHEL documentation to Rocky Linux 9.",
+        "body": "Rocky Linux 8 is getting old so move the RHEL user guide and documentation CI to Rocky Linux 9, updating the base image and the PGDG repository to EL-9.\n\nInstall awscli from the awscli2 package and azure-cli from EPEL instead of pulling awscli through pip and azure-cli from the Microsoft package repository. This simplifies the build and drops the pip and Microsoft repository dependencies.\n\nRemove the RHEL 8 PowerTools repository since CRB is already enabled via crb on Rocky 9."
+    },
+    {
+        "commit": "ab4de698eb125a35baaf772184a4f2b0a2612abd",
+        "date": "2026-07-08 16:33:10 +0700",
+        "subject": "Add ransomware and malware protection to the feature list.",
+        "body": "The repo-target-time feature allows a repository on versioned object storage to be read at a point-in-time, but this protection against accidental, malware, or ransomware damage was not mentioned in the feature list."
+    },
+    {
+        "commit": "c16a81844a5005d52943ea70ca74b90e23c46c54",
+        "date": "2026-07-08 15:48:13 +0700",
+        "subject": "Add linter check for hidden characters and binary files.",
+        "body": "Invisible, bidirectional, and homoglyph characters can hide code that looks benign under review, e.g. Trojan Source and Glassworm, and binary files cannot be reviewed at all. The linter now walks every file in the repo and requires it to be 7-bit ASCII text with tab and newline as the only permitted control characters, which catches the entire class at once. A short skip list exempts the two committed binary files and the generated git-history.cache.\n\nThe StringId check now also runs on hand-written .c.inc files, excluding generated .auto.c.inc and vendored .vendor.c.inc.\n\nIntentional non-ASCII test data is written with \\xNN escapes, an accented contributor id is normalized to ASCII, and smart quotes in meson.build are replaced."
+    },
+    {
+        "commit": "9c9c9e71345ce792bc925e41568fd69286b874a7",
+        "date": "2026-07-08 12:24:40 +0700",
+        "subject": "Report the actual error when a unit test fails during coverage testing.",
+        "body": "When a unit test failed under valgrind (or otherwise exited before flushing coverage data) the real error was hidden and replaced by a gcov error about the missing coverage file.\n\nThe test command pipes output to tee so stderr can be copied to both stderr and stdout, but that made the pipeline return tee's exit status rather than the test's. The masked (zero) status caused the harness to attempt coverage generation, which then failed on the missing coverage data and reported that failure instead of the actual test error.\n\nSave the test exit status to a file and exit with it explicitly so the real status is preserved through the pipe. PIPESTATUS/pipefail cannot be used here because the vm=none path runs through dash."
+    },
+    {
+        "commit": "cf847f94cd7ab6517ec1abb30075fb53dc75d5f8",
+        "date": "2026-07-07 20:57:08 +0700",
+        "subject": "Document that expire-auto uses the backup command configuration.",
+        "body": "When expire runs automatically after a successful backup it uses the configuration loaded for the backup command, so options set only in an expire command section are not applied. Note this behavior in the expire-auto option help and point users to disabling it and running expire separately when expire-specific configuration is needed."
+    },
+    {
+        "commit": "4945139392c21f197f2e307abc3c89b5548cef8d",
+        "date": "2026-07-07 18:31:54 +0700",
+        "subject": "Add archive-expire-before option to clean up WAL archive.",
+        "body": "Add a new command-line option archive-expire-before to the expire command. It removes WAL segments earlier than a given segment from the archive, while never removing WAL that a retained backup still requires.\n\nA typical use is to drive archive clean-up from a standby's restartpoint (using PostgreSQL's archive_cleanup_command) without having to fall back to pg_archivecleanup and lose pgBackRest's retention safeguards."
+    },
+    {
+        "commit": "6cd692b1b321faf544ee3a9b1f503fd48007d7c7",
+        "date": "2026-07-07 17:56:34 +0700",
+        "subject": "Extract WAL expiration into expireArchiveId().",
+        "body": "Move the per-archive-id WAL removal loop out of removeExpiredArchive() into a new expireArchiveId() function that takes the archive id, the retention ranges to preserve, and the scan boundary. This is a pure refactor with no change in behavior."
+    },
+    {
+        "commit": "2137bda1a5a1ad890d0137feffe8491102041af3",
+        "date": "2026-07-07 16:53:50 +0700",
+        "subject": "Document that info reads encryption settings from global section.",
+        "body": "The info command reads encryption settings only from the global section when run without the stanza option, so encryption settings configured per stanza require the stanza option to read an encrypted stanza. Note this in the user guide encryption section and the repo-cipher-pass config reference."
+    },
+    {
+        "commit": "fad857896965347d10b13cbccaba27a6e44c85c8",
+        "date": "2026-07-07 15:43:50 +0700",
+        "subject": "Prevent a flaky command/control test when stop terminates a process.",
+        "body": "The \"processId is valid\" test in command/control had a child process acquire two archive lock files under a single pid, then relied on stop --force sending a term signal to that process. cmdStop() sends the term signal after reading the first lock file but before reading the second, so on a fast or loaded host (most often Debian 12 in CI) the child could receive the signal and release its flock on the second file before stop read it. stop then saw the file as unlocked rather than duplicate and emitted a spurious \"unable to read lock file\" warning, failing the log expectation.\n\nHave the child ignore the term signal so it keeps holding both lock files until the parent explicitly releases it after checking the log. This makes stop reliably see the second file as a duplicate of an already-signaled pid and skip it, closing the race window entirely rather than narrowing it with timeouts. kill() still returns success, so the single \"sent term signal\" message is logged as before."
+    },
+    {
+        "commit": "3e9eabd8a5551cdaeb6bc78a52f000eaf239defb",
+        "date": "2026-07-07 15:26:14 +0700",
+        "subject": "Make stanza option internal for the repo-* commands.",
+        "body": "The stanza option is accepted by repo-get, repo-ls, repo-put, and repo-rm but does not construct a stanza-specific path as the documentation implied. It is only meaningful in combination with the storage path constants (e.g. <REPO:ARCHIVE>, <REPO:BACKUP>), which are themselves undocumented. This left the option documented but apparently non-functional for anyone spelling out the repository path directly.\n\nMark the option as internal for these commands so it no longer appears in the help/reference while remaining fully functional. This preserves existing usage (e.g. check_pgbackrest and macro-based tooling) with no behavioral change."
+    },
+    {
+        "commit": "34a035f4d62f06822c1f60f72a605762cc1ad79c",
+        "date": "2026-07-07 15:19:33 +0700",
+        "subject": "Add archive-push-batch-size to limit WAL pushed per asynchronous run.",
+        "body": "In asynchronous mode archive-push pushes every ready WAL segment in a single run and archive-push-queue-max is only checked at the start of the run, so a run that works through a large backlog can let the queue grow well past the limit before it is rechecked.\n\nAdd the archive-push-batch-size option (default 16GiB) to cap the amount of WAL pushed per run. The list of WAL to be pushed is trimmed to a whole number of segments using the size of the first ready segment, always keeping at least one, so the process exits and is respawned by the next archive-push, which rechecks the queue. Lower the value to recheck the queue more often at the cost of spawning the asynchronous process more frequently."
+    },
+    {
+        "commit": "3a71dc839a89b83f592c1d5813c068bcded1b6bc",
+        "date": "2026-07-07 12:57:04 +0700",
+        "subject": "Prevent an out-of-bounds error buffer write on an oversized message.",
+        "body": "errorInternalThrowSysFmt() appends the system message at messageBufferTemp + messageSize, where messageSize is the vsnprintf() return value: the untruncated length. A formatted message that reaches ERROR_MESSAGE_BUFFER_SIZE pushes that offset to or past the end of the buffer and underflows the remaining-size argument, so the \": [errno] ...\" suffix is written out of bounds into the adjacent stack trace buffer.\n\nLimit messageSize to ERROR_MESSAGE_BUFFER_SIZE - 1 before the append, in errorInternalThrowSysFmt() and its coverage-only twin errorInternalThrowOnSysFmt(), so it stays in bounds; the message content is already truncated by vsnprintf().\n\nThis mirrors the logPost() fix in c6e7ba81, and like it requires a single formatted message larger than the buffer to reach."
+    },
+    {
+        "commit": "c6e7ba81ab766494ec487f20d33c9086b29fafd1",
+        "date": "2026-07-07 12:38:39 +0700",
+        "subject": "Prevent an out-of-bounds log buffer write on an oversized message.",
+        "body": "logPost() appends the linefeed and null terminator at bufferPos, which each caller advances by the return value of snprintf()/vsnprintf(). That return value is the untruncated length, so a single log message longer than LOG_BUFFER_SIZE leaves bufferPos past the end of the 32 KiB logBuffer and the two writes land out of bounds. The message content itself is already truncated safely by snprintf(); only the terminator placement was unsafe.\n\nLimit bufferPos to LOG_BUFFER_SIZE - 2 in logPost() so the linefeed and terminator always fit. This is a single choke point that also covers the same pattern in logInternalFmt() and logPre(), and closes an off-by-one that remained even when a message exactly filled the buffer."
+    },
+    {
+        "commit": "2af68385aad069aa5d08f0b52ce9993367af52e4",
+        "date": "2026-07-07 12:29:44 +0700",
+        "subject": "Report a readable status when a test system command fails.",
+        "body": "HRN_SYSTEM built its failure message from the raw system() return value and embedded errorStackTrace() in it. That return value is a wait status (32512 when the command cannot be found), not an exit code, and is meaningless to the reader. Worse, errorStackTrace() asserts that an error is currently populated, so when a command failed with no active error the assert aborted the test binary before the AssertError could be thrown.\n\nDecode the status with hrnSystemStatus() into the exit code (127 in that example), the terminating signal, or an unable-to-execute note, and drop the redundant stack trace since the harness already prints one when it reports the error."
+    },
+    {
+        "commit": "11f5582dfe696187cab1f15d08f649a5117730b3",
+        "date": "2026-07-07 12:26:38 +0700",
+        "subject": "Allow the S3 STS endpoint to be configured.",
+        "body": "The STS endpoint used to retrieve temporary credentials for web identity authentication (repo-s3-key-type=web-id) was hardcoded to the global sts.amazonaws.com. Credentials issued by the global endpoint are not honored in AWS opt-in regions such as eu-central-2, which require tokens from the corresponding regional STS endpoint, so authentication failed there.\n\nAdd repo-s3-sts-host to configure the STS endpoint, defaulting to sts.amazonaws.com so existing behavior is unchanged. Setting a regional endpoint such as sts.eu-central-2.amazonaws.com enables web identity authentication in opt-in regions and may also be used for GovCloud, China regions, or to reduce latency."
+    },
+    {
+        "commit": "5ca98abc91f823ef97ff6a1e77d65727d1259218",
+        "date": "2026-07-07 11:31:45 +0700",
+        "subject": "Use the full buffer when formatting error messages.",
+        "body": "snprintf() and vsnprintf() take the total destination size and reserve the byte for the null terminator themselves, so passing ERROR_MESSAGE_BUFFER_SIZE - 1 needlessly discarded the last usable byte of messageBufferTemp. Pass the full ERROR_MESSAGE_BUFFER_SIZE; the output is still bounded and null-terminated.\n\nIn the *Fmt variants the appended system message drops the matching - 1 so it continues to consume exactly the space left after the formatted message."
+    },
+    {
+        "commit": "976c0fa73ca66b6268937dc53331db5e8536b7b2",
+        "date": "2026-07-07 11:05:03 +0700",
+        "subject": "Replace strncpy() with memcpy()/snprintf() and ban it.",
+        "body": "Security scanners routinely flag strncpy() as unsafe (it does not null-terminate when the source length meets or exceeds the size), generating noise even where each call is correct. Remove every use to avoid the churn.\n\nWhere the source length is known to fit the destination, use a plain memcpy(): the config option name and JSON key (both already bounded by a preceding size check that throws), the \"invalid\" address fallback, and the exact-length symlink target and buffered read in the libssh2 test harness. In addrInfoToZ() the \"invalid\" literal is promoted to a macro and new asserts document that the caller's buffer is large enough.\n\nWhere the copy may truncate, use snprintf(\"%s\", ...), which always null-terminates and matches the idiom already used in these files (logInternalFmt() and the sibling snprintf() in errorInternalThrowSys()): the error message, stack trace, and log message buffers. A memcpy() with a length clamp was avoided here because the clamp branch is unreachable in practice (these buffers are already bounded) and would break 100% coverage.\n\nlogSignal() runs in a signal handler where snprintf() is not async-signal-safe, so it uses memcpy() of the (always short, internal) signal name including its null terminator.\n\nThe libssh2 readdir and libpq PQcancel test shims assert the scripted value fits and then memcpy() it with its null terminator; tests always script a value that fits, so emulating the truncating library calls is unnecessary and harness files are not coverage targets.\n\nThe error test builds an over-long message by filling a buffer with a repeated character; null-terminate it so the new snprintf(\"%s\", ...) has a bounded string to read, where strncpy() previously tolerated the missing terminator via its length argument.\n\nPoison strncpy() in build.h so any future use is a compile-time error that will be caught by CI."
+    },
+    {
+        "commit": "e41a84e01a749cfcd4a9f71ac287e7e3015772c2",
+        "date": "2026-07-07 08:36:31 +0700",
+        "subject": "Update FreeBSD CI versions."
+    },
+    {
+        "commit": "f1ef62956adabf305a7e959477ea1bb668fd8d65",
+        "date": "2026-07-03 16:54:47 +0700",
+        "subject": "Fewer binary searches when building manifest.",
+        "body": "manifestBuildIncr() iterates every file in the new manifest and, for each file that will be copied, looks up the matching file in the prior manifest. It located that file with manifestFileExists() and then fetched it with manifestFileFind(), and later wrote the result back with manifestFileUpdate(), which searches for the file by name yet again. That is three binary searches per file where one is enough, so on a cluster with millions of files the loop performs millions of redundant searches.\n\nReduce this to a single search per file. manifestFilePackFindDefault() returns the prior file pack, or NULL when it is missing, in one search instead of the manifestFileExists()/manifestFileFind() pair. manifestFileUpdateByIdx() writes the updated file back using the index already known from the enclosing loop rather than searching for it by name.\n\nMove the file asserts from manifestFileUpdate() down into manifestFilePackUpdate() so both update paths keep the same validation now that manifestFileUpdateByIdx() bypasses manifestFileUpdate()."
+    },
+    {
+        "commit": "a0c14359392e283d88f72e7f9f815d9e78ddfb10",
+        "date": "2026-07-03 16:32:00 +0700",
+        "subject": "Exit async archive-push on first error.",
+        "body": "When the repository was unavailable the async archive-push process kept trying every ready WAL segment, retrying each failure and writing an error file for it. Because the archive queue is only checked at the start of each run, a run could take so long that the WAL volume filled and PostgreSQL stopped before archive-push-queue-max was rechecked.\n\nExit the run as soon as any job errors so the async process is respawned by the next archive-push, which rechecks the queue and drops WAL once it exceeds archive-push-queue-max. Continuing past an error cannot relieve disk pressure because PostgreSQL cannot recycle any WAL past the oldest unarchived segment, so the segments pushed ahead free nothing; the only relief is the queue-max drop. job-retry already absorbs transient failures before they are reported here, so a reported error is a real failure and there is little benefit to continuing.\n\nIn-flight jobs are allowed to finish so their status is recorded and no segment is pushed twice."
+    },
+    {
+        "commit": "a6cba0a018929f381f9dcea50ffd5f0d8fd5806d",
+        "date": "2026-07-03 16:19:15 +0700",
+        "subject": "Retry S3 bucket creation to allow time for Ceph to start up.",
+        "body": "Since Ceph replaced Minio as the documentation S3 server it is slower to start, and the bucket-creation command in the user guide can run before the Ceph RGW endpoint is accepting connections, failing the doc build with \"Could not connect to the endpoint URL\".\n\nAdd a retry to the aws s3 mb command, which is the first command to contact the endpoint since the preceding aws configure set commands only write local config. The executor reruns it until it succeeds or the timeout elapses, so once the bucket is created the versioning command that follows no longer races startup."
+    },
+    {
+        "commit": "7fe363658639bbc2f70e53496fa6da4acb9e481e",
+        "date": "2026-07-03 15:49:46 +0700",
+        "subject": "Fix archive-push-queue-max not enforced when a WAL file errors.",
+        "body": "In asynchronous mode archive-push-queue-max measured the queue against the process list (WAL that still needs to be pushed) rather than the ready list (all WAL that PostgreSQL is waiting to archive). When a WAL file errored repeatedly the async look-ahead kept pushing the later files successfully and writing their ok status files, but PostgreSQL retries the failed file in order and never acknowledges the later ones, so those files dropped out of the process list while their WAL remained in pg_wal. The queue therefore appeared tiny and was never dropped, letting pg_wal fill the disk — exactly the outcome the option exists to prevent.\n\nMeasure the queue against the ready list, as synchronous mode already does. The files that get dropped are unchanged, so writing the ok status for the failed file unblocks PostgreSQL, which then acknowledges the already-pushed files from their existing status files and drains the queue."
+    },
+    {
+        "commit": "a31febfbd9ba639589fe57e4083ae9358b1306a4",
+        "date": "2026-06-30 16:38:40 +0700",
+        "subject": "Reconnect SFTP storage after the server drops an idle connection.",
+        "body": "pgBackRest opens a separate libssh2 session for read and write storage and one can sit idle for many minutes (for example the repository read session during the parallel copy phase of a backup). SFTP servers and intervening firewalls drop such idle connections, and the next use failed with a socket-level libssh2 error because there was no reconnect path.\n\nDetect a lost connection from the libssh2 socket error (SOCKET_RECV, SOCKET_TIMEOUT, SOCKET_DISCONNECT, or BAD_USE), transparently reopen the session, and retry the operation once. Recovery is applied at the read, write, and directory open boundaries, which is where the reported failures occur. SOCKET_SEND is excluded since a failed send is ambiguous, and storageSftpInfo() does not reconnect because it generally runs while a directory listing handle is open.\n\nTo support reopening, the connection sequence is extracted into storageSftpOpen() so it can be run again, the connection parameters are retained on the storage object, and the read and write objects fetch the session through the storageSftpSession()/storageSftpSessionSftp() getters so they pick up a reopened session rather than a cached pointer."
+    },
+    {
+        "commit": "aa0e215019f50f92a8f0c97f907affc1d3bf86c4",
+        "date": "2026-06-30 12:32:46 +0700",
+        "subject": "Fix expire removing a backup in progress on another host.",
+        "body": "During expiration any backup directory on disk that is not present in backup.info is removed. A backup in progress is not added to backup.info until it completes, so when expire runs on one host while a backup runs on another (e.g. expire on a standby while the primary backs up) the in-progress backup is deleted and corrupted.\n\nThe guard that preserves a resumable backup (one with backup.manifest.copy but no backup.manifest) was only applied during adhoc expiration. Apply it during all expiration so an in-progress or resumable latest backup is never removed. The adhoc case, where a resumable dependent of the expired backup is removed when its ancestor no longer exists, is unchanged."
+    },
+    {
+        "commit": "2d767de3c59cf5570639e75755dc73c626fb99e1",
+        "date": "2026-06-30 10:42:59 +0700",
+        "subject": "Fix heap overflow when a pg option is set without pg1.",
+        "body": "The pg group always reserves index 0 for key 1 (pg1) to maintain compatibility with older versions, but the index map was sized only from the keys that were actually configured. When pg options were set at keys other than 1 while key 1 was absent (e.g. pg2-path and pg3-path with no pg1-path) the reserved index was written one element past the end of the map. The stray write landed in allocator slack on glibc but corrupted the heap on musl, causing the segmentation fault reported on Alpine.\n\nThe undersized map also caused the highest-numbered pg path to be silently dropped even where the overflow itself did no visible damage.\n\nSize the map to include the reserved index and set the group index total to the number of entries actually written. The reserved key 1 has no values in this case so it is removed later as a phantom group index, and commands that require pg1-path continue to error as before."
+    },
+    {
+        "commit": "2b8226b44d8537c900b74110306ea4fcf2dd2d12",
+        "date": "2026-06-29 10:47:20 +0700",
+        "subject": "Fix neutral-umask documentation to match actual lock/log modes",
+        "body": "The neutral-umask help text claimed the lock and log directories are created with directory and file modes 0770 and 0660, but the code creates them with the standard defaults of 0750 and 0640. The log directory is also no longer created automatically. Remove the inaccurate sentence so the documentation reflects the code."
+    },
+    {
+        "commit": "d4f697ebce705f9439798f970103fd38f829dfff",
+        "date": "2026-06-29 08:57:07 +0700",
+        "subject": "Hint that pgBackRest may be out of date when a version is unsupported.",
+        "body": "When pgBackRest encounters a PostgreSQL version it does not recognize — looking up the version interface, reading pg_control, or reading a WAL header — it reports the version as unsupported with a single hint asking whether the version is supported. A frequent cause is simply that pgBackRest is out of date on a host, e.g. an old binary on the restore host reading a backup from a newer cluster, but the message gave no indication of this.\n\nAdd a second hint suggesting that pgBackRest may need to be updated on all hosts. Also report the version from pgInterfaceVersion() in user-facing form (e.g. 13 rather than 130000) and use the PG_NAME/PROJECT_NAME macros in place of the hard-coded names."
+    },
+    {
+        "commit": "a1e1542e405dd20bc1d6821ae4fe622e899a8e10",
+        "date": "2026-06-25 17:51:19 +0700",
+        "subject": "Replace Minio with Ceph for S3 documentation and testing.",
+        "body": "The Minio project is no longer maintained and the commercial successor, AIStore, requires an API key even for the free version, which is not very friendly for CI.\n\nUse Ceph instead. While slower, Ceph (in addition to being maintained) has the advantage of correctly handing prefixes with no current versions when listing."
+    },
+    {
+        "commit": "253dbc3f03e5581c98bb97b252dc77b8defd3693",
+        "date": "2026-06-25 15:52:17 +0700",
+        "subject": "Bundle backup files in order rather than scanning for a better fit.",
+        "body": "Previously a file that would push a bundle over repo-bundle-size was skipped in the hope that a smaller file later in the queue would fit, which kept bundles under the target size at the cost of additional file unpacks.\n\nNow files are added to the bundle in queue order and the bundle is closed once it reaches repo-bundle-size. As a result a bundle may exceed the target size by up to repo-bundle-limit, i.e. the size of the file that crosses the threshold, which is now noted in the help for repo-bundle-size.\n\nIn addition to the immediate benefits, this is important for a future commit where preserving bundle order from the prior backup is important."
+    },
+    {
+        "commit": "23e966cd8f17a8cd446b04901d0ae66ebf4118ee",
+        "date": "2026-06-25 15:31:53 +0700",
+        "subject": "Report the underlying error when a query fails to complete.",
+        "body": "After processing a query result, pgClientQuery() drained the connection with a CHECK that the next PQgetResult() returned NULL, raising a generic ServiceError (\"NULL result required to complete request\") when it did not. This fires when the connection is lost after the first result is delivered but before the command completes, e.g. under load, so the message exposed none of the actual cause and discarded the extra result that held it.\n\nFetch the extra result, raise a DbQueryError that includes its error message, and free it. Add hints pointing at a lost connection, aggressive idle_session_timeout / idle_in_transaction_session_timeout settings, and the PostgreSQL log and network as the likely causes."
+    },
+    {
+        "commit": "b5a578a5c2c88d53fca0ee8cfbfb8ee662ce7e48",
+        "date": "2026-06-24 10:43:30 +0700",
+        "subject": "Add S3 process authentication.",
+        "body": "Add a process value to repo-s3-key-type and a repo-s3-process-cmd option that specifies a command (and optional arguments) to execute for retrieving temporary S3 credentials. The first list entry is the command and the remaining entries are passed as parameters.\n\nThe process must output JSON containing AccessKeyId, SecretAccessKey, SessionToken, and Expiration fields, following the AWS process credential provider format. Credentials are automatically refreshed before the expiration time."
+    },
+    {
+        "commit": "f5aa587fa482f82fa4d8e1829e35407425b1f183",
+        "date": "2026-06-22 20:25:34 +0700",
+        "subject": "Add sponsors."
+    },
+    {
+        "commit": "d72bea9fe7c3975fc6832a51b0b0c1c041c467d2",
+        "date": "2026-06-19 15:24:17 +0700",
+        "subject": "Fetch the libssh2 session from storage in SFTP read/write objects.",
+        "body": "The SFTP read and write objects cached the libssh2 session and sftp session pointers passed to their constructors. Add storageSftpSession() and storageSftpSessionSftp() getters and fetch the session from the storage object instead, removing the session parameters from storageReadSftpNew() and storageWriteSftpNew().\n\nFetching the session on demand means the read and write objects always use the storage object's current session rather than a copy taken at construction. The will be used in a future commit to pick up a new session after transparently reopening a connection the server dropped while idle."
+    },
+    {
+        "commit": "7da81569a0f43fdd580f01a329c626cf7213c10e",
+        "date": "2026-06-19 14:12:01 +0700",
+        "subject": "Remove the unused sftpHandle field from the SFTP storage driver.",
+        "body": "StorageSftp carried an sftpHandle field that production code never set. Directory listing opens a local handle, and each read/write object opens and owns its own handle in its open function, so this field was always NULL.\n\nDespite that it was passed to storageReadSftpNew() and storageWriteSftpNew(), which immediately overwrite their own sftpHandle when the file is opened, and was \"closed\" in storageSftpLibSsh2SessionFreeResource(). Both paths were dead.\n\nRemove the field, the constructor parameter (and its function log), and the close block in the free resource. Drop the unit tests that populated the field to exercise the removed close path, and extend the free-resource branch test so the sftp_shutdown EAGAIN retry loop stays covered."
+    },
+    {
+        "commit": "af586e230e5a17467e5e4051f4a655db154a1356",
+        "date": "2026-06-19 12:39:40 +0700",
+        "subject": "Throw real SFTP read-open errors instead of masking them as missing.",
+        "body": "Previously storageReadSftpOpen() only inspected the failure when the libssh2 error was LIBSSH2_ERROR_SFTP_PROTOCOL or LIBSSH2_ERROR_EAGAIN. Any other error (e.g. a socket error such as LIBSSH2_ERROR_SOCKET_RECV) fell through silently, leaving a NULL handle and causing the storage layer to report the file as missing.\n\nThrow on any open failure except a genuine missing file (SFTP_PROTOCOL + LIBSSH2_FX_NO_SUCH_FILE), which is still returned to the caller via the result so ignoreMissing continues to work. This brings read-open error handling in line with storageWriteSftpOpen()."
+    },
+    {
+        "commit": "1c57106e2dc1f5df45eec71145d03feb32c5ae49",
+        "date": "2026-06-19 11:36:42 +0700",
+        "subject": "Simplify error handling in SFTP storageWriteSftpOpen().",
+        "body": "The nested LIBSSH2_ERROR_SFTP_PROTOCOL check called storageSftpEvalLibSsh2Error() identically in both branches, so collapse it into a single condition that throws FileMissingError for the no-such-file case and otherwise falls through to storageSftpEvalLibSsh2Error(). This is safe because storageSftpEvalLibSsh2Error() already omits the sftp error detail when the error is not a protocol error, and libssh2_sftp_last_error() can be read unconditionally since it has no side effects."
+    },
+    {
+        "commit": "b2106121e69b7a42607a27d61f3715ce401d15c2",
+        "date": "2026-06-18 13:28:31 +0700",
+        "subject": "Use a storage feature to gate remove errorOnMissing.",
+        "body": "The Azure, GCS, and S3 drivers each asserted that errorOnMissing was never set in their remove function, hardcoding in every driver the fact that it cannot detect a missing file on remove. That capability was implied by an assert scattered across the drivers rather than declared anywhere.\n\nAdd a storageFeatureFileRemoveMissing feature that a driver sets when it can report a file as missing on remove, and enable it for the Posix driver (but not CIFS, which shares the driver). Move the check into storageRemove(), which now asserts errorOnMissing is set only when the storage supports the feature, and drop the redundant per-driver asserts along with the now-unused errorOnMissing log parameter."
+    },
+    {
+        "commit": "9ea20ad9d07d339af6cbaf7c0989b04f0aece9b7",
+        "date": "2026-06-18 12:32:20 +0700",
+        "subject": "Bring SFTP storageRemove() in line with the other repository storage drivers.",
+        "body": "The SFTP driver, like the Azure, GCS, and S3 drivers, is only ever used for repositories, and no repository code path requests errorOnMissing on remove. Those cloud drivers therefore assert that errorOnMissing is never set, but storageSftpRemove() still honored it.\n\nAssert that errorOnMissing is never set and drop it from the remove logic, so a missing file is always ignored and every other libssh2/SFTP result is raised. This matches the cloud drivers and removes a code path that was never exercised in production."
+    },
+    {
+        "commit": "3ce84b97a72181e7a2d7453aee1383fe9784ada4",
+        "date": "2026-06-18 00:30:29 +0700",
+        "subject": "Change storage for storageMoveP() call in storage/posix unit test.",
+        "body": "Since the source file will be deleted the specified storage needs to be the same storage as the source file and writable.\n\nCurrently there is a loophole what allows this to work but it will be enforced in a future commit."
+    },
+    {
+        "commit": "c869963f8cbe1bd7eefc5d6f241936c07aaf21f6",
+        "date": "2026-06-18 00:05:05 +0700",
+        "subject": "Error on SFTP remove failures other than missing file.",
+        "body": "storageSftpRemove() only raised an error for a libssh2 LIBSSH2_ERROR_SFTP_PROTOCOL result; any other result (e.g. a transport failure such as LIBSSH2_ERROR_SOCKET_SEND) was silently treated as a successful removal unless errorOnMissing was set. A send failure says nothing about whether the file was removed -- the request may never have reached the server -- so the file could remain on the repository while pgBackRest believed it was gone.\n\nRaise an error for every result except a genuine LIBSSH2_FX_NO_SUCH_FILE when errorOnMissing is not set, which is the only case where a failed remove legitimately maps to success."
+    },
+    {
+        "commit": "ce33913a80697e2d2873e4e8d8975eb09bbf6bd3",
+        "date": "2026-06-17 22:44:13 +0700",
+        "subject": "Unify the file remove error message.",
+        "body": "storageRemove() (Posix and SFTP) threw the ad-hoc \"unable to remove '%s'\" while path remove used STORAGE_ERROR_PATH_REMOVE_FILE \"unable to remove file '%s'\", so the same failure was reported two different ways depending on the entry point.\n\nReplace STORAGE_ERROR_PATH_REMOVE_FILE with STORAGE_ERROR_FILE_REMOVE and use it for both single-file and recursive path removal, so every file removal failure now reads \"unable to remove file '%s'\". The SFTP path remove detail is also separated with a colon (\"...': libssh sftp [...]\") to match similar messages instead of a bare space."
+    },
+    {
+        "commit": "7fd8bc89a15cb039111aa85fd37f9dc68f7c4d6d",
+        "date": "2026-06-17 12:22:42 +0700",
+        "subject": "Fix potential buffer overrun in error module.",
+        "body": "errorInternalThrow() called strncpy(stackTraceBuffer, stackTrace, n - 1) followed by messageBuffer[n - 1] = '\\0' -- a copy-paste bug that wrote the NUL terminator into the wrong buffer.\n\nSince both buffers are ERROR_MESSAGE_BUFFER_SIZE the errant write was in-bounds and messageBuffer was already terminated, so the bug was silent in practice. But when stackTrace's length >= sizeof(stackTraceBuffer) - 1, strncpy() does not null-terminate, leaving stackTraceBuffer non-terminated and exposing errorContext.error.stackTrace to over-read by any consumer."
+    },
+    {
+        "commit": "5b77f9bc22fc8b7bb42a29df0ab74ff1d87a0c8d",
+        "date": "2026-06-17 12:15:48 +0700",
+        "subject": "Refactor SFTP unit tests.",
+        "body": "Replace the verbose, hand-built HrnLibSsh2 script entries in the SFTP unit tests with a set of per-function HRN_LIBSSH2_* response macros (one per libssh2 shim function). Each macro names its function, bakes in the fixed parameters the production code always passes, and defaults the common result, so a test supplies only the values that vary as trailing designated initializers.\n\nThe harness now defaults omitted values rather than requiring every field to be spelled out: libssh2_session_hostkey() defaults length/type/value; libssh2_sftp_stat_ex() defaults an omitted .attr to a regular file with mode 0640, defaults .flags to the standard attribute set (adding a size for regular files), and defaults .uid/.gid to the test user/group. Add HRN_LIBSSH2_ATTR_EXISTENCE (path exists but reports no attributes) and HRN_LIBSSH2_OWNER_ROOT (report ownership by root) sentinels, plus HRN_LIBSSH2_DIR/FILE/LINK/FIFO() helpers that OR a file type with an octal mode.\n\nReplace the NULL-terminated script array and hrnLibSsh2ScriptSet(array) with HRN_LIBSSH2_SCRIPT_SET(...), which computes the script length so no terminator entry is needed; hrnLibSsh2ScriptSet() now takes an explicit size. Rebuild HRNLIBSSH2_MACRO_STARTUP/SHUTDOWN() and HOSTKEY_HASH_ENTRY() on top of the new macros, and stat_ex now verifies the requested stat_type (via .follow) instead of scripting it as a parameter.\n\nReorganize the tests themselves: split bundled comment groups into TEST_TITLE sections, split scripts per section, and drop redundant connect/disconnect setup. Remove tests that duplicate Posix tests for common code. Remove duplicative SFTP tests. Rename HrnLibSsh2 fields for clarity (attrPerms -> attr/mode, symlinkExTarget -> target).\n\nThese changes cut sftpTest.c roughly in half."
+    },
+    {
+        "commit": "ffa325b8a44c1e9e44dc038bbcc8aece6f312a90",
+        "date": "2026-06-17 11:24:30 +0700",
+        "subject": "Add batch delete for Azure storage.",
+        "body": "Path remove (used by expire and friends) issued one HTTP DELETE per file. Use the Azure Blob Batch API to remove up to 256 objects per request, as the GCS driver already does, by sending the deletes as multipart sub-requests.\n\nAzure's batch parser is stricter than the MIME/OData spec it is based on: it requires the body to begin with the boundary delimiter (no leading CRLF preamble) and splits header lines on \": \", so the multipart builder now emits the opening delimiter without a leading CRLF and writes the MIME part headers and embedded sub-request headers in the \"Name: value\" form. The multipart request code is shared with the GCS driver, which accepts either form.\n\nAzure omits the blank line that terminates the headers of an empty-body sub-response, relying on the boundary's CRLF as the terminator, so multipart response header parsing now allows eof to end the header block.\n\nSub-requests that fail (not 2xx or 404) are retried individually. A failed part is mapped back to the original request by its position in the response rather than the echoed content-id header, since Azure omits content-id on some error responses."
+    },
+    {
+        "commit": "34bba828c6ba97579d65c2199c02d94bf31257a5",
+        "date": "2026-06-14 16:41:31 +0700",
+        "subject": "Harden HTTP chunked response parsing.",
+        "body": "Tolerate chunk extensions by stripping everything from the first ';' on the chunk-size line before parsing the hex size, and consume any chunk trailers (and the blank line that terminates them) following the terminating zero-size chunk so the connection is left aligned for reuse.\n\nTreat the transfer-encoding value case-insensitively so \"Chunked\" is accepted as \"chunked\".\n\nReject a response that sets both transfer-encoding and content-length even when content-length is 0. The previous check keyed off contentSize > 0, so a zero content-length slipped through. Track whether the header was present with a dedicated flag and reject the ambiguous combination uniformly, as RFC 7230 permits."
+    },
+    {
+        "commit": "bc6d399a6a160f5fa41dd3a98ae046dff66e56a8",
+        "date": "2026-06-14 16:18:33 +0700",
+        "subject": "PostgreSQL 19beta1 support.",
+        "body": "Add PostgreSQL 19 as an unreleased version (release: false) and vendor its control/checkpoint structures, catalog and control versions, and XLOG_PAGE_MAGIC.\n\nPostgreSQL 19 stores data_checksum_version in pg_control as a four-state ChecksumStateType enum (OFF, VERSION, INPROGRESS_OFF, INPROGRESS_ON) rather than the prior 0/1 value. Validate the field against the version-appropriate maximum and clear the in-progress states to 0, since page checksums cannot be relied on while checksums are being enabled or disabled. Consumers of pageChecksumVersion therefore continue to see only 0 or 1.\n\nAdd the PG19 test harness and the supporting Perl/CI plumbing (DbVersion, VmTest, container build) and adjust the integration test matrix."
+    },
+    {
+        "commit": "dde263d699bade3ba791c6da1f4813873c3b0fee",
+        "date": "2026-06-14 10:14:19 +0700",
+        "subject": "Clarify zero-size chunk comment in HTTP response parsing.",
+        "body": "The previous \"still zero\" wording leaned on the reader tracking that contentRemaining was zero on entry and remained zero after parsing the next chunk size. State the actual meaning instead: a zero-size chunk terminates the response."
+    },
+    {
+        "commit": "e166a33f48a00192c09b0f1cea3465243c03d1f1",
+        "date": "2026-06-13 12:46:46 +0700",
+        "subject": "Prevent recursive exit() on signal.",
+        "body": "musl 1.2.6 intentionally crashes when exit() is called recursively, which happened when a signal arrived while exit() was already in progress, e.g. when a server terminated a child that was already exiting. Set a flag when exit is in progress so exitOnSignal() ignores the signal and allows the in-flight exit() to complete. Reset the flag in exitInit() since a forked child may inherit it from a parent that was exiting.\n\nAlso call exitSafe() before notifying the parent in the server tests so a signal sent in response to the notification cannot arrive before the exit in progress flag is set.\n\nAdd Alpine 3.24 to CI to exercise the unit tests against musl 1.2.6, which is where this crash was found."
+    },
+    {
+        "commit": "aca779a6ec3f4d6ba1d7c2d5c8bbb2fa64e215ef",
+        "date": "2026-06-13 12:18:33 +0700",
+        "subject": "Run integration tests on Alpine 3.21 (musl libc).",
+        "body": "Drop the c-only restriction for the a321 CI job so the full unit and integration suites run on musl libc, exercising the integration tests (including SFTP) against Alpine in addition to glibc.\n\nApply the ssh-rsa HostKeyAlgorithms/PubkeyAcceptedAlgorithms workaround to a321 as well as u22, since Alpine 3.21 ships OpenSSH 9.x which no longer offers the SHA-1 ssh-rsa host-key algorithm by default and the libssh2 client requires it (otherwise the SFTP handshake fails key exchange with LIBSSH2_ERROR_KEX_FAILURE).\n\nSuppress the libssh2_session_init_ex and libssh2_session_handshake \"possibly lost\" leaks reported by valgrind during SFTP integration. These are persistent allocations tied to the session lifetime and are flagged only on the Linux CI runner where valgrind wraps the integration test binary. The suppressions go in valgrind.suppress.none because integration tests always run with vm none.\n\nGeneralize hrnHostPgBinPath() to probe the Debian, RHEL, and Alpine PostgreSQL bin paths in turn rather than hardcoding two, and throw a clear assert if none match.\n\nAdd a321 to the default VM list, install PostgreSQL 15/16/17 on Alpine, and point VMDEF_PGSQL_BIN at the Alpine layout. Rebuild the a321 base image accordingly."
+    },
+    {
+        "commit": "760dd8db69e7c6e5cbb9c5b7e2067b6813cf4497",
+        "date": "2026-06-12 21:34:45 +0700",
+        "subject": "Fix Alpine group conflicts in CI containers.",
+        "body": "Handle /etc/group entries with non-empty member fields when renaming TEST_GROUP_ID and only create the Alpine group when it does not already exist."
+    },
+    {
+        "commit": "3ce9fb95636c223461c0b321e39fb3ca917c4dbc",
+        "date": "2026-06-12 21:04:06 +0700",
+        "subject": "Update Fedora CI container to Fedora 44."
+    },
+    {
+        "commit": "cb694fcb4d46e770897dc6824497efaae2762530",
+        "date": "2026-06-12 20:57:16 +0700",
+        "subject": "Update (almost) EOL Debian 11 to Debian 12 in CI.",
+        "body": "Debian 11 will be EOL just after the next release but it is also a blocker for some planned work due to old package versions. It seems fine to just expire it a bit early.\n\nAlso update the integration tests to run Debian 12 on Posix since Azure is not supported on i386."
+    },
+    {
+        "commit": "3e2e3b1ff057147b356dd28b6b38c143799fb764",
+        "date": "2026-06-12 11:46:58 +0700",
+        "subject": "Add code count exclusion for SVG files."
+    },
+    {
+        "commit": "464f3020a9c4de2f82c5bfaabffaacfb6d0cfd7b",
+        "date": "2026-06-12 10:11:49 +0700",
+        "subject": "Move ignoreMissing out of the storage read drivers.",
+        "body": "Previously each read driver decided whether a missing file was an error, which duplicated the ignoreMissing logic across the Posix, SFTP, remote, S3, Azure, and GCS drivers. Now driver open() simply reports whether the file exists and StorageRead throws FileMissingError when missing files are not ignored.\n\nSince the client now makes this decision, ignoreMissing no longer needs to be passed through the remote protocol and a missing file is reported locally rather than as an error raised from the remote."
+    },
+    {
+        "commit": "2b7825ad4695aeee5e8fc44038ba8caf06c8d1a1",
+        "date": "2026-06-11 12:10:35 +0700",
+        "subject": "Add valgrind suppressions for libbacktrace unwind false positives.",
+        "body": "When libbacktrace is enabled, throwing an error calls backtrace_full(), which unwinds the stack with libgcc's _Unwind_Backtrace. On aarch64 the unwinder (and glibc's _dl_find_object, which it calls to look up unwind tables) branches on values valgrind considers uninitialised. Since tests run under valgrind with --exit-on-first-error=yes, the false positive aborted any test that happened to trip it, e.g. storage/sftp.\n\nSuppress Cond and Value8 errors that originate inside _Unwind_Backtrace when called from backtrace_full."
+    },
+    {
+        "commit": "eaac49e3c28d61e5121260b62dc31111fa6a7830",
+        "date": "2026-06-09 13:27:53 +0700",
+        "subject": "Move issue template to new format required by Github.",
+        "body": ".github/ISSUE_TEMPLATE.md is no longer filling new issues even though it should still be working according to the documentation.\n\nRather than fight the system just move to the new format."
+    },
+    {
+        "commit": "6c518001c24ad2405eaf750d358f69703322a221",
+        "date": "2026-06-09 12:37:48 +0700",
+        "subject": "Add support for S3 Outposts.",
+        "body": "Add a repo-s3-service option that controls the SigV4 signing service name. Defaults to 's3' for standard S3 endpoints. Set to 's3-outposts' when using an S3 Outposts endpoint.\n\nThe signing service is used in the credential scope, HMAC signing key derivation, and authorization header. The option accepts free-form input to support future AWS service variants."
+    },
+    {
+        "commit": "a953aa74b51e05cde3e5ace02473442f941da7f9",
+        "date": "2026-06-09 11:23:15 +0700",
+        "subject": "Invert storage read/write interface ownership.",
+        "body": "Previously, drivers constructed StorageRead/StorageWrite objects directly and stored metadata in a shared interface struct. Now, StorageRead/StorageWrite create the driver via storageInterfaceNewReadP()/NewWriteP() and mediate between IoRead/IoWrite and the driver. Drivers return opaque objects and own their metadata independently.\n\nThis loosens the tight coupling between drivers and the StorageRead/StorageWrite layer. The remote write driver replaces its back-pointer to StorageWrite with a filterGroup callback, eliminating the circular dependency. It makes retry in StorageRead much more readable.\n\nAlso move the logic for testing whether a file version could not be found out of the drivers and into StorageRead."
+    },
+    {
+        "commit": "71f52f7d923211d6e5641c0aac61fd4d8da8e966",
+        "date": "2026-06-08 17:15:27 +0700",
+        "subject": "Remove extraneous pathSync test in the SFTP storage driver.",
+        "body": "The driver does not implement path sync so there is not reason to test the behavior."
+    },
+    {
+        "commit": "7d4c0d58edd6f62170b57e9b3372360d4336ae94",
+        "date": "2026-06-08 17:08:58 +0700",
+        "subject": "Test the Posix driver for syncPath rather than StorageWrite.",
+        "body": "The syncPath value in StorageWrite is for informational purposes and does not determine if the path is actually synced or not.\n\nInstead probe the Posix driver to make sure that syncPath is disabled so there is no error on CIFS."
+    },
+    {
+        "commit": "0c62043419d46437b8a63637162e7554cbef495a",
+        "date": "2026-06-04 15:07:50 +0700",
+        "subject": "Rename execOne() to execOneExpect().",
+        "body": "This clears the way to use the shorter version in the core code."
+    },
+    {
+        "commit": "beb189fbb3c467244580cc58a3966a9ddd5c689c",
+        "date": "2026-06-04 11:31:44 +0700",
+        "subject": "Add repo-s3-key-type=pod-id documentation missed in 79544f64."
+    },
+    {
+        "commit": "c02ddc3ad993485e6aca50aa26fa5a0f9e5b3232",
+        "date": "2026-06-01 12:59:46 +0900",
+        "subject": "Update lock-threads action version.",
+        "body": "Also remove unused PR settings."
+    },
+    {
+        "commit": "e1cbd5b55c65d34b4c471a179f674d1d0f9aa772",
+        "date": "2026-05-29 12:15:28 +0900",
+        "subject": "New CI container builds.",
+        "body": "These should have been updated in 742fff17 when libsystemd was added but doing it now includes the last PostgreSQL minor releases."
+    },
+    {
+        "commit": "1e6d23fea72ac9c599f8b62a2e0a3de02d0d08d0",
+        "date": "2026-05-29 10:36:48 +0900",
+        "subject": "Add user/group caching for faster manifest build.",
+        "body": "On systems where uid/gid lookups are routed to a remote name service (sssd, systemd-userdbd, LDAP, etc.), every getpwuid()/getgrgid() call incurs a Unix socket round-trip. This dominates the manifest build phase for clusters with millions of files, even though the data files almost always share a single owner.\n\nAdd a small fixed-size (16-entry) per-process cache for userNameFromId() and groupNameFromId(). Linear scan is faster than a hash table at this size. Negative results (unknown ids) are also cached. Cache overflow falls through to uncached lookups."
+    },
+    {
+        "commit": "2cc9898fa14e10ba04f5ab6d213cafbb695369fa",
+        "date": "2026-05-28 22:17:30 +0900",
+        "subject": "Remove extraneous const."
+    },
+    {
+        "commit": "742fff174a3f5baaed932afa284334ca2aa1be82",
+        "date": "2026-05-19 11:37:48 +0900",
+        "subject": "Add systemd notify integration.",
+        "body": "Allow systemd to have a better understanding as to when pgBackRest has finished starting or is stopping.\n\nThis implementation is based off of the existing implementations in\nPostgreSQL [1] and PgBouncer [2]. PgBouncer also has an\nimplementation for `notify-reload` but this is not implemented here\nas it is a very recent feature [3] that is unavailable on many Linux\ndistributions.\n\n[1] https://www.postgresql.org/message-id/flat/CAFj8pRA4%3DhVj-d%3D8O7PSMjopsFUHPcAftd5tLqFC_xb035hNQA%40mail.gmail.com#e346a6189d8b0ed44c745c4aaaef587f\n[2] https://github.com/pgbouncer/pgbouncer/commit/3816a0073f09944a6f7eaa278d2226ca4942b911\n[3] https://github.com/systemd/systemd/blob/fa6d3bffe30064c4d4092b3daa749465f08d35fb/NEWS#L6176"
+    },
+    {
+        "commit": "3a6c67183cd9c6a12c24f0d978ef5e501b7c3fcf",
+        "date": "2026-05-19 10:19:58 +0900",
+        "subject": "C11 is now the minimum C standard.",
+        "body": "This standard is over fifteen years old and the features we are interested in seem well supported on popular compilers.\n\nThe main advantage is that static_assert() will now display the specified message on error rather than the ever-cryptic `negative width\nin bit-field '__error_if_negative'`. Now that we can depend on having\nstatic_assert() we can replace our STATIC_ASSERT_STMT() macro.\n\nReplace our ALIGN_OF() macro with alignof().\n\nReplace our FN_NO_RETURN macro with noreturn. Include stdnoreturn.h in build.h to avoid needing to include it in many header files.\n\nUse an anonymous union in common/type/json.c where it simplifies syntax.\nOther uses of union seem better as they are."
+    },
+    {
+        "commit": "6a40144d91a1e304f39f8fb1fd0e17e57a84b3df",
+        "date": "2026-05-18 20:27:00 +0900",
+        "subject": "Add sponsors and announcement that pgBackRest will continue."
+    },
+    {
+        "commit": "91b8dd60351c53b6a90c6aa3ce0d938ceb861cab",
+        "date": "2026-05-18 20:14:45 +0900",
+        "subject": "Add news page.",
+        "body": "Move recent announcements that were added to the top of the homepage."
+    },
+    {
+        "commit": "e0c934d231e9cfda4f63e2c8831915cf8b23319d",
+        "date": "2026-05-18 10:05:02 +0900",
+        "subject": "Fix documentation typos."
+    },
+    {
+        "commit": "892b60bc7908b3d2d7825f611e72f25a958a9019",
+        "date": "2026-05-17 11:56:56 +0900",
+        "subject": "Add dark mode favicon.",
+        "body": "In dark mode the black favicon was barely visible. Use a white favicon in dark mode instead.\n\nAlso, use the new SVG logo for the favicon and update logo.png to the new style."
+    },
+    {
+        "commit": "7ad4fd21c1e0c9c715f4241f184e9e01bfb49929",
+        "date": "2026-05-16 16:55:12 +0900",
+        "subject": "Remove attribution for armchair icon since it is now licensed."
+    },
+    {
+        "commit": "684f12c6cb3ea8852a59d2ae32e709f1f4dc3e3f",
+        "date": "2026-04-27 13:17:20 +0900",
+        "subject": "Remove information about v1 releases.",
+        "body": "These releases do no support any current version of PostgreSQL so they are of limited value."
+    },
+    {
+        "commit": "77312b33ba913132b33401d862c2e354f323c786",
+        "date": "2026-04-14 14:51:42 +0700",
+        "subject": "Add per-repo backup progress to info command output.",
+        "body": "When backups are running on multiple repositories simultaneously, the info command now reports per-repo progress in addition to the existing overall progress. A new repo array is included in JSON output for backup locks. This avoids confusing progress jumps when one repo finishes before another."
+    },
+    {
+        "commit": "ce8bb04d5b91b41a5b5f9218f622de775a50ab29",
+        "date": "2026-04-14 12:40:33 +0700",
+        "subject": "Limit CI permissions on the repository to read."
+    },
+    {
+        "commit": "2ef86735347e2d5f93d8a484f26dcb5e4f88f01d",
+        "date": "2026-04-14 12:34:32 +0700",
+        "subject": "Remove CodeQL CI job.",
+        "body": "This job has never surfaced any useful data and now it is failing, so remove it.\n\nIt appears that CodeQL can now be automated directly within the Github interface, so that seems like a better route if we decide to reenable it."
+    },
+    {
+        "commit": "afd6939656db0934e3557efc9acdcbe5074aabd4",
+        "date": "2026-04-13 18:22:49 +0700",
+        "subject": "Allow FreeBSD tests to continue running even if one fails."
+    },
+    {
+        "commit": "c823ce2f7cc714bdba589fb37ea9497e9acbf977",
+        "date": "2026-04-13 18:19:41 +0700",
+        "subject": "Update GitHub Actions versions."
+    },
+    {
+        "commit": "45987413d3b99d530d5627177b83bf67d0a26d25",
+        "date": "2026-04-13 18:11:36 +0700",
+        "subject": "Migrate Cirrus CI tests to Github Actions.",
+        "body": "Cirrus CI is shutting down on June 1 so migrate all tests. This could have been done before, probably, but it was not clear how to run FreeBSD on Github Actions. The cross-platforms-actions action solves that problem.\n\nFix a couple of minor test issues found on MacOS.\n\nAlso remove the dead make-cmd option. This has not been valid since the migration to meson."
+    },
+    {
+        "commit": "d3cdff17f5c038807045c26c604eed6677c6749b",
+        "date": "2026-04-10 13:26:21 +0700",
+        "subject": "Migrate documentation block rendering to C.",
+        "body": "This also requires a fair amount of support code that cannot be removed from Perl yet."
+    },
+    {
+        "commit": "ff69fcb6714d215cf55e1a8e08b04e5c0a0649f0",
+        "date": "2026-04-07 10:20:29 +0700",
+        "subject": "Remove obsolete Perl code."
+    },
+    {
+        "commit": "7f82fb6635c1e3e9dd285d53076e9aee3fbf1ca2",
+        "date": "2026-03-30 16:39:44 +0700",
+        "subject": "Add backup.info checks to verify command.",
+        "body": "Verify currently checks only backup directories present in the repository and does not validate consistency with backup.info. As a result, discrepancies between the repo contents and backup.info may go unnoticed.\n\nWarn if a backup directory exists but is not described in backup.info. Warn if a backup is listed in backup.info but missing on disk. Add backups found only in backup.info (but not on disk) to the processing list so that verify command reports their status as manifest missing."
+    },
+    {
+        "commit": "6704ffacfbf8f6a65353268cb0c036289c2d3610",
+        "date": "2026-03-24 15:04:52 +0700",
+        "subject": "Test changes in preparation for additional verification of backup.info."
+    },
+    {
+        "commit": "6e4f10203fef225f29590ea9bffa4990417e9cbd",
+        "date": "2026-03-23 11:22:25 +0700",
+        "subject": "Remove unused backtrace-supported.h include.",
+        "body": "This header is only useful for autoconf builds and in any case it was not being used correctly."
+    },
+    {
+        "commit": "088537454983f5d040f9b857e60ed0939220541b",
+        "date": "2026-03-23 10:44:57 +0700",
+        "subject": "Add alternate error to common/io/tls test module for WSL."
+    },
+    {
+        "commit": "e54b4a42fd15291e872b937b23d92867237d8f7f",
+        "date": "2026-03-17 11:46:33 +0700",
+        "subject": "Move archiveAsyncExec() to command/command module and rename.",
+        "body": "Spawning an async process is useful for more than archive-get/push so move the function to a module used by all commands."
+    },
+    {
+        "commit": "9016b362fcf6ca04031716cd49216f9e69f35108",
+        "date": "2026-03-07 21:46:15 +0700",
+        "subject": "Comment out unused CSS elements.",
+        "body": "These are useful to denote elements that could be styled but currently work with defaults. However, CSS linters dislike empty rules so comment them out. This was already done with some rules but not followed consistently."
+    },
+    {
+        "commit": "6d7ddc3e0a6fc62fee002fbd689cf4205b726ff8",
+        "date": "2026-03-07 15:35:11 +0700",
+        "subject": "Add support for sponsors in the documentation.",
+        "body": "This allows logos to be displayed for sponsors in HTML on the homepage.\n\nThe markdown will continue to list sponsors in text but the list will be pulled from the new XML."
+    },
+    {
+        "commit": "4397d122470d4309f86186f885f74a07be132fc6",
+        "date": "2026-03-04 21:37:13 +0700",
+        "subject": "Remove FreeBSD 13 and add FreeBSD 15 to Cirrus CI.",
+        "body": "FreeBSD 13 will be EOL soon after the next release."
+    },
+    {
+        "commit": "8e711d40cbf6775b01aad9818388a45c36c7ae7f",
+        "date": "2026-03-04 20:15:55 +0700",
+        "subject": "Update Fedora test image to Fedora 43."
+    },
+    {
+        "commit": "9bb26a5065e36c1776b04129eecb02b1bddfd3b9",
+        "date": "2026-03-04 17:16:18 +0700",
+        "subject": "Update PostgresQL versions in user guide.",
+        "body": "PostgreSQL 13 is EOL and no longer available in the yum.postgresql.org repository.\n\nUpdate the base and upgrade versions of the RHEL and Debian documentation to better cover supported versions."
+    },
+    {
+        "commit": "4a2008c6ed218ad6773cfd83e49ac56c8242b525",
+        "date": "2026-02-23 16:51:21 +0700",
+        "subject": "Ensure backup-timestamp-start is non-zero in unit tests.",
+        "body": "The unit tests do not require this field to be non-zero so in general it has not been set.\n\nHowever, in production this field is always set and can be used to calculate timestamp deltas, which will be useful in a future commit.\n\nCommit the test changes separately to show that there is no change in behavior."
+    },
+    {
+        "commit": "b908d5e2c5b37ef968f19e2c40a1001e19e5b87f",
+        "date": "2026-02-21 08:37:31 +0700",
+        "subject": "Improve seek performance during block incremental delta restore.",
+        "body": "The prior code issued a seek for each block even if the file was in the correct position. The extra call to lseek() was probably not too expensive but a flush was also required in case of a seek on the next loop. Flushing the write buffer after each block (which is often 8KiB) was definitely wasteful.\n\nFix this by adding seek to the IoWrite interface. That means the file position can be tracked and calls to seek/flush are only done when needed.\n\nSeek during write is only used in PGDATA during restore so seek functionality is only added to the Posix driver."
+    },
+    {
+        "commit": "009644b443b755cd1f407a7ba34ebbf273608346",
+        "date": "2026-02-20 17:56:30 +0700",
+        "subject": "Update always_inline to __always_inline__.",
+        "body": "This is the preferred syntax to avoid conflict with user-defined macros."
+    },
+    {
+        "commit": "2c747f277e0869a130fafc135a78d2f87af96acf",
+        "date": "2026-02-20 13:14:01 +0700",
+        "subject": "Add meson check for __builtin_types_compatible_p().",
+        "body": "This check was lost in the migration from autoconf which means that the UNCONSTIFY() macros has not been enforcing since then.\n\nAdd the check so UNCONSTIFY() enforces as expected."
+    },
+    {
+        "commit": "fc42e85d8c73473558006675e2a2a312fb7e0801",
+        "date": "2026-02-19 22:53:52 +0700",
+        "subject": "Fix incorrect postgres/interface unit test title."
+    },
+    {
+        "commit": "119c089cccccd773bc8eb517f82ec6c36e5fb37d",
+        "date": "2026-02-19 22:33:05 +0700",
+        "subject": "Update uncrustify to recognize .c.inc files.",
+        "body": "But ignore .auto.c.inc and .vendor.c.inc files."
+    },
+    {
+        "commit": "1ce2522e359e9968087562dd5db94f248370780e",
+        "date": "2026-02-19 22:28:36 +0700",
+        "subject": "Refactor info/manifest module into included modules.",
+        "body": "Similar to 1db52ef9 break up this module to make it more maintainable."
+    },
+    {
+        "commit": "27fff599eef3575d9751ed4e5907debcc05372b4",
+        "date": "2026-02-19 22:23:01 +0700",
+        "subject": "Move info/manifest.c to info/manifest/manifest.c.",
+        "body": "This module will be split up so move it to its own path first."
+    },
+    {
+        "commit": "cf003f67e71b33cf83a653ff5c918b551e2d47be",
+        "date": "2026-02-17 15:05:33 +0700",
+        "subject": "Move static build defines to build.h.",
+        "body": "Putting these defines in meson.build is a bit annoying because of the added syntax and double commenting. Since the defines are static there is no good reason to have them there.\n\nThis also creates a place for test builds to add global defines -- again rather than in meson.build."
+    },
+    {
+        "commit": "b9eb7f811307c070d4015ebbb64eb9dc3b231a66",
+        "date": "2026-02-16 10:00:35 +0700",
+        "subject": "Fix test error message typos and add error details."
+    },
+    {
+        "commit": "27319dde50194a055a746d3b3c2e68f711a8e13f",
+        "date": "2026-02-16 09:03:39 +0700",
+        "subject": "Explicitly free block map read in restoreFile().",
+        "body": "This will be freed when the current file is complete but freeing it before the write is opened saves memory."
+    },
+    {
+        "commit": "17db234f1bbdef7f57d2c80cd41473016c5eb893",
+        "date": "2026-02-14 12:57:35 +0700",
+        "subject": "Reverse sort order in backup and restore comparators.",
+        "body": "Both of these lists were sorted descending so all comparisons in the comparator had to be reversed. This made it hard to reason about sort order.\n\nIt makes more sense to sort ascending and have the comparisons also be ascending. The final sort order remains the same."
+    },
+    {
+        "commit": "1db52ef9f387ddf451213bcc5aeb900519d2782e",
+        "date": "2026-02-13 10:20:47 +0700",
+        "subject": "Refactor restore module into included modules.",
+        "body": "The restore module has been large and unwieldy for some time but I have been loathe to split it into separate compilation units because it means maintaining additional header files, updating build files, and losing optimizations from static functions. These functions are only used internally by restore and it seems wasteful to extern them.\n\nWe already have a number of cases where C files are included directly into other C files, especially .vendor.c.inc and .auto.c.inc files. We also include C files to add functionality needed for build/doc/test to core objects without having to add that functionality to core. See src/build/common/string.c for an example.\n\nThe test/coverage code already supports C includes but I had to update it to recognize the new extension."
+    },
+    {
+        "commit": "bc3ef206799595c5c07e206c3626ca0816bbd3b0",
+        "date": "2026-02-09 22:23:40 +0700",
+        "subject": "Move initialization of StorageRead and StorageWrite to interface.",
+        "body": "Moving initialization to the interface consolidates code and removes duplication in the drivers. This will become critical as the interface manipulates multiple drivers to improve performance.\n\nThis refactor is less important for StorageWrite but it seems better to keep them consistent."
+    },
+    {
+        "commit": "8d59a6f67eaa05acdb291acf3d580e1c331b6efc",
+        "date": "2026-02-08 17:39:14 +0700",
+        "subject": "Remove package build testing.",
+        "body": "This made sense during the days when the project was juggling Perl code, a C binary, and a C library. These days the build is far simpler and this dependency just means build failures when salsa.debian.org is cranky (often) without any apparent benefit."
+    },
+    {
+        "commit": "607965144392cf64a700443a2ada5dce198aac96",
+        "date": "2026-02-07 17:01:32 +0700",
+        "subject": "Minor memory context optimization in restoreFile().",
+        "body": "The temp mem context block was outside the if statement that determines if a file needs to be copied or not, which meant that some mem contexts would never be used.\n\nReverse this order to avoid creating unused mem contexts."
+    },
+    {
+        "commit": "06b99d93dc7c76461b8e39b6cf653665963ec4d5",
+        "date": "2026-02-07 13:19:08 +0700",
+        "subject": "Calculate limit for Posix/SFTP during read instead of when created.",
+        "body": "This was not a bug since the Posix/SFTP drivers do not allow read retries but it could easily turn into a bug if retries are enabled in the future so it seems safer to move the logic to a location that will work with retries."
+    },
+    {
+        "commit": "e11fe39d0bbc9c6b71a7c232d3381ce1c0dec554",
+        "date": "2026-02-01 11:35:05 +0700",
+        "subject": "Improve designated initializers in data arrays.",
+        "body": "Designated initializers were being used to initialize the structs but not the arrays. Adding designated initializers makes the code a little clearer.\n\nIn the packTypeMapData array designated initializers also allow removal of the explicit zero padding and make initialization order unimportant (though it is better to keep them in order to match the enum)."
+    },
+    {
+        "commit": "10d18be71923adbb396c2fd124c708c57be2fbb2",
+        "date": "2026-02-01 11:23:41 +0700",
+        "subject": "Fix comments in common/pack module."
+    },
+    {
+        "commit": "449529f98fad1ff50b8662c66230e469e311f91d",
+        "date": "2026-01-30 08:18:06 +0700",
+        "subject": "Fix typo in NEWS.md."
+    },
+    {
+        "commit": "b8b0dbceb333353158132e845e443a1391a9b3c3",
+        "date": "2026-01-23 16:10:09 +0700",
+        "subject": "Fix float-equal compiler warnings.",
+        "body": "ed390780 added this warning but included an extra dash which caused it to be ignored. Remove the extra dash so the warning is applied.\n\nAlso remove some unused test code that violated the new warning."
+    },
+    {
+        "commit": "c2b10a85b77aa19b3540f25a8c5324d68211aa14",
+        "date": "2026-01-23 10:17:56 +0700",
+        "subject": "Use more specific warning for nonstring meson compiler probe.",
+        "body": "Previously -Wextra was used, which is overly broad and led to the issue in 303e7458. Instead use a specific error to avoid side effects.\n\nIt is possible that this warning will not be recognized by all compilers but that is not an issue since this is only important for development. Warnings are ignored for production builds."
+    },
+    {
+        "commit": "d4465bd6f78d6d58d18ebedbe8f63b55d0ae2508",
+        "date": "2026-01-23 10:08:48 +0700",
+        "subject": "Suppress unused parameter errors in meson compiler probes.",
+        "body": "The main() parameters in meson compiler probes were not being used but could cause unused parameter errors.\n\nSince the parameters are not needed remove them. This also has the benefit of making the code a bit simpler."
+    },
+    {
+        "commit": "af8a9e1ea797e07367c8a100714ce03d873f9dbc",
+        "date": "2026-01-21 16:50:30 +0700",
+        "subject": "Update NEWS.md for new version and features."
+    },
+    {
+        "commit": "9fb9f73066c87370430b75dee8fe6171ec791d48",
+        "date": "2026-01-20 12:30:05 +0700",
+        "subject": "Documentation no longer builds on PostgreSQL < 10.",
+        "body": "pgBackRest still supports PostgreSQL 9.6 but documentation is not built for EOL versions.\n\nThis will simplify the migration of the documentation to C."
+    },
+    {
+        "commit": "9ea54af67c122ce4f59263089b14ae3cfd28167d",
+        "date": "2026-01-20 12:17:52 +0700",
+        "subject": "Enhance StringId with optional sequence information.",
+        "body": "It is convenient that a StringId can be used as an integer and also be rendered as a string. However, in many cases it is simpler and more efficient to have a sequence that can be used for lookup into an array or in a switch statement. This is particularly useful for StringIds generated by the config module.\n\nSequences cannot be used everywhere, though. In some cases StringIds are generated from text stored in files (e.g. compress type) in which case it is not possible to add sequence info without additional complexity."
+    },
+    {
+        "commit": "2a4fcf4b582e0636108a71882244e34462fe3809",
+        "date": "2026-01-19 17:36:38 +0700",
+        "subject": "Update LICENSE.txt and PostgreSQL copyright for 2026."
+    },
+    {
+        "commit": "d9f778ee3238bd6aaef0e92dba97e70c92b1cd5e",
+        "date": "2026-01-19 17:17:07 +0700",
+        "subject": "Begin v2.59.0 development."
+    },
+    {
         "commit": "d50cfa9ee0b0b921fb6823165c65f23ff5fed0fc",
         "date": "2026-01-19 17:03:44 +0700",
         "subject": "v2.58.0: Object Storage Improvements"

--- a/doc/xml/auto/metric-coverage-report.auto.xml
+++ b/doc/xml/auto/metric-coverage-report.auto.xml
@@ -1,43 +1,43 @@
 <table-row>
     <table-cell>build/common</table-cell>
-    <table-cell>26/26 (100.00%)</table-cell>
-    <table-cell>68/68 (100.00%)</table-cell>
-    <table-cell>247/247 (100.00%)</table-cell>
+    <table-cell>32/32 (100.00%)</table-cell>
+    <table-cell>72/72 (100.00%)</table-cell>
+    <table-cell>268/268 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>build/config</table-cell>
     <table-cell>39/39 (100.00%)</table-cell>
-    <table-cell>558/558 (100.00%)</table-cell>
-    <table-cell>1160/1160 (100.00%)</table-cell>
+    <table-cell>564/564 (100.00%)</table-cell>
+    <table-cell>1142/1142 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>build/error</table-cell>
     <table-cell>6/6 (100.00%)</table-cell>
-    <table-cell>26/26 (100.00%)</table-cell>
-    <table-cell>78/78 (100.00%)</table-cell>
+    <table-cell>22/22 (100.00%)</table-cell>
+    <table-cell>71/71 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>build/help</table-cell>
     <table-cell>13/13 (100.00%)</table-cell>
-    <table-cell>134/134 (100.00%)</table-cell>
-    <table-cell>262/262 (100.00%)</table-cell>
+    <table-cell>138/138 (100.00%)</table-cell>
+    <table-cell>265/265 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>build/postgres</table-cell>
     <table-cell>8/8 (100.00%)</table-cell>
-    <table-cell>60/60 (100.00%)</table-cell>
-    <table-cell>151/151 (100.00%)</table-cell>
+    <table-cell>58/58 (100.00%)</table-cell>
+    <table-cell>149/149 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>command</table-cell>
-    <table-cell>15/15 (100.00%)</table-cell>
-    <table-cell>92/92 (100.00%)</table-cell>
-    <table-cell>182/182 (100.00%)</table-cell>
+    <table-cell>17/17 (100.00%)</table-cell>
+    <table-cell>104/104 (100.00%)</table-cell>
+    <table-cell>210/210 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -49,30 +49,30 @@
 
 <table-row>
     <table-cell>command/archive</table-cell>
-    <table-cell>15/15 (100.00%)</table-cell>
-    <table-cell>104/104 (100.00%)</table-cell>
-    <table-cell>200/200 (100.00%)</table-cell>
+    <table-cell>14/14 (100.00%)</table-cell>
+    <table-cell>98/98 (100.00%)</table-cell>
+    <table-cell>189/189 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>command/archive/get</table-cell>
-    <table-cell>9/9 (100.00%)</table-cell>
-    <table-cell>200/200 (100.00%)</table-cell>
-    <table-cell>433/433 (100.00%)</table-cell>
+    <table-cell>10/10 (100.00%)</table-cell>
+    <table-cell>208/208 (100.00%)</table-cell>
+    <table-cell>447/447 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>command/archive/push</table-cell>
     <table-cell>12/12 (100.00%)</table-cell>
-    <table-cell>130/130 (100.00%)</table-cell>
-    <table-cell>348/348 (100.00%)</table-cell>
+    <table-cell>142/142 (100.00%)</table-cell>
+    <table-cell>359/359 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>command/backup</table-cell>
     <table-cell>50/50 (100.00%)</table-cell>
-    <table-cell>790/790 (100.00%)</table-cell>
-    <table-cell>1643/1643 (100.00%)</table-cell>
+    <table-cell>786/786 (100.00%)</table-cell>
+    <table-cell>1640/1640 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -91,9 +91,9 @@
 
 <table-row>
     <table-cell>command/expire</table-cell>
-    <table-cell>10/10 (100.00%)</table-cell>
-    <table-cell>256/256 (100.00%)</table-cell>
-    <table-cell>373/373 (100.00%)</table-cell>
+    <table-cell>11/11 (100.00%)</table-cell>
+    <table-cell>274/274 (100.00%)</table-cell>
+    <table-cell>392/392 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -105,9 +105,9 @@
 
 <table-row>
     <table-cell>command/info</table-cell>
-    <table-cell>15/15 (100.00%)</table-cell>
-    <table-cell>412/412 (100.00%)</table-cell>
-    <table-cell>709/709 (100.00%)</table-cell>
+    <table-cell>16/16 (100.00%)</table-cell>
+    <table-cell>430/430 (100.00%)</table-cell>
+    <table-cell>748/748 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -128,7 +128,7 @@
     <table-cell>command/repo</table-cell>
     <table-cell>9/9 (100.00%)</table-cell>
     <table-cell>110/110 (100.00%)</table-cell>
-    <table-cell>205/205 (100.00%)</table-cell>
+    <table-cell>195/195 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -142,7 +142,7 @@
     <table-cell>command/server</table-cell>
     <table-cell>6/6 (100.00%)</table-cell>
     <table-cell>24/24 (100.00%)</table-cell>
-    <table-cell>79/79 (100.00%)</table-cell>
+    <table-cell>81/81 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -155,15 +155,15 @@
 <table-row>
     <table-cell>command/verify</table-cell>
     <table-cell>22/22 (100.00%)</table-cell>
-    <table-cell>356/356 (100.00%)</table-cell>
-    <table-cell>721/721 (100.00%)</table-cell>
+    <table-cell>366/366 (100.00%)</table-cell>
+    <table-cell>733/733 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>common</table-cell>
-    <table-cell>145/145 (100.00%)</table-cell>
-    <table-cell>614/614 (100.00%)</table-cell>
-    <table-cell>1335/1335 (100.00%)</table-cell>
+    <table-cell>146/146 (100.00%)</table-cell>
+    <table-cell>624/624 (100.00%)</table-cell>
+    <table-cell>1350/1350 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -211,15 +211,15 @@
 <table-row>
     <table-cell>common/error</table-cell>
     <table-cell>33/33 (100.00%)</table-cell>
-    <table-cell>62/62 (100.00%)</table-cell>
-    <table-cell>178/178 (100.00%)</table-cell>
+    <table-cell>66/66 (100.00%)</table-cell>
+    <table-cell>179/179 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>common/io</table-cell>
-    <table-cell>60/60 (100.00%)</table-cell>
-    <table-cell>180/180 (100.00%)</table-cell>
-    <table-cell>513/513 (100.00%)</table-cell>
+    <table-cell>61/61 (100.00%)</table-cell>
+    <table-cell>182/182 (100.00%)</table-cell>
+    <table-cell>523/523 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -232,15 +232,15 @@
 <table-row>
     <table-cell>common/io/http</table-cell>
     <table-cell>58/58 (100.00%)</table-cell>
-    <table-cell>284/284 (100.00%)</table-cell>
-    <table-cell>677/677 (100.00%)</table-cell>
+    <table-cell>292/292 (100.00%)</table-cell>
+    <table-cell>685/685 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>common/io/socket</table-cell>
     <table-cell>28/28 (100.00%)</table-cell>
     <table-cell>110/110 (100.00%)</table-cell>
-    <table-cell>337/337 (100.00%)</table-cell>
+    <table-cell>339/339 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -252,16 +252,16 @@
 
 <table-row>
     <table-cell>common/type</table-cell>
-    <table-cell>334/334 (100.00%)</table-cell>
-    <table-cell>916/916 (100.00%)</table-cell>
-    <table-cell>3107/3107 (100.00%)</table-cell>
+    <table-cell>335/335 (100.00%)</table-cell>
+    <table-cell>922/922 (100.00%)</table-cell>
+    <table-cell>3123/3123 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>config</table-cell>
-    <table-cell>91/91 (100.00%)</table-cell>
-    <table-cell>1001/1002 (99.90%)</table-cell>
-    <table-cell>1612/1612 (100.00%)</table-cell>
+    <table-cell>93/93 (100.00%)</table-cell>
+    <table-cell>1025/1026 (99.90%)</table-cell>
+    <table-cell>1649/1649 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -273,16 +273,23 @@
 
 <table-row>
     <table-cell>info</table-cell>
-    <table-cell>93/93 (100.00%)</table-cell>
-    <table-cell>936/936 (100.00%)</table-cell>
-    <table-cell>2030/2030 (100.00%)</table-cell>
+    <table-cell>48/48 (100.00%)</table-cell>
+    <table-cell>240/240 (100.00%)</table-cell>
+    <table-cell>712/712 (100.00%)</table-cell>
+</table-row>
+
+<table-row>
+    <table-cell>info/manifest</table-cell>
+    <table-cell>10/10 (100.00%)</table-cell>
+    <table-cell>132/132 (100.00%)</table-cell>
+    <table-cell>303/303 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>postgres</table-cell>
     <table-cell>36/36 (100.00%)</table-cell>
-    <table-cell>126/126 (100.00%)</table-cell>
-    <table-cell>329/329 (100.00%)</table-cell>
+    <table-cell>140/140 (100.00%)</table-cell>
+    <table-cell>336/336 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -295,22 +302,22 @@
 <table-row>
     <table-cell>protocol</table-cell>
     <table-cell>60/60 (100.00%)</table-cell>
-    <table-cell>264/264 (100.00%)</table-cell>
-    <table-cell>858/858 (100.00%)</table-cell>
+    <table-cell>266/266 (100.00%)</table-cell>
+    <table-cell>860/860 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage</table-cell>
-    <table-cell>63/63 (100.00%)</table-cell>
-    <table-cell>278/278 (100.00%)</table-cell>
-    <table-cell>707/707 (100.00%)</table-cell>
+    <table-cell>68/68 (100.00%)</table-cell>
+    <table-cell>298/298 (100.00%)</table-cell>
+    <table-cell>754/754 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage/azure</table-cell>
-    <table-cell>25/25 (100.00%)</table-cell>
-    <table-cell>148/148 (100.00%)</table-cell>
-    <table-cell>437/437 (100.00%)</table-cell>
+    <table-cell>26/26 (100.00%)</table-cell>
+    <table-cell>164/164 (100.00%)</table-cell>
+    <table-cell>487/487 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
@@ -323,41 +330,41 @@
 <table-row>
     <table-cell>storage/gcs</table-cell>
     <table-cell>34/34 (100.00%)</table-cell>
-    <table-cell>184/184 (100.00%)</table-cell>
-    <table-cell>581/581 (100.00%)</table-cell>
+    <table-cell>176/176 (100.00%)</table-cell>
+    <table-cell>574/574 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage/posix</table-cell>
-    <table-cell>28/28 (100.00%)</table-cell>
-    <table-cell>167/168 (99.40%)</table-cell>
-    <table-cell>325/325 (100.00%)</table-cell>
+    <table-cell>29/29 (100.00%)</table-cell>
+    <table-cell>165/166 (99.40%)</table-cell>
+    <table-cell>328/328 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage/remote</table-cell>
-    <table-cell>38/38 (100.00%)</table-cell>
+    <table-cell>40/40 (100.00%)</table-cell>
     <table-cell>128/128 (100.00%)</table-cell>
-    <table-cell>572/572 (100.00%)</table-cell>
+    <table-cell>568/568 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage/s3</table-cell>
-    <table-cell>30/30 (100.00%)</table-cell>
+    <table-cell>31/31 (100.00%)</table-cell>
     <table-cell>194/194 (100.00%)</table-cell>
-    <table-cell>625/625 (100.00%)</table-cell>
+    <table-cell>651/651 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>storage/sftp</table-cell>
-    <table-cell>32/32 (100.00%)</table-cell>
-    <table-cell>400/400 (100.00%)</table-cell>
-    <table-cell>712/712 (100.00%)</table-cell>
+    <table-cell>39/39 (100.00%)</table-cell>
+    <table-cell>408/408 (100.00%)</table-cell>
+    <table-cell>762/762 (100.00%)</table-cell>
 </table-row>
 
 <table-row>
     <table-cell>TOTAL</table-cell>
-    <table-cell>1708/1708 (100.00%)</table-cell>
-    <table-cell>10992/10994 (99.98%)</table-cell>
-    <table-cell>25782/25782 (100.00%)</table-cell>
+    <table-cell>1705/1705 (100.00%)</table-cell>
+    <table-cell>10608/10610 (99.98%)</table-cell>
+    <table-cell>25128/25128 (100.00%)</table-cell>
 </table-row>

--- a/doc/xml/index.xml
+++ b/doc/xml/index.xml
@@ -43,9 +43,9 @@
     <section if="'{[news]}' eq 'y'" id="news">
         <title>News</title>
 
+        <p><b>July 20, 2026</b> - <link page="news" section="/distribution-tarball">New Distribution Tarball</link></p>
+        <p><b>July 20, 2026</b> - <link page="news" section="/release-2-59-0">{[project]} 2.59.0 Released</link></p>
         <p><b>May 18, 2026</b> - <link page="news" section="/will-continue">{[project]} Will Continue!</link></p>
-        <p><b>May 7, 2026</b> - <link page="news" section="/maintenance-update">Maintenance Update</link></p>
-        <p><b>April 27, 2026</b> - <link page="news" section="/no-longer-maintained">{[project]} Is No Longer Being Maintained</link></p>
     </section>
 
     <!-- ======================================================================================================================= -->

--- a/doc/xml/news.xml
+++ b/doc/xml/news.xml
@@ -57,7 +57,7 @@
 
             <list>
                 <list-item>Only the restore command may be run as root by default. Use allow-root to run other commands as root (though this is not recommended).</list-item>
-                <list-item>A new distribution tarball with pregenerated documentation, man page, and code is attached to each release to simplify packaging.</list-item>
+                <list-item>A new distribution tarball with pregenerated documentation, man page, and code is attached to each release to simplify packaging. See <link url="{[backrest-url-base]}/news.html#distribution-tarball">New Distribution Tarball</link> for more information.</list-item>
                 <list-item>There is a new optional dependency on libsystemd.</list-item>
             </list>
         </section>
@@ -69,7 +69,6 @@
                 <list-item><link url="{[backrest-url-base]}">Website</link></list-item>
                 <list-item><link page="user-guide-index">User Guides</link></list-item>
                 <list-item><link page="release">Release Notes</link></list-item>
-                <list-item><link url="{[backrest-url-base]}#support">Support</link></list-item>
             </list>
         </section>
 

--- a/doc/xml/news.xml
+++ b/doc/xml/news.xml
@@ -4,6 +4,83 @@
     <description>News</description>
 
     <!-- ======================================================================================================================= -->
+    <section id="distribution-tarball">
+        <title>New Distribution Tarball</title>
+
+        <p><b>July 20, 2026</b></p>
+
+        <p>Starting with <backrest/> 2.59.0, every release includes a distribution tarball that makes building from source simpler. Unlike a checkout of the git repository, the tarball ships the generated source and the rendered documentation pre-built, so <backrest/> builds and installs without the code generation or documentation tooling that a repository checkout requires.</p>
+
+        <p>The tarball contains the <backrest/> source with the pre-generated code, the command reference man page, the HTML documentation, and a smoke test to verify the build. It builds with meson and ninja using only the usual <backrest/> libraries.</p>
+
+        <p>The tarball is attached to each release as an asset named <file>pgbackrest-{version}.tar.gz</file>, along with a matching <file>.sha256sum</file> checksum. Download it from the <link url="{[github-url-base]}/releases">releases</link> page on GitHub, then see the <file>README.md</file> in the tarball for build and test instructions.</p>
+
+        <p>Packagers are encouraged to build from the distribution tarball to avoid the extra build tooling that generating code and documentation will require in future releases.</p>
+    </section>
+
+    <!-- ======================================================================================================================= -->
+    <section id="release-2-59-0">
+        <title><backrest/> 2.59.0 Released</title>
+
+        <p><b>July 20, 2026</b></p>
+
+        <p>The <backrest/> community is pleased to announce the release of <link url="{[backrest-url-base]}">{[project]}</link> 2.59.0, the latest version of the reliable, easy-to-use backup and restore solution that can seamlessly scale up to the largest databases and workloads.</p>
+
+        <p><backrest/> supports a robust set of features for managing your backup and recovery infrastructure, including: parallel backup/restore, full/differential/incremental backups, block incremental backup, multiple repositories, delta restore, parallel asynchronous archiving, malware/ransomware protection, per-file checksums, page checksums (when enabled) validated during backup, multiple compression types, encryption, partial/failed backup resume, backup from standby, tablespace and link support, S3/Azure/GCS/SFTP support, backup expiration, local/remote operation via SSH or TLS, flexible configuration, and more.</p>
+
+        <p><backrest/> can be installed from the <link url="https://yum.postgresql.org">{[postgres]} Yum Repository</link> or the <link url="https://apt.postgresql.org">{[postgres]} APT Repository</link> and packages are also available for many other distributions. Source code can be downloaded from <link page="release">releases</link>.</p>
+
+        <section id="feature">
+            <title>Significant New Features and Improvements</title>
+
+            <list>
+                <list-item><postgres/> 19 support (David Steele)</list-item>
+                <list-item>Add archive-expire-before option to clean up WAL archive (Stefan Fercot)</list-item>
+                <list-item>Add support for S3 Outposts (Shiva Kumar Ambigi)</list-item>
+                <list-item>Add S3 process authentication (David Steele)</list-item>
+                <list-item>Add user/group caching for faster manifest build (Gunnar Lindholm)</list-item>
+                <list-item>Reconnect SFTP storage after the server drops an idle connection (David Steele)</list-item>
+                <list-item>Add per-repo backup progress to info command output (Will Morland)</list-item>
+                <list-item>Add batch delete for Azure storage (David Steele)</list-item>
+                <list-item>Add backup.info checks to verify command (Denis Garsh)</list-item>
+                <list-item>Allow the S3 STS endpoint to be configured (Simon Gratton)</list-item>
+                <list-item>Add systemd notify integration (Andrew Jackson)</list-item>
+                <list-item>Error when running as root unless allow-root is enabled (David Steele)</list-item>
+                <list-item>Exit async archive-push on first error (David Steele)</list-item>
+            </list>
+
+            <p>See the <link page="release" section="2.59.0">2.59.0 Release Notes</link> for additional features and improvements.</p>
+        </section>
+
+        <section id="note">
+            <title>Important Notes</title>
+
+            <list>
+                <list-item>Only the restore command may be run as root by default. Use allow-root to run other commands as root (though this is not recommended).</list-item>
+                <list-item>A new distribution tarball with pregenerated documentation, man page, and code is attached to each release to simplify packaging.</list-item>
+                <list-item>There is a new optional dependency on libsystemd.</list-item>
+            </list>
+        </section>
+
+        <section id="link">
+            <title>Links</title>
+
+            <list>
+                <list-item><link url="{[backrest-url-base]}">Website</link></list-item>
+                <list-item><link page="user-guide-index">User Guides</link></list-item>
+                <list-item><link page="release">Release Notes</link></list-item>
+                <list-item><link url="{[backrest-url-base]}#support">Support</link></list-item>
+            </list>
+        </section>
+
+        <section id="Sponsorship">
+            <title>Sponsorship</title>
+
+            <p>This release was made possible by the generous sponsorship of <link url="https://aws.amazon.com">AWS</link>, <link url="https://supabase.com">Supabase</link>, <link url="https://pgedge.com">pgEdge</link>, <link url="https://tigerdata.com">Tiger Data</link>, <link url="https://percona.com">Percona</link>, <link url="https://eon.io">Eon</link>, <link url="https://xata.io">Xata</link>, <link url="https://dalibo.com">Dalibo</link>, and <link url="https://dataegret.com/">Data Egret</link>.</p>
+        </section>
+    </section>
+
+    <!-- ======================================================================================================================= -->
     <section id="will-continue">
         <title><backrest/> Will Continue!</title>
 

--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -1,5 +1,13 @@
-<release date="XXXX-XX-XX" version="2.59.0dev" title="UNDER DEVELOPMENT">
+<release date="2026-07-20" version="2.59.0" title="PostgreSQL 19 Support">
     <release-core-list>
+        <text>
+            <p><b>NOTE TO PACKAGERS</b>: A new distribution tarball is available which simplifies the build process by providing pregenerated HTML documentation, man page, and code. The tarball is attached to each release as an asset and is named <file>pgbackrest-{version}.tar.gz</file>. See the <file>README.md</file> in the tarball for details. Please use the new distribution tarball to avoid the additional build tooling required to generate code in future releases.</p>
+
+            <p><b>NOTE TO PACKAGERS</b>: There is a new optional dependency on <id>libsystemd</id>.</p>
+
+            <p><b>IMPORTANT NOTE</b>: Starting with this release, only the <cmd>restore</cmd> command may be run as root by default. Use <setting>allow-root</setting> to run other commands as root (though this is not recommended).</p>
+        </text>
+
         <release-bug-list>
             <release-item>
                 <github-issue id="2622"/>
@@ -41,6 +49,10 @@
             </release-item>
 
             <release-item>
+                <commit subject="Fix potential buffer overrun in error module."/>
+                <commit subject="Use the full buffer when formatting error messages."/>
+                <commit subject="Prevent an out-of-bounds error buffer write on an oversized message."/>
+
                 <release-item-contributor-list>
                     <release-item-contributor id="christophe.pettus"/>
                     <release-item-reviewer id="david.steele"/>
@@ -266,7 +278,7 @@
             </release-item>
 
             <release-item>
-                <github-issue id="2732"/>
+                <github-pull-request id="2732"/>
 
                 <release-item-contributor-list>
                     <release-item-contributor id="david.steele"/>
@@ -328,6 +340,14 @@
             </release-item>
 
             <release-item>
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                </release-item-contributor-list>
+
+                <p>Hint that pgBackRest may be out of date when a version is unsupported.</p>
+            </release-item>
+
+            <release-item>
                 <github-issue id="2757"/>
                 <github-pull-request id="2760"/>
 
@@ -360,22 +380,11 @@
 
                 <p><proper>C11</proper> is now the minimum C standard.</p>
             </release-item>
-
-            <release-item>
-                <github-issue id="2735"/>
-
-                <release-item-contributor-list>
-                    <release-item-contributor id="david.steele"/>
-                    <release-item-reviewer id="stefan.fercot"/>
-                </release-item-contributor-list>
-
-                <p>Make <setting>stanza</setting> option internal for the <cmd>repo-*</cmd> commands.</p>
-            </release-item>
         </release-improvement-list>
 
         <release-development-list>
             <release-item>
-                <github-issue id="2731"/>
+                <github-pull-request id="2731"/>
 
                 <release-item-contributor-list>
                     <release-item-contributor id="david.steele"/>
@@ -390,6 +399,17 @@
 
     <release-doc-list>
         <release-improvement-list>
+            <release-item>
+                <github-issue id="2735"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                </release-item-contributor-list>
+
+                <p>Make <setting>stanza</setting> option internal for the <cmd>repo-*</cmd> commands.</p>
+            </release-item>
+
             <release-item>
                 <github-issue id="1407"/>
                 <github-pull-request id="2805"/>

--- a/doc/xml/release/2020s/2026/2.59.0.xml
+++ b/doc/xml/release/2020s/2026/2.59.0.xml
@@ -1,7 +1,7 @@
 <release date="2026-07-20" version="2.59.0" title="PostgreSQL 19 Support">
     <release-core-list>
         <text>
-            <p><b>NOTE TO PACKAGERS</b>: A new distribution tarball is available which simplifies the build process by providing pregenerated HTML documentation, man page, and code. The tarball is attached to each release as an asset and is named <file>pgbackrest-{version}.tar.gz</file>. See the <file>README.md</file> in the tarball for details. Please use the new distribution tarball to avoid the additional build tooling required to generate code in future releases.</p>
+            <p><b>NOTE TO PACKAGERS</b>: A new distribution tarball is available which simplifies the build process by providing pregenerated HTML documentation, man page, and code. The tarball is attached to each release as an asset and is named <file>pgbackrest-{version}.tar.gz</file>. See the <file>README.md</file> in the tarball for details. Please use the new distribution tarball to avoid the additional build tooling required to generate code in future releases. See <link page="news" section="/distribution-tarball">New Distribution Tarball</link> for more information.</p>
 
             <p><b>NOTE TO PACKAGERS</b>: There is a new optional dependency on <id>libsystemd</id>.</p>
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 project(
     'pgbackrest',
     ['c'],
-    version: '2.59.0dev',
+    version: '2.59.0',
     license: 'MIT',
     meson_version: '>=0.47',
     default_options: [

--- a/src/version.h
+++ b/src/version.h
@@ -36,9 +36,9 @@ Project version components. PROJECT_VERSION and PROJECT_VERSION_NUM are automati
 #define PROJECT_VERSION_MAJOR                                       2
 #define PROJECT_VERSION_MINOR                                       59
 #define PROJECT_VERSION_PATCH                                       0
-#define PROJECT_VERSION_SUFFIX                                      "dev"
+#define PROJECT_VERSION_SUFFIX                                      ""
 
-#define PROJECT_VERSION                                             "2.59.0dev"
+#define PROJECT_VERSION                                             "2.59.0"
 #define PROJECT_VERSION_NUM                                         2059000
 
 #endif


### PR DESCRIPTION
NOTE TO PACKAGERS: A new distribution tarball is available which simplifies the build process by providing pregenerated HTML documentation, man page, and code. The tarball is attached to each release as an asset and is named pgbackrest-{version}.tar.gz. See the README.md in the tarball for details. Please use the new distribution tarball to avoid the additional build tooling required to generate code in future releases.

NOTE TO PACKAGERS: There is a new optional dependency on libsystemd.

IMPORTANT NOTE: Starting with this release, only the restore command may be run as root by default. Use allow-root to run other commands as root (though this is not recommended).

Bug Fixes:

* Fix expire removing a backup in progress on another host. (Reviewed by Douglas J Hunley. Reported by Dmitrii.)
* Fix archive-push-queue-max not enforced when a WAL file errors. (Reviewed by Stefan Fercot. Reported by vut12.)
* Fix async archive-get failure during recovery across a timeline switch. (Reviewed by Douglas J Hunley. Reported by Jimmy Yih.)
* Fix potential buffer overrun in error module. (Fixed by Christophe Pettus. Reviewed by David Steele.)
* Fix use-after-free of parallel protocol client. (Reviewed by Douglas J Hunley. Reported by Georgy Shelkovy.)
* Fix heap overflow when a pg option is set without pg1. (Reviewed by Douglas J Hunley. Reported by Naveen.)

Features:

* PostgreSQL 19beta2 support. (Reviewed by Stefan Fercot.)
* Add archive-expire-before option to clean up WAL archive. (Contributed by Stefan Fercot. Reviewed by David Steele.)
* Add batch delete for Azure storage. (Reviewed by Douglas J Hunley, Crispy.)
* Add support for S3 Outposts. (Contributed by Shiva Kumar Ambigi. Reviewed by David Steele, Roberto Mello.)
* Add S3 process authentication. (Reviewed by Andrew Charlton. Suggested by Andrew Charlton.)

Improvements:

* Reconnect SFTP storage after the server drops an idle connection. (Reviewed by Stefan Fercot. Suggested by mustafa0x, tisserat.)
* Add user/group caching for faster manifest build. (Contributed by Gunnar Lindholm. Reviewed by David Steele.)
* Add per-repo backup progress to info command output. (Contributed by Will Morland. Reviewed by David Steele, Stefan Fercot.)
* Add backup.info checks to verify command. (Contributed by Denis Garsh. Reviewed by David Steele, Douglas J Hunley.)
* Allow the S3 STS endpoint to be configured. (Contributed by Simon Gratton. Reviewed by David Steele.)
* Add archive-push-batch-size to limit WAL pushed per asynchronous run. (Reviewed by Stefan Fercot.)
* Exit async archive-push on first error. (Reviewed by Stefan Fercot. Suggested by Lardière Sébastien.)
* Harden HTTP chunked response parsing. (Contributed by Shubham. Reviewed by David Steele.)
* Error when running as root unless allow-root is enabled. (Reviewed by Douglas J Hunley.)
* Fewer binary searches when building manifest. (Contributed by Gunnar Lindholm. Reviewed by David Steele.)
* Improve seek performance during block incremental delta restore. (Reviewed by David Christensen, Douglas J Hunley.)
* Bundle backup files in order rather than scanning for a better fit. (Reviewed by Stefan Fercot.)
* Report the underlying error when a query fails to complete. (Reviewed by Andrew Pogrebnoi. Suggested by Marco Fontana.)
* Report the actual error when an S3 credential request fails. (Reviewed by Douglas J Hunley. Suggested by Mitchell Grice.)
* Report archive-push spool path errors to the PostgreSQL log. (Reviewed by Douglas J Hunley. Suggested by Don Seiler.)
* Hint that pgBackRest may be out of date when a version is unsupported.
* Add systemd notify integration. (Contributed by Andrew Jackson. Reviewed by David Steele.)
* Suppress unused parameter errors in meson compiler probes. (Contributed by Jörg Plate. Reviewed by David Steele.)
* C11 is now the minimum C standard. (Reviewed by Mohammad Ali Nazir Kosar.)

Documentation Improvements:

* Make stanza option internal for the repo-* commands. (Reviewed by Stefan Fercot.)
* Document that info reads encryption settings from global section. (Reviewed by Stefan Fercot. Suggested by Ron Johnson.)
* Document that expire-auto uses the backup command configuration. (Reviewed by Stefan Fercot. Suggested by Lardière Sébastien.)
* Document adjusting the logrotate su directive for a dedicated user. (Reviewed by Douglas J Hunley. Suggested by lkanbus.)
* Document that end-of-line comments are not supported in config files. (Reviewed by Douglas J Hunley. Suggested by Alex Richman.)

Test Suite Improvements:

* Fix Alpine group conflicts in CI containers. (Contributed by Artur Zakirov. Reviewed by David Steele.)