### PR TITLE
Compare a new backup label only against its own full backup set.

### DIFF
--- a/doc/xml/release/2020s/2026/2.60.0.xml
+++ b/doc/xml/release/2020s/2026/2.60.0.xml
@@ -23,6 +23,19 @@
 
                 <p>Combine prior block incremental map reads during backup.</p>
             </release-item>
+
+            <release-item>
+                <github-issue id="2792"/>
+                <github-pull-request id="2824"/>
+
+                <release-item-contributor-list>
+                    <release-item-ideator id="anton.glushakov"/>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="douglas.j.hunley"/>
+                </release-item-contributor-list>
+
+                <p>Compare a new backup label only against its own full backup set.</p>
+            </release-item>
         </release-improvement-list>
 
         <release-development-list>

--- a/src/command/backup/label.c.inc
+++ b/src/command/backup/label.c.inc
@@ -19,11 +19,20 @@ backupLabelCreate(const BackupType type, const String *const backupLabelPrior, c
     {
         const String *backupLabelLatest = NULL;
 
+        // For full backup compare against all backups. For other backup types compare only against backups in the same full backup
+        // set, i.e. those whose name begins with the full backup part of backupLabelPrior. Since the new label is generated from
+        // backupLabelPrior it can never conflict with a label in another full backup set. This prevents label generation from
+        // failing when the last full backup is removed and then a diff/incr is generated from the last remaining full backup, or
+        // when a removed full backup is still returned by the repository listing, which can happen on object stores that retain
+        // empty prefixes.
+        const String *const labelRegExp =
+            type == backupTypeFull ?
+                backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true) :
+                strNewFmt("^%.*sF\\_" DATE_TIME_REGEX "(D|I)", DATE_TIME_LEN, strZ(backupLabelPrior));
+
         // Get the newest backup
         const StringList *const backupList = strLstSort(
-            storageListP(
-                storageRepo(), STRDEF(STORAGE_REPO_BACKUP),
-                .expression = backupRegExpP(.full = true, .differential = true, .incremental = true)),
+            storageListP(storageRepo(), STRDEF(STORAGE_REPO_BACKUP), .expression = strNewFmt("%s$", strZ(labelRegExp))),
             sortOrderDesc);
 
         if (!strLstEmpty(backupList))
@@ -36,18 +45,11 @@ backupLabelCreate(const BackupType type, const String *const backupLabelPrior, c
 
         if (!strLstEmpty(historyYearList))
         {
-            // For full backup compare against all backups in the history. For other backup types find backups whose name begins
-            // with full backup part of backupLabelLatest. This prevents label generation from failing when the last full backup is
-            // removed and then an diff/incr is generated from the last remaining full backup.
-            const String *const fileNameRegExp =
-                (type == backupTypeFull) ?
-                    backupRegExpP(.full = true, .differential = true, .incremental = true, .noAnchorEnd = true) :
-                    strNewFmt("^%.*sF\\_" DATE_TIME_REGEX "(D|I)", DATE_TIME_LEN, strZ(backupLabelLatest));
             const StringList *const historyList = strLstSort(
                 storageListP(
                     storageRepo(),
                     strNewFmt(STORAGE_REPO_BACKUP "/" BACKUP_PATH_HISTORY "/%s", strZ(strLstGet(historyYearList, 0))),
-                    .expression = strNewFmt("%s\\.manifest\\.%s$", strZ(fileNameRegExp), strZ(compressTypeStr(compressTypeGz)))),
+                    .expression = strNewFmt("%s\\.manifest\\.%s$", strZ(labelRegExp), strZ(compressTypeStr(compressTypeGz)))),
                 sortOrderDesc);
 
             if (!strLstEmpty(historyList))

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -1379,6 +1379,12 @@ testRun(void)
                 STORAGE_REPO_BACKUP "/backup.history/2019/%s.manifest.gz",
                 strZ(backupLabelFormat(backupTypeFull, NULL, timestamp - 1))));
 
+        // Add a full backup that sorts after the prior backup, e.g. a backup that has been removed but is still returned by the
+        // repository listing. It must not be considered when generating a diff/incr label.
+        HRN_STORAGE_PUT_EMPTY(
+            storageRepoWrite(),
+            zNewFmt(STORAGE_REPO_BACKUP "/%s", strZ(backupLabelFormat(backupTypeFull, NULL, timestamp - 2))));
+
         TEST_RESULT_STR(
             backupLabelCreate(backupTypeDiff, olderBackupLabel, timestamp),
             backupLabelFormat(backupTypeDiff, olderBackupLabel, timestamp),


### PR DESCRIPTION
A diff or incr label is generated from the prior backup label, so it begins with the full backup part of that label and can only collide with, or need to sort after, a label in the same full backup set. The history lookup has always known this and restricts itself to one set, but the repository listing beside it compared against every backup in the repository, including full backups from other sets, which a diff or incr label sorts before whenever the full backup it belongs to is older.

That costs nothing while the listing holds only backups that exist. On object stores that keep a prefix alive after everything under it has been deleted, such as MinIO with object locking or SeaweedFS, a backup that pgBackRest removed goes on being returned by the listing. An aborted full backup cleaned up by resume therefore keeps sorting after the prior full backup, and every diff and incr taken afterwards fails with "new backup label ... is not later than latest backup label ...", naming a backup that is no longer there.

Build the expression that restricts a comparison to a single full backup set once and filter both the backup listing and the history listing with it. For a full backup the expression matches everything, as it did before.

Build the expression from the prior backup label rather than from the newest label in the repository listing, since that is the value the listing gets wrong and it is also the label the new label is generated from. Where the last full backup has been removed and a diff or incr is generated from the last remaining full backup, which is the case the history restriction was written for, the two labels are the same.