### PR TITLE
Add context to block map read errors during backup.

### DIFF
--- a/doc/xml/release/2020s/2026/2.60.0.xml
+++ b/doc/xml/release/2020s/2026/2.60.0.xml
@@ -49,6 +49,18 @@
 
                 <p>Reduce the manifest checks made when reconstructing <file>backup.info</file>.</p>
             </release-item>
+
+            <release-item>
+                <github-pull-request id="2830"/>
+
+                <release-item-contributor-list>
+                    <release-item-contributor id="david.steele"/>
+                    <release-item-reviewer id="stefan.fercot"/>
+                    <release-item-reviewer id="douglas.j.hunley"/>
+                </release-item-contributor-list>
+
+                <p>Add context to block map read errors during backup.</p>
+            </release-item>
         </release-improvement-list>
 
         <release-development-list>

--- a/src/command/backup/file.c.inc
+++ b/src/command/backup/file.c.inc
@@ -53,6 +53,99 @@ typedef struct BackupFileResult
     Pack *pageChecksumResult;
 } BackupFileResult;
 
+// Create the block incremental filter, reading the prior block map when there is one. Errors are rethrown with the location of the
+// map because neither the read nor the map parse know where the map came from, which makes a mismatch between the manifest and the
+// repository very hard to diagnose.
+static IoFilter *
+backupFileBlockIncr(
+    const BackupFile *const file, const unsigned int blockIncrReference, const uint64_t bundleId, const uint64_t bundleOffset,
+    StorageReadMulti *const biMapRead, const CipherSpec *const cipherSpecBackup, const IoFilter *const compress,
+    const IoFilter *const encrypt)
+{
+    FUNCTION_LOG_BEGIN(logLevelTrace);
+        FUNCTION_LOG_PARAM_P(VOID, file);
+        FUNCTION_LOG_PARAM(UINT, blockIncrReference);
+        FUNCTION_LOG_PARAM(UINT64, bundleId);
+        FUNCTION_LOG_PARAM(UINT64, bundleOffset);
+        FUNCTION_LOG_PARAM(STORAGE_READ_MULTI, biMapRead);
+        FUNCTION_LOG_PARAM(CIPHER_SPEC, cipherSpecBackup);
+        FUNCTION_LOG_PARAM(IO_FILTER, compress);
+        FUNCTION_LOG_PARAM(IO_FILTER, encrypt);
+    FUNCTION_LOG_END();
+
+    ASSERT(file != NULL);
+    ASSERT(file->blockIncrSize != 0);
+
+    IoFilter *result;
+
+    // If there is no prior block map then create the filter without one
+    if (file->blockIncrMapPriorFile == NULL)
+    {
+        result = blockIncrNew(
+            file->blockIncrSuperSize, file->blockIncrSize, file->blockIncrChecksumSize, blockIncrReference, bundleId, bundleOffset,
+            NULL, compress, encrypt);
+    }
+    // Else read the prior block map and create the filter with it
+    else
+    {
+        ASSERT(biMapRead != NULL);
+
+        MEM_CONTEXT_TEMP_BEGIN()
+        {
+            TRY_BEGIN()
+            {
+                Buffer *const blockMap = bufNew(0);
+                IoWrite *const blockMapWrite = ioBufferWriteNew(blockMap);
+
+                // Add a size filter before decryption so the size is measured as stored in the repository
+                ioFilterGroupAdd(ioWriteFilterGroup(blockMapWrite), ioSizeNew());
+
+                if (cipherSpecType(cipherSpecBackup) != cipherTypeNone)
+                {
+                    ioFilterGroupAdd(
+                        ioWriteFilterGroup(blockMapWrite), cipherBlockNewP(cipherModeDecrypt, cipherSpecBackup, .raw = true));
+                }
+
+                ioWriteOpen(blockMapWrite);
+                ioCopyP(storageReadMultiIo(biMapRead), blockMapWrite, .limit = VARUINT64(file->blockIncrMapPriorSize));
+                ioWriteClose(blockMapWrite);
+
+                // The entire map must have been read. When it was not the map is smaller than the manifest expects and the parse
+                // below would fail without making it clear that data is missing.
+                const uint64_t blockMapSizeRead = pckReadU64P(
+                    ioFilterGroupResultP(ioWriteFilterGroup(blockMapWrite), SIZE_FILTER_TYPE));
+
+                if (blockMapSizeRead != file->blockIncrMapPriorSize)
+                {
+                    THROW_FMT(
+                        FileReadError, "expected %" PRIu64 " byte(s) but read %" PRIu64, file->blockIncrMapPriorSize,
+                        blockMapSizeRead);
+                }
+
+                // Create the filter in the prior context so the map read above can be freed
+                MEM_CONTEXT_PRIOR_BEGIN()
+                {
+                    result = blockIncrNew(
+                        file->blockIncrSuperSize, file->blockIncrSize, file->blockIncrChecksumSize, blockIncrReference, bundleId,
+                        bundleOffset, blockMap, compress, encrypt);
+                }
+                MEM_CONTEXT_PRIOR_END();
+            }
+            CATCH_ANY()
+            {
+                THROWP_FMT(
+                    errorType(), "unable to read block map for '%s' from '%s' at offset %" PRIu64 " size %" PRIu64 ": %s",
+                    strZ(file->manifestFile), strZ(storagePathP(storageRepo(), file->blockIncrMapPriorFile)),
+                    file->blockIncrMapPriorOffset, file->blockIncrMapPriorSize, errorMessage());
+            }
+            TRY_END();
+        }
+        MEM_CONTEXT_TEMP_END();
+    }
+
+    FUNCTION_LOG_RETURN(IO_FILTER, result);
+}
+
 static List *
 backupFile(
     const String *const repoFile, const uint64_t bundleId, const bool bundleRaw, const unsigned int blockIncrReference,
@@ -284,33 +377,10 @@ backupFile(
                     // compressed/encrypted separately
                     if (file->blockIncrSize != 0)
                     {
-                        // Read prior block map
-                        Buffer *blockMap = NULL;
-
-                        if (file->blockIncrMapPriorFile != NULL)
-                        {
-                            blockMap = bufNew(0);
-                            IoWrite *const blockMapWrite = ioBufferWriteNew(blockMap);
-
-                            if (cipherSpecType(cipherSpecBackup) != cipherTypeNone)
-                            {
-                                ioFilterGroupAdd(
-                                    ioWriteFilterGroup(blockMapWrite),
-                                    cipherBlockNewP(cipherModeDecrypt, cipherSpecBackup, .raw = true));
-                            }
-
-                            ioWriteOpen(blockMapWrite);
-                            ioCopyP(storageReadMultiIo(biMapRead), blockMapWrite, .limit = VARUINT64(file->blockIncrMapPriorSize));
-                            ioWriteClose(blockMapWrite);
-                            ioWriteFree(blockMapWrite);
-                        }
-
-                        // Add block incremental filter
                         ioFilterGroupAdd(
                             ioReadFilterGroup(readIo),
-                            blockIncrNew(
-                                file->blockIncrSuperSize, file->blockIncrSize, file->blockIncrChecksumSize, blockIncrReference,
-                                bundleId, bundleOffset, blockMap, compress, encrypt));
+                            backupFileBlockIncr(
+                                file, blockIncrReference, bundleId, bundleOffset, biMapRead, cipherSpecBackup, compress, encrypt));
 
                         repoChecksum = true;
                     }

--- a/test/src/module/command/backupTest.c
+++ b/test/src/module/command/backupTest.c
@@ -3723,6 +3723,32 @@ testRun(void)
             // File that gets truncated to zero during the backup
             HRN_STORAGE_PUT(storagePgWrite(), "truncate-to-zero", BUFSTRDEF("DATA"), .timeModified = backupTimeStart);
 
+            // Error when the prior block map is not where the manifest says it is. Truncate the file that contains the map so the
+            // read comes up short, then restore it before running the backup for real.
+            const String *const blockIncrGrowFile = STRDEF(
+                STORAGE_REPO_BACKUP "/20191103-165320F/pg_data/block-incr-grow" BACKUP_BLOCK_INCR_EXT);
+            const Buffer *const blockIncrGrowBuffer = storageGetP(storageNewReadP(storageRepo(), blockIncrGrowFile));
+
+            HRN_STORAGE_PUT_Z(storageRepoWrite(), strZ(blockIncrGrowFile), "");
+
+            hrnBackupPqScriptP(
+                PG_VERSION_11, backupTimeStart, .walCompressType = compressTypeGz, .walTotal = 2, .walSwitch = true,
+                .errorAfterCopyStart = true);
+            TEST_ERROR(
+                hrnCmdBackup(), FileReadError,
+                "raised from local-1 shim protocol: unable to read block map for 'pg_data/block-incr-grow' from '" TEST_PATH
+                "/repo/backup/test1/20191103-165320F/pg_data/block-incr-grow.pgbi' at offset 24576 size 24: expected 24 byte(s) but"
+                " read 0");
+
+            TEST_RESULT_LOG(
+                "P00   INFO: last backup label = 20191103-165320F, version = " PROJECT_VERSION "\n"
+                "P00   INFO: execute backup start: backup begins after the next regular checkpoint completes\n"
+                "P00   INFO: backup start archive = 0000000105DC213000000000, lsn = 5dc2130/0\n"
+                "P00   INFO: check archive for segment 0000000105DC213000000000\n"
+                "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]");
+
+            HRN_STORAGE_PUT(storageRepoWrite(), strZ(blockIncrGrowFile), blockIncrGrowBuffer);
+
             // Run backup
             HRN_BACKUP_SCRIPT_SET(
                 {.op = hrnBackupScriptOpUpdate, .file = storagePathP(storagePg(), STRDEF("truncate-to-zero")),
@@ -3735,6 +3761,7 @@ testRun(void)
                 "P00   INFO: execute backup start: backup begins after the next regular checkpoint completes\n"
                 "P00   INFO: backup start archive = 0000000105DC213000000000, lsn = 5dc2130/0\n"
                 "P00   INFO: check archive for segment 0000000105DC213000000000\n"
+                "P00   INFO: backup '20191103-165320F_20191106-002640D' cannot be resumed: resume only valid for full backup\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-larger (1.4MB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/block-incr-grow (128KB, [PCT]) checksum [SHA1]\n"
                 "P01 DETAIL: backup file " TEST_PATH "/pg1/grow-to-block-incr (bundle 1/0, 16KB, [PCT]) checksum [SHA1]\n"


### PR DESCRIPTION
A block incremental file stores its block map at the end of its data and the location of the map is recorded in the manifest, so when the data at that location is not a complete map the error comes from the map parser, which knows nothing about where the map came from. In #2829 that leaves the user with "unexpected eof" and no indication of which file failed, where the map was expected to be, or whether the data is short or simply not a map. The same signature in #2489 could not be diagnosed for the same reason.

Rethrow errors from the read and the parse with the manifest file, repository path, offset and map size. Also measure the bytes read from the repository, before decryption, and error when they are fewer than the manifest expects, since a short read would otherwise surface as a parse error that gives no hint that data is missing. This does not address whatever causes the mismatch, but it makes the next report actionable.

Move the read into backupFileBlockIncr() to keep the copy loop readable. The map is read in its own memory context with the filter created in the prior context, so the map buffer is freed once the filter has parsed it rather than living until the file is done.