### PR TITLE
Skip unexpected output before protocol greeting.

### DIFF
--- a/src/protocol/client.c
+++ b/src/protocol/client.c
@@ -21,6 +21,8 @@ output sampled for error reporting, and the hint added to errors caused by unexp
 #define PROTOCOL_GREETING_SKIP_MAX                                  65536
 #define PROTOCOL_GREETING_SKIP_SAMPLE_MAX                           64
 
+#define PROTOCOL_GREETING_UNEXPECTED_OUTPUT_FMT                                                                                    \
+    "after %zu byte(s) of unexpected output beginning with '%s'"
 #define PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT                                                                                   \
     "HINT: is the remote shell printing output for non-interactive sessions?"
 
@@ -341,8 +343,8 @@ protocolClientGreetingNotFound(const char *const reason, const size_t skipSize, 
 
     THROW_FMT(
         ProtocolError,
-        "greeting not found (%s) after %zu byte(s) of unexpected output beginning with '%s'\n"
-        PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT, reason, skipSize, strZ(skipSample));
+        "greeting not found (%s) " PROTOCOL_GREETING_UNEXPECTED_OUTPUT_FMT "\n" PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT,
+        reason, skipSize, strZ(skipSample));
 }
 
 /**********************************************************************************************************************************/
@@ -376,20 +378,21 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
             .sessionList = lstNewP(sizeof(ProtocolClientSession)),
         };
 
-        // Read, parse, and check the protocol greeting. The greeting is a JSON object on a single line so any line that does not
-        // begin as one is unexpected output (e.g. a login banner printed by the remote shell for a non-interactive SSH session).
-        // Unexpected output is an error since more of it is likely to arrive in the middle of the protocol session, but search for
-        // the greeting first so the error can confirm that the correct remote was reached. The search is bounded so a stream that
-        // never produces a greeting errors cleanly and errors include a sample of the output to help identify the source.
+        // Read, parse, and check the protocol greeting. The greeting is a machine-generated JSON object on a single line so it
+        // always begins with { and any line that does not is unexpected output (e.g. a login banner printed by the remote shell
+        // for a non-interactive SSH session). Unexpected output is an error since more of it is likely to arrive in the middle of
+        // the protocol session, but search for the greeting first so the error can confirm that the correct remote was reached.
+        // The search is bounded so a stream that never produces a greeting errors cleanly and errors include a sample of the
+        // output to help identify the source.
         MEM_CONTEXT_TEMP_BEGIN()
         {
             String *const skipSample = strNew();
-            volatile size_t skipSize = 0;
-            volatile bool greetingFound = false;
+            size_t skipSize = 0;
+            bool greetingFound = false;
 
             do
             {
-                String *volatile greetingLine = NULL;
+                String *greetingLine = NULL;
 
                 TRY_BEGIN()
                 {
@@ -402,18 +405,7 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
                 }
                 TRY_END();
 
-                JsonRead *volatile greeting = NULL;
-                volatile bool greetingIsJson = false;
-
-                TRY_BEGIN()
-                {
-                    greeting = jsonReadNew(greetingLine);
-
-                    jsonReadObjectBegin(greeting);
-
-                    greetingIsJson = true;
-                }
-                CATCH(JsonFormatError)
+                if (!strBeginsWithZ(greetingLine, "{"))
                 {
                     // The line does not begin as a JSON object so it is unexpected output rather than a malformed greeting. Skip
                     // it, keeping a sample of the skipped output (sanitized to printable characters) for error reporting.
@@ -437,14 +429,16 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
                         protocolClientGreetingNotFound("maximum unexpected output exceeded", skipSize, skipSample);
 
                     strFree(greetingLine);
-                    jsonReadFree(greeting);
                 }
-                TRY_END();
-
-                // Once the line begins as a JSON object any error from parsing or validation is a real greeting mismatch (e.g. a
-                // version skew or protocol change) rather than unexpected output, so let it propagate
-                if (greetingIsJson)
+                // Else the line begins as a JSON object so treat it as the greeting. Any error from parsing or validation is a
+                // real greeting mismatch (e.g. a version skew or protocol change) rather than unexpected output, so let it
+                // propagate.
+                else
                 {
+                    JsonRead *const greeting = jsonReadNew(greetingLine);
+
+                    jsonReadObjectBegin(greeting);
+
                     const struct
                     {
                         const StringId key;
@@ -490,7 +484,7 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
             {
                 THROW_FMT(
                     ProtocolError,
-                    "greeting found after %zu byte(s) of unexpected output beginning with '%s'\n"
+                    "greeting found " PROTOCOL_GREETING_UNEXPECTED_OUTPUT_FMT "\n"
                     PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT "\n"
                     "HINT: unexpected output may interrupt the protocol at any time so the connection cannot be used until the"
                     " output is disabled.",

--- a/src/protocol/client.c
+++ b/src/protocol/client.c
@@ -13,9 +13,14 @@ Protocol Client
 #include "version.h"
 
 /***********************************************************************************************************************************
-Maximum bytes of unexpected output (e.g. a login banner from the remote shell) tolerated before the greeting
+Maximum bytes of unexpected output (e.g. a login banner from the remote shell) tolerated before the greeting, maximum bytes of that
+output sampled for error reporting, and the hint added to errors when the greeting is not found
 ***********************************************************************************************************************************/
 #define PROTOCOL_GREETING_SKIP_MAX                                  65536
+#define PROTOCOL_GREETING_SKIP_SAMPLE_MAX                           64
+
+#define PROTOCOL_GREETING_NOT_FOUND_HINT                                                                                           \
+    "HINT: is the remote shell printing output for non-interactive sessions?"
 
 /***********************************************************************************************************************************
 Client state enum
@@ -345,70 +350,110 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
             .sessionList = lstNewP(sizeof(ProtocolClientSession)),
         };
 
-        // Read, parse, and check the protocol greeting
+        // Read, parse, and check the protocol greeting. The greeting is a JSON object on a single line so any line that does not
+        // parse as one is unexpected output (e.g. a login banner printed by the remote shell for a non-interactive SSH session),
+        // which is skipped since it would otherwise make the remote unusable. Skipped output is bounded so a stream that never
+        // produces a greeting errors cleanly and errors include a sample of the output to help identify the source.
         MEM_CONTEXT_TEMP_BEGIN()
         {
-            // Skip any output before the greeting, e.g. a login banner printed by the remote shell for non-interactive SSH
-            // sessions, which would otherwise make the remote unusable. The greeting is always a JSON object on a single line so
-            // any line that does not start with { cannot be the greeting. The skipped output is bounded so a stream that never
-            // produces a greeting errors cleanly.
-            const String *greetingLine = ioReadLine(this->pub.read);
-            size_t skipSize = 0;
+            String *const skipSample = strNew();
+            volatile size_t skipSize = 0;
+            volatile bool greetingFound = false;
 
-            while (!strBeginsWithZ(greetingLine, "{"))
+            do
             {
-                skipSize += strSize(greetingLine) + 1;
+                String *volatile greetingLine = NULL;
 
-                if (skipSize > PROTOCOL_GREETING_SKIP_MAX)
+                TRY_BEGIN()
                 {
+                    greetingLine = ioReadLine(this->pub.read);
+                }
+                CATCH(FileReadError)
+                {
+                    // The stream ended or a line was too large to buffer so the greeting is not coming
+                    if (skipSize == 0)
+                        THROW_FMT(ProtocolError, "greeting not found (%s)\n" PROTOCOL_GREETING_NOT_FOUND_HINT, errorMessage());
+
                     THROW_FMT(
                         ProtocolError,
-                        "greeting not found after %zu bytes of unexpected output\n"
-                        "HINT: is the remote shell printing output for non-interactive sessions?", skipSize);
+                        "greeting not found (%s) after %zu byte(s) of unexpected output beginning with '%s'\n"
+                        PROTOCOL_GREETING_NOT_FOUND_HINT, errorMessage(), skipSize, strZ(skipSample));
                 }
+                TRY_END();
 
-                greetingLine = ioReadLine(this->pub.read);
+                TRY_BEGIN()
+                {
+                    JsonRead *const greeting = jsonReadNew(greetingLine);
+
+                    jsonReadObjectBegin(greeting);
+
+                    const struct
+                    {
+                        const StringId key;
+                        const char *const value;
+                    } expected[] =
+                    {
+                        {.key = PROTOCOL_GREETING_NAME, .value = PROJECT_NAME},
+                        {.key = PROTOCOL_GREETING_SERVICE, .value = strZ(service)},
+                        {.key = PROTOCOL_GREETING_VERSION, .value = PROJECT_VERSION},
+                    };
+
+                    for (unsigned int expectedIdx = 0; expectedIdx < LENGTH_OF(expected); expectedIdx++)
+                    {
+                        if (!jsonReadKeyExpectStrId(greeting, expected[expectedIdx].key))
+                            THROW_FMT(ProtocolError, "unable to find greeting key '%s'", zNewStrId(expected[expectedIdx].key));
+
+                        if (jsonReadTypeNext(greeting) != jsonTypeString)
+                            THROW_FMT(ProtocolError, "greeting key '%s' must be string type", zNewStrId(expected[expectedIdx].key));
+
+                        const String *const actualValue = jsonReadStr(greeting);
+
+                        if (!strEqZ(actualValue, expected[expectedIdx].value))
+                        {
+                            THROW_FMT(
+                                ProtocolError,
+                                "expected value '%s' for greeting key '%s' but got '%s'\n"
+                                "HINT: is the same version of " PROJECT_NAME " installed on the local and remote host?",
+                                expected[expectedIdx].value, zNewStrId(expected[expectedIdx].key), strZ(actualValue));
+                        }
+                    }
+
+                    jsonReadObjectEnd(greeting);
+
+                    greetingFound = true;
+                }
+                CATCH(JsonFormatError)
+                {
+                    // The line is not a greeting so skip it, keeping the beginning of the skipped output for error reporting
+                    skipSize += strSize(greetingLine) + 1;
+
+                    if (strEmpty(skipSample))
+                    {
+                        if (strSize(greetingLine) > PROTOCOL_GREETING_SKIP_SAMPLE_MAX)
+                        {
+                            strCatZN(skipSample, strZ(greetingLine), PROTOCOL_GREETING_SKIP_SAMPLE_MAX);
+                            strCatZ(skipSample, "...");
+                        }
+                        else
+                            strCat(skipSample, greetingLine);
+                    }
+
+                    if (skipSize > PROTOCOL_GREETING_SKIP_MAX)
+                    {
+                        THROW_FMT(
+                            ProtocolError,
+                            "greeting not found after %zu byte(s) of unexpected output beginning with '%s'\n"
+                            PROTOCOL_GREETING_NOT_FOUND_HINT, skipSize, strZ(skipSample));
+                    }
+
+                    strFree(greetingLine);
+                }
+                TRY_END();
             }
+            while (!greetingFound);
 
             if (skipSize != 0)
                 LOG_WARN_FMT("skipped %zu byte(s) of unexpected output before greeting from %s", skipSize, strZ(name));
-
-            JsonRead *const greeting = jsonReadNew(greetingLine);
-
-            jsonReadObjectBegin(greeting);
-
-            const struct
-            {
-                const StringId key;
-                const char *const value;
-            } expected[] =
-            {
-                {.key = PROTOCOL_GREETING_NAME, .value = PROJECT_NAME},
-                {.key = PROTOCOL_GREETING_SERVICE, .value = strZ(service)},
-                {.key = PROTOCOL_GREETING_VERSION, .value = PROJECT_VERSION},
-            };
-
-            for (unsigned int expectedIdx = 0; expectedIdx < LENGTH_OF(expected); expectedIdx++)
-            {
-                if (!jsonReadKeyExpectStrId(greeting, expected[expectedIdx].key))
-                    THROW_FMT(ProtocolError, "unable to find greeting key '%s'", zNewStrId(expected[expectedIdx].key));
-
-                if (jsonReadTypeNext(greeting) != jsonTypeString)
-                    THROW_FMT(ProtocolError, "greeting key '%s' must be string type", zNewStrId(expected[expectedIdx].key));
-
-                const String *const actualValue = jsonReadStr(greeting);
-
-                if (!strEqZ(actualValue, expected[expectedIdx].value))
-                {
-                    THROW_FMT(
-                        ProtocolError,
-                        "expected value '%s' for greeting key '%s' but got '%s'\n"
-                        "HINT: is the same version of " PROJECT_NAME " installed on the local and remote host?",
-                        expected[expectedIdx].value, zNewStrId(expected[expectedIdx].key), strZ(actualValue));
-                }
-            }
-
-            jsonReadObjectEnd(greeting);
         }
         MEM_CONTEXT_TEMP_END();
 

--- a/src/protocol/client.c
+++ b/src/protocol/client.c
@@ -3,6 +3,8 @@ Protocol Client
 ***********************************************************************************************************************************/
 #include <build.h>
 
+#include <ctype.h>
+
 #include "common/debug.h"
 #include "common/log.h"
 #include "common/time.h"
@@ -13,13 +15,13 @@ Protocol Client
 #include "version.h"
 
 /***********************************************************************************************************************************
-Maximum bytes of unexpected output (e.g. a login banner from the remote shell) tolerated before the greeting, maximum bytes of that
-output sampled for error reporting, and the hint added to errors when the greeting is not found
+Maximum bytes of unexpected output (e.g. a login banner from the remote shell) searched for the greeting, maximum bytes of that
+output sampled for error reporting, and the hint added to errors caused by unexpected output
 ***********************************************************************************************************************************/
 #define PROTOCOL_GREETING_SKIP_MAX                                  65536
 #define PROTOCOL_GREETING_SKIP_SAMPLE_MAX                           64
 
-#define PROTOCOL_GREETING_NOT_FOUND_HINT                                                                                           \
+#define PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT                                                                                   \
     "HINT: is the remote shell printing output for non-interactive sessions?"
 
 /***********************************************************************************************************************************
@@ -319,6 +321,30 @@ protocolClientFreeResource(THIS_VOID)
     FUNCTION_LOG_RETURN_VOID();
 }
 
+/***********************************************************************************************************************************
+Error when the greeting cannot be found in the protocol stream
+***********************************************************************************************************************************/
+static noreturn void
+protocolClientGreetingNotFound(const char *const reason, const size_t skipSize, const String *const skipSample)
+{
+    FUNCTION_TEST_BEGIN();
+        FUNCTION_TEST_PARAM(STRINGZ, reason);
+        FUNCTION_TEST_PARAM(SIZE, skipSize);
+        FUNCTION_TEST_PARAM(STRING, skipSample);
+    FUNCTION_TEST_END();
+
+    ASSERT(reason != NULL);
+    ASSERT(skipSample != NULL);
+
+    if (skipSize == 0)
+        THROW_FMT(ProtocolError, "greeting not found (%s)\n" PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT, reason);
+
+    THROW_FMT(
+        ProtocolError,
+        "greeting not found (%s) after %zu byte(s) of unexpected output beginning with '%s'\n"
+        PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT, reason, skipSize, strZ(skipSample));
+}
+
 /**********************************************************************************************************************************/
 FN_EXTERN ProtocolClient *
 protocolClientNew(const String *const name, const String *const service, IoRead *const read, IoWrite *const write)
@@ -351,9 +377,10 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
         };
 
         // Read, parse, and check the protocol greeting. The greeting is a JSON object on a single line so any line that does not
-        // parse as one is unexpected output (e.g. a login banner printed by the remote shell for a non-interactive SSH session),
-        // which is skipped since it would otherwise make the remote unusable. Skipped output is bounded so a stream that never
-        // produces a greeting errors cleanly and errors include a sample of the output to help identify the source.
+        // begin as one is unexpected output (e.g. a login banner printed by the remote shell for a non-interactive SSH session).
+        // Unexpected output is an error since more of it is likely to arrive in the middle of the protocol session, but search for
+        // the greeting first so the error can confirm that the correct remote was reached. The search is bounded so a stream that
+        // never produces a greeting errors cleanly and errors include a sample of the output to help identify the source.
         MEM_CONTEXT_TEMP_BEGIN()
         {
             String *const skipSample = strNew();
@@ -371,22 +398,53 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
                 CATCH(FileReadError)
                 {
                     // The stream ended or a line was too large to buffer so the greeting is not coming
-                    if (skipSize == 0)
-                        THROW_FMT(ProtocolError, "greeting not found (%s)\n" PROTOCOL_GREETING_NOT_FOUND_HINT, errorMessage());
-
-                    THROW_FMT(
-                        ProtocolError,
-                        "greeting not found (%s) after %zu byte(s) of unexpected output beginning with '%s'\n"
-                        PROTOCOL_GREETING_NOT_FOUND_HINT, errorMessage(), skipSize, strZ(skipSample));
+                    protocolClientGreetingNotFound(errorMessage(), skipSize, skipSample);
                 }
                 TRY_END();
 
+                JsonRead *volatile greeting = NULL;
+                volatile bool greetingIsJson = false;
+
                 TRY_BEGIN()
                 {
-                    JsonRead *const greeting = jsonReadNew(greetingLine);
+                    greeting = jsonReadNew(greetingLine);
 
                     jsonReadObjectBegin(greeting);
 
+                    greetingIsJson = true;
+                }
+                CATCH(JsonFormatError)
+                {
+                    // The line does not begin as a JSON object so it is unexpected output rather than a malformed greeting. Skip
+                    // it, keeping a sample of the skipped output (sanitized to printable characters) for error reporting.
+                    skipSize += strSize(greetingLine) + 1;
+
+                    if (strEmpty(skipSample))
+                    {
+                        for (size_t sampleIdx = 0;
+                             sampleIdx < strSize(greetingLine) && sampleIdx < PROTOCOL_GREETING_SKIP_SAMPLE_MAX; sampleIdx++)
+                        {
+                            const char sampleChr = strZ(greetingLine)[sampleIdx];
+
+                            strCatChr(skipSample, isprint((unsigned char)sampleChr) ? sampleChr : '.');
+                        }
+
+                        if (strSize(greetingLine) > PROTOCOL_GREETING_SKIP_SAMPLE_MAX)
+                            strCatZ(skipSample, "...");
+                    }
+
+                    if (skipSize > PROTOCOL_GREETING_SKIP_MAX)
+                        protocolClientGreetingNotFound("maximum unexpected output exceeded", skipSize, skipSample);
+
+                    strFree(greetingLine);
+                    jsonReadFree(greeting);
+                }
+                TRY_END();
+
+                // Once the line begins as a JSON object any error from parsing or validation is a real greeting mismatch (e.g. a
+                // version skew or protocol change) rather than unexpected output, so let it propagate
+                if (greetingIsJson)
+                {
                     const struct
                     {
                         const StringId key;
@@ -422,38 +480,22 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
 
                     greetingFound = true;
                 }
-                CATCH(JsonFormatError)
-                {
-                    // The line is not a greeting so skip it, keeping the beginning of the skipped output for error reporting
-                    skipSize += strSize(greetingLine) + 1;
-
-                    if (strEmpty(skipSample))
-                    {
-                        if (strSize(greetingLine) > PROTOCOL_GREETING_SKIP_SAMPLE_MAX)
-                        {
-                            strCatZN(skipSample, strZ(greetingLine), PROTOCOL_GREETING_SKIP_SAMPLE_MAX);
-                            strCatZ(skipSample, "...");
-                        }
-                        else
-                            strCat(skipSample, greetingLine);
-                    }
-
-                    if (skipSize > PROTOCOL_GREETING_SKIP_MAX)
-                    {
-                        THROW_FMT(
-                            ProtocolError,
-                            "greeting not found after %zu byte(s) of unexpected output beginning with '%s'\n"
-                            PROTOCOL_GREETING_NOT_FOUND_HINT, skipSize, strZ(skipSample));
-                    }
-
-                    strFree(greetingLine);
-                }
-                TRY_END();
             }
             while (!greetingFound);
 
+            // Unexpected output is an error even though the greeting was eventually found. The output source (e.g. a login shell
+            // rc file) is likely to write more output during the protocol session, which cannot be tolerated once the protocol is
+            // established, so the connection cannot be trusted until the output is disabled.
             if (skipSize != 0)
-                LOG_WARN_FMT("skipped %zu byte(s) of unexpected output before greeting from %s", skipSize, strZ(name));
+            {
+                THROW_FMT(
+                    ProtocolError,
+                    "greeting found after %zu byte(s) of unexpected output beginning with '%s'\n"
+                    PROTOCOL_GREETING_UNEXPECTED_OUTPUT_HINT "\n"
+                    "HINT: unexpected output may interrupt the protocol at any time so the connection cannot be used until the"
+                    " output is disabled.",
+                    skipSize, strZ(skipSample));
+            }
         }
         MEM_CONTEXT_TEMP_END();
 

--- a/src/protocol/client.c
+++ b/src/protocol/client.c
@@ -13,6 +13,11 @@ Protocol Client
 #include "version.h"
 
 /***********************************************************************************************************************************
+Maximum bytes of unexpected output (e.g. a login banner from the remote shell) tolerated before the greeting
+***********************************************************************************************************************************/
+#define PROTOCOL_GREETING_SKIP_MAX                                  65536
+
+/***********************************************************************************************************************************
 Client state enum
 ***********************************************************************************************************************************/
 typedef enum
@@ -343,7 +348,32 @@ protocolClientNew(const String *const name, const String *const service, IoRead 
         // Read, parse, and check the protocol greeting
         MEM_CONTEXT_TEMP_BEGIN()
         {
-            JsonRead *const greeting = jsonReadNew(ioReadLine(this->pub.read));
+            // Skip any output before the greeting, e.g. a login banner printed by the remote shell for non-interactive SSH
+            // sessions, which would otherwise make the remote unusable. The greeting is always a JSON object on a single line so
+            // any line that does not start with { cannot be the greeting. The skipped output is bounded so a stream that never
+            // produces a greeting errors cleanly.
+            const String *greetingLine = ioReadLine(this->pub.read);
+            size_t skipSize = 0;
+
+            while (!strBeginsWithZ(greetingLine, "{"))
+            {
+                skipSize += strSize(greetingLine) + 1;
+
+                if (skipSize > PROTOCOL_GREETING_SKIP_MAX)
+                {
+                    THROW_FMT(
+                        ProtocolError,
+                        "greeting not found after %zu bytes of unexpected output\n"
+                        "HINT: is the remote shell printing output for non-interactive sessions?", skipSize);
+                }
+
+                greetingLine = ioReadLine(this->pub.read);
+            }
+
+            if (skipSize != 0)
+                LOG_WARN_FMT("skipped %zu byte(s) of unexpected output before greeting from %s", skipSize, strZ(name));
+
+            JsonRead *const greeting = jsonReadNew(greetingLine);
 
             jsonReadObjectBegin(greeting);
 

--- a/test/src/module/protocol/protocolTest.c
+++ b/test/src/module/protocol/protocolTest.c
@@ -528,7 +528,7 @@ testRun(void)
     if (testBegin("ProtocolClient, ProtocolCommand, and ProtocolServer"))
     {
         // -------------------------------------------------------------------------------------------------------------------------
-        TEST_TITLE("greeting not found");
+        TEST_TITLE("greeting not found or preceded by unexpected output");
 
         HRN_FORK_BEGIN()
         {
@@ -559,6 +559,18 @@ testRun(void)
             }
             HRN_FORK_CHILD_END();
 
+            HRN_FORK_CHILD_BEGIN()
+            {
+                // Noise with non-printable characters followed by a valid greeting, e.g. a login banner that clears the terminal.
+                // The greeting is found but the connection cannot be used since more noise is likely during the protocol session.
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("\033[2Jlogin banner"));
+                ioWriteStrLine(
+                    HRN_FORK_CHILD_WRITE(),
+                    STRDEF("{\"name\":\"" PROJECT_NAME "\",\"service\":\"test\",\"version\":\"" PROJECT_VERSION "\"}"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
+            }
+            HRN_FORK_CHILD_END();
+
             HRN_FORK_PARENT_BEGIN()
             {
                 // Set the buffer size so a single line can be too large to buffer
@@ -568,8 +580,8 @@ testRun(void)
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError,
-                    "greeting not found after 65538 byte(s) of unexpected output beginning with"
-                    " '0123456789012345678901234567890123456789012345678901234567890123...'\n"
+                    "greeting not found (maximum unexpected output exceeded) after 65538 byte(s) of unexpected output beginning"
+                    " with '0123456789012345678901234567890123456789012345678901234567890123...'\n"
                     "HINT: is the remote shell printing output for non-interactive sessions?");
 
                 TEST_ERROR(
@@ -585,6 +597,14 @@ testRun(void)
                     " 'bash: pgbackrest: command not found'\n"
                     "HINT: is the remote shell printing output for non-interactive sessions?");
 
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(3), HRN_FORK_PARENT_WRITE(3)),
+                    ProtocolError,
+                    "greeting found after 17 byte(s) of unexpected output beginning with '.[2Jlogin banner'\n"
+                    "HINT: is the remote shell printing output for non-interactive sessions?\n"
+                    "HINT: unexpected output may interrupt the protocol at any time so the connection cannot be used until the"
+                    " output is disabled.");
+
                 ioBufferSizeSet(ioBufferSizeDefault);
             }
             HRN_FORK_PARENT_END();
@@ -598,10 +618,11 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - child process");
 
-                // Noise before the greeting (e.g. a login banner) is skipped, even when it begins with {, so the client sees the
-                // bogus greeting on a later line
+                // Noise that does not begin as a JSON object (e.g. a login banner) is skipped while searching for the greeting,
+                // but a line that begins as a JSON object is treated as the greeting and any error from it is a hard failure
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("bogus greeting"));
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{login banner}"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":999}"));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":null}"));
@@ -615,13 +636,13 @@ testRun(void)
                 ioWriteStrLine(
                     HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":\"pgBackRest\",\"service\":\"test\",\"version\":\"bogus\"}"));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
+                ioWriteStrLine(
+                    HRN_FORK_CHILD_WRITE(),
+                    STRDEF("{\"name\":\"" PROJECT_NAME "\",\"service\":\"test\",\"version\":\"" PROJECT_VERSION "\",\"zzz\":1}"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("server with error");
-
-                // Noise in a packet separate from the greeting, which the client skips with a warning
-                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("login banner"));
-                ioWriteFlush(HRN_FORK_CHILD_WRITE());
 
                 ProtocolServer *server = NULL;
 
@@ -677,7 +698,11 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - client");
 
-                // The noise lines before the bogus greeting are skipped
+                // The noise line before the bogus greeting is skipped, but a line that begins as a JSON object is treated as the
+                // greeting so the parse error is a hard failure rather than being skipped as noise
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
+                    JsonFormatError, "invalid type at: login banner}");
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError, "greeting key 'name' must be string type");
@@ -703,6 +728,11 @@ testRun(void)
                     "expected value '" PROJECT_VERSION "' for greeting key 'version' but got 'bogus'\n"
                     "HINT: is the same version of " PROJECT_NAME " installed on the local and remote host?");
 
+                // A greeting with a trailing key is a hard failure (e.g. a protocol change) rather than being skipped as noise
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
+                    JsonFormatError, "invalid type at: ,\"zzz\":1}");
+
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("new client with successful handshake");
 
@@ -720,8 +750,6 @@ testRun(void)
                     TEST_RESULT_VOID(protocolClientMove(NULL, memContextPrior()), "move null client");
                 }
                 MEM_CONTEXT_TEMP_END();
-
-                TEST_RESULT_LOG("P00   WARN: skipped 13 byte(s) of unexpected output before greeting from test client");
 
                 TEST_RESULT_INT(protocolClientIoReadFd(client), ioReadFd(client->pub.read), "get read fd");
 

--- a/test/src/module/protocol/protocolTest.c
+++ b/test/src/module/protocol/protocolTest.c
@@ -527,6 +527,70 @@ testRun(void)
     // *****************************************************************************************************************************
     if (testBegin("ProtocolClient, ProtocolCommand, and ProtocolServer"))
     {
+        // -------------------------------------------------------------------------------------------------------------------------
+        TEST_TITLE("greeting not found");
+
+        HRN_FORK_BEGIN()
+        {
+            HRN_FORK_CHILD_BEGIN()
+            {
+                // Noise that exceeds the skip bound without ever producing a greeting
+                ioWriteStrLine(
+                    HRN_FORK_CHILD_WRITE(),
+                    STRDEF("0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"));
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), strNewFmt("%*s", 65436, ""));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
+            }
+            HRN_FORK_CHILD_END();
+
+            HRN_FORK_CHILD_BEGIN()
+            {
+                // A single line too large to buffer
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), strNewFmt("%*s", 65537, ""));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
+            }
+            HRN_FORK_CHILD_END();
+
+            HRN_FORK_CHILD_BEGIN()
+            {
+                // Noise followed by eof, e.g. the remote command was not found
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("bash: pgbackrest: command not found"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
+            }
+            HRN_FORK_CHILD_END();
+
+            HRN_FORK_PARENT_BEGIN()
+            {
+                // Set the buffer size so a single line can be too large to buffer
+                const size_t ioBufferSizeDefault = ioBufferSize();
+                ioBufferSizeSet(65536);
+
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
+                    ProtocolError,
+                    "greeting not found after 65538 byte(s) of unexpected output beginning with"
+                    " '0123456789012345678901234567890123456789012345678901234567890123...'\n"
+                    "HINT: is the remote shell printing output for non-interactive sessions?");
+
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(1), HRN_FORK_PARENT_WRITE(1)),
+                    ProtocolError,
+                    "greeting not found (unable to find line in 65536 byte buffer)\n"
+                    "HINT: is the remote shell printing output for non-interactive sessions?");
+
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(2), HRN_FORK_PARENT_WRITE(2)),
+                    ProtocolError,
+                    "greeting not found (unexpected eof while reading line) after 36 byte(s) of unexpected output beginning with"
+                    " 'bash: pgbackrest: command not found'\n"
+                    "HINT: is the remote shell printing output for non-interactive sessions?");
+
+                ioBufferSizeSet(ioBufferSizeDefault);
+            }
+            HRN_FORK_PARENT_END();
+        }
+        HRN_FORK_END();
+
         HRN_FORK_BEGIN()
         {
             HRN_FORK_CHILD_BEGIN()
@@ -534,9 +598,10 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - child process");
 
-                // Noise before the greeting (e.g. a login banner) is skipped, so the client sees the bogus greeting on the next
-                // line
+                // Noise before the greeting (e.g. a login banner) is skipped, even when it begins with {, so the client sees the
+                // bogus greeting on a later line
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("bogus greeting"));
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{login banner}"));
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":999}"));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":null}"));
@@ -551,12 +616,12 @@ testRun(void)
                     HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":\"pgBackRest\",\"service\":\"test\",\"version\":\"bogus\"}"));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
 
-                // Noise before the greeting is bounded; a single line larger than the bound must error
-                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), strNewFmt("%*s", 65537, ""));
-                ioWriteFlush(HRN_FORK_CHILD_WRITE());
-
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("server with error");
+
+                // Noise in a packet separate from the greeting, which the client skips with a warning
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("login banner"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
 
                 ProtocolServer *server = NULL;
 
@@ -612,13 +677,10 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - client");
 
-                // The noise line before the bogus greeting is skipped with a warning
+                // The noise lines before the bogus greeting are skipped
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError, "greeting key 'name' must be string type");
-
-                TEST_RESULT_LOG("P00   WARN: skipped 15 byte(s) of unexpected output before greeting from test client");
-
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError, "greeting key 'name' must be string type");
@@ -642,15 +704,6 @@ testRun(void)
                     "HINT: is the same version of " PROJECT_NAME " installed on the local and remote host?");
 
                 // -----------------------------------------------------------------------------------------------------------------
-                TEST_TITLE("skip bound exceeded - client");
-
-                TEST_ERROR(
-                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
-                    ProtocolError,
-                    "greeting not found after 65538 bytes of unexpected output\n"
-                    "HINT: is the remote shell printing output for non-interactive sessions?");
-
-                // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("new client with successful handshake");
 
                 ProtocolClient *client = NULL;
@@ -667,6 +720,8 @@ testRun(void)
                     TEST_RESULT_VOID(protocolClientMove(NULL, memContextPrior()), "move null client");
                 }
                 MEM_CONTEXT_TEMP_END();
+
+                TEST_RESULT_LOG("P00   WARN: skipped 13 byte(s) of unexpected output before greeting from test client");
 
                 TEST_RESULT_INT(protocolClientIoReadFd(client), ioReadFd(client->pub.read), "get read fd");
 

--- a/test/src/module/protocol/protocolTest.c
+++ b/test/src/module/protocol/protocolTest.c
@@ -534,8 +534,9 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - child process");
 
+                // Noise before the greeting (e.g. a login banner) is skipped, so the client sees the bogus greeting on the next
+                // line
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("bogus greeting"));
-                ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":999}"));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":null}"));
@@ -548,6 +549,10 @@ testRun(void)
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
                 ioWriteStrLine(
                     HRN_FORK_CHILD_WRITE(), STRDEF("{\"name\":\"pgBackRest\",\"service\":\"test\",\"version\":\"bogus\"}"));
+                ioWriteFlush(HRN_FORK_CHILD_WRITE());
+
+                // Noise before the greeting is bounded; a single line larger than the bound must error
+                ioWriteStrLine(HRN_FORK_CHILD_WRITE(), strNewFmt("%*s", 65537, ""));
                 ioWriteFlush(HRN_FORK_CHILD_WRITE());
 
                 // -----------------------------------------------------------------------------------------------------------------
@@ -607,12 +612,13 @@ testRun(void)
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("bogus greetings - client");
 
-                TEST_ERROR(
-                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
-                    JsonFormatError, "invalid type at: bogus greeting");
+                // The noise line before the bogus greeting is skipped with a warning
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError, "greeting key 'name' must be string type");
+
+                TEST_RESULT_LOG("P00   WARN: skipped 15 byte(s) of unexpected output before greeting from test client");
+
                 TEST_ERROR(
                     protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
                     ProtocolError, "greeting key 'name' must be string type");
@@ -634,6 +640,15 @@ testRun(void)
                     ProtocolError,
                     "expected value '" PROJECT_VERSION "' for greeting key 'version' but got 'bogus'\n"
                     "HINT: is the same version of " PROJECT_NAME " installed on the local and remote host?");
+
+                // -----------------------------------------------------------------------------------------------------------------
+                TEST_TITLE("skip bound exceeded - client");
+
+                TEST_ERROR(
+                    protocolClientNew(STRDEF("test client"), STRDEF("test"), HRN_FORK_PARENT_READ(0), HRN_FORK_PARENT_WRITE(0)),
+                    ProtocolError,
+                    "greeting not found after 65538 bytes of unexpected output\n"
+                    "HINT: is the remote shell printing output for non-interactive sessions?");
 
                 // -----------------------------------------------------------------------------------------------------------------
                 TEST_TITLE("new client with successful handshake");


### PR DESCRIPTION
A login shell that prints output for non-interactive SSH sessions (an unguarded banner such as neofetch or motd in a shell rc) corrupts the protocol stream, and every remote operation fails with an opaque error deep in the first command, e.g.:

```
ERROR: [099]: invalid type at: [?25l[?7l    /#####   #####.
```

Since the greeting is always a JSON object on a single line, `protocolClientNew()` now searches for the greeting by skipping leading lines that do not begin as a JSON object, bounded at 64KiB so a stream that never produces a greeting still errors cleanly. Per review discussion, unexpected output is treated as a hard error rather than a warning: output that precedes the greeting is likely to continue during the protocol session, where it cannot be detected and will cause remote operations to fail unpredictably. The greeting is still searched for first so the error can confirm that the correct remote was reached, and the error includes the number of bytes skipped, a sample of the output to help identify the source, and hints:

```
ERROR: [103]: greeting found after 17 byte(s) of unexpected output beginning with '.[2Jlogin banner'
       HINT: is the remote shell printing output for non-interactive sessions?
       HINT: unexpected output may interrupt the protocol at any time so the connection cannot be used until the output is disabled.
```

Also per review:

* The `JsonFormatError` catch is narrowed to the check that the line begins as a JSON object. Errors from parsing or validating the rest of the greeting (e.g. a version skew or protocol change) now propagate as real failures instead of being treated as skippable noise.
* The `JsonRead` object is freed on the skip path.
* The skipped output sample is sanitized to printable characters so remote output cannot inject terminal escapes or forge log lines in error messages.
* The greeting-not-found errors are consolidated into a single helper.

Only the client read direction is affected; the reverse direction never passes through a login shell.

Tested with the protocol module unit tests (noise before a valid greeting, search bound exceeded, eof after noise, sanitized sample, trailing greeting key, existing bogus-greeting cases) at full coverage.